### PR TITLE
feat: ログインページのロゴ下にテストテキストを追加

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -94,6 +94,7 @@ export default function WorkerLogin() {
               className="object-contain"
             />
           </div>
+          <p className="mt-2 text-gray-600">テストのテキスト</p>
         </div>
 
         {/* ログインフォーム */}


### PR DESCRIPTION
## Summary
- ログインページのロゴ下に「テストのテキスト」を追加

## Test plan
- [ ] `/login` ページにアクセス
- [ ] ロゴの下にテキストが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)