### PR TITLE
fix: カタカナ入力欄の入力制限をバリデーション方式に変更

### DIFF
--- a/app/mypage/profile/ProfileEditClient.tsx
+++ b/app/mypage/profile/ProfileEditClient.tsx
@@ -6,7 +6,7 @@ import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { updateUserProfile } from '@/src/lib/actions';
 import { validateFile, getSafeImageUrl, isValidImageUrl } from '@/utils/fileValidation';
-import { formatKatakana, formatKatakanaWithSpace, formatPhoneNumber } from '@/utils/inputValidation';
+import { formatKatakana, formatKatakanaWithSpace, formatPhoneNumber, isKatakanaOnly, isKatakanaWithSpaceOnly } from '@/utils/inputValidation';
 import toast from 'react-hot-toast';
 import AddressSelector from '@/components/ui/AddressSelector';
 import { QUALIFICATION_GROUPS } from '@/constants/qualifications';
@@ -475,6 +475,21 @@ export default function ProfileEditClient({ userProfile }: ProfileEditClientProp
       return;
     }
 
+    // フリガナのカタカナチェック
+    if (formData.lastNameKana && !isKatakanaOnly(formData.lastNameKana)) {
+      toast.error('姓（カナ）はカタカナで入力してください');
+      return;
+    }
+    if (formData.firstNameKana && !isKatakanaOnly(formData.firstNameKana)) {
+      toast.error('名（カナ）はカタカナで入力してください');
+      return;
+    }
+    // 口座名義のカタカナチェック
+    if (formData.accountName && !isKatakanaWithSpaceOnly(formData.accountName)) {
+      toast.error('口座名義はカタカナで入力してください');
+      return;
+    }
+
     setIsSaving(true);
 
     try {
@@ -698,11 +713,14 @@ export default function ProfileEditClient({ userProfile }: ProfileEditClientProp
                   const value = formatKatakana(e.target.value);
                   setFormData({ ...formData, lastNameKana: value });
                 }}
-                className={`w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent ${showErrors && !formData.lastNameKana ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
+                className={`w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent ${showErrors && !formData.lastNameKana ? 'border-red-500 bg-red-50' : formData.lastNameKana && !isKatakanaOnly(formData.lastNameKana) ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
                 placeholder="ヤマダ"
               />
               {showErrors && !formData.lastNameKana && (
                 <p className="text-red-500 text-xs mt-1">姓（カナ）を入力してください</p>
+              )}
+              {formData.lastNameKana && !isKatakanaOnly(formData.lastNameKana) && (
+                <p className="text-red-500 text-xs mt-1">カタカナで入力してください</p>
               )}
               <p className="text-xs text-gray-500 mt-1">※カタカナで入力（ひらがなは自動変換）</p>
             </div>
@@ -715,11 +733,14 @@ export default function ProfileEditClient({ userProfile }: ProfileEditClientProp
                   const value = formatKatakana(e.target.value);
                   setFormData({ ...formData, firstNameKana: value });
                 }}
-                className={`w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent ${showErrors && !formData.firstNameKana ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
+                className={`w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent ${showErrors && !formData.firstNameKana ? 'border-red-500 bg-red-50' : formData.firstNameKana && !isKatakanaOnly(formData.firstNameKana) ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
                 placeholder="タロウ"
               />
               {showErrors && !formData.firstNameKana && (
                 <p className="text-red-500 text-xs mt-1">名（カナ）を入力してください</p>
+              )}
+              {formData.firstNameKana && !isKatakanaOnly(formData.firstNameKana) && (
+                <p className="text-red-500 text-xs mt-1">カタカナで入力してください</p>
               )}
               <p className="text-xs text-gray-500 mt-1">※カタカナで入力（ひらがなは自動変換）</p>
             </div>
@@ -1278,10 +1299,13 @@ export default function ProfileEditClient({ userProfile }: ProfileEditClientProp
                   value={formData.accountName}
                   onChange={(e) => setFormData({ ...formData, accountName: formatKatakanaWithSpace(e.target.value) })}
                   placeholder="ヤマダ タロウ"
-                  className={`w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent ${showErrors && !formData.accountName ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
+                  className={`w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent ${showErrors && !formData.accountName ? 'border-red-500 bg-red-50' : formData.accountName && !isKatakanaWithSpaceOnly(formData.accountName) ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
                 />
                 {showErrors && !formData.accountName && (
                   <p className="text-red-500 text-xs mt-1">口座名義を入力してください</p>
+                )}
+                {formData.accountName && !isKatakanaWithSpaceOnly(formData.accountName) && (
+                  <p className="text-red-500 text-xs mt-1">カタカナで入力してください</p>
                 )}
                 <p className="text-xs text-gray-500 mt-1">※カタカナで入力（ひらがなは自動変換）</p>
               </div>

--- a/app/register/worker/page.tsx
+++ b/app/register/worker/page.tsx
@@ -217,6 +217,16 @@ export default function WorkerRegisterPage() {
       return;
     }
 
+    // フリガナのカタカナチェック
+    if (!isKatakanaOnly(formData.lastNameKana)) {
+      toast.error('セイ（フリガナ）はカタカナで入力してください');
+      return;
+    }
+    if (!isKatakanaOnly(formData.firstNameKana)) {
+      toast.error('メイ（フリガナ）はカタカナで入力してください');
+      return;
+    }
+
     // 経験分野確認
     if (experienceFields.length === 0) {
       toast.error('少なくとも1つの経験分野を選択してください');
@@ -376,11 +386,14 @@ export default function WorkerRegisterPage() {
                     required
                     value={formData.lastNameKana}
                     onChange={(e) => setFormData({ ...formData, lastNameKana: formatKatakana(e.target.value) })}
-                    className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary ${showErrors && !formData.lastNameKana ? 'border-red-500 bg-red-50' : showErrors && formData.lastNameKana && !isKatakanaOnly(formData.lastNameKana) ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
+                    className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary ${showErrors && !formData.lastNameKana ? 'border-red-500 bg-red-50' : formData.lastNameKana && !isKatakanaOnly(formData.lastNameKana) ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
                     placeholder="ヤマダ"
                   />
                   {showErrors && !formData.lastNameKana && (
                     <p className="text-red-500 text-xs mt-1">セイ（フリガナ）を入力してください</p>
+                  )}
+                  {formData.lastNameKana && !isKatakanaOnly(formData.lastNameKana) && (
+                    <p className="text-red-500 text-xs mt-1">カタカナで入力してください</p>
                   )}
                   <p className="text-xs text-gray-500 mt-1">※カタカナで入力（ひらがなは自動変換）</p>
                 </div>
@@ -393,11 +406,14 @@ export default function WorkerRegisterPage() {
                     required
                     value={formData.firstNameKana}
                     onChange={(e) => setFormData({ ...formData, firstNameKana: formatKatakana(e.target.value) })}
-                    className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary ${showErrors && !formData.firstNameKana ? 'border-red-500 bg-red-50' : showErrors && formData.firstNameKana && !isKatakanaOnly(formData.firstNameKana) ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
+                    className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary ${showErrors && !formData.firstNameKana ? 'border-red-500 bg-red-50' : formData.firstNameKana && !isKatakanaOnly(formData.firstNameKana) ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
                     placeholder="タロウ"
                   />
                   {showErrors && !formData.firstNameKana && (
                     <p className="text-red-500 text-xs mt-1">メイ（フリガナ）を入力してください</p>
+                  )}
+                  {formData.firstNameKana && !isKatakanaOnly(formData.firstNameKana) && (
+                    <p className="text-red-500 text-xs mt-1">カタカナで入力してください</p>
                   )}
                   <p className="text-xs text-gray-500 mt-1">※カタカナで入力（ひらがなは自動変換）</p>
                 </div>

--- a/utils/inputValidation.ts
+++ b/utils/inputValidation.ts
@@ -16,20 +16,24 @@ export function hiraganaToKatakana(value: string): string {
   });
 }
 
-// カタカナ入力用のハンドラー（ひらがな自動変換 + カタカナ以外を除外）
+// カタカナ入力用のハンドラー（ひらがな自動変換のみ、他の文字は残す）
+// バリデーションは送信時にisKatakanaOnlyで行う
 export function formatKatakana(value: string): string {
-  // ひらがなをカタカナに変換
-  let converted = hiraganaToKatakana(value);
-  // カタカナ、長音記号、中点のみを残す
-  return converted.replace(/[^ァ-ヶー・]/g, '');
+  // ひらがなをカタカナに変換するだけ（他の文字は残す）
+  return hiraganaToKatakana(value);
 }
 
 // カタカナ入力用（スペース許容版: 口座名義などに使用）
+// バリデーションは送信時にisKatakanaWithSpaceOnlyで行う
 export function formatKatakanaWithSpace(value: string): string {
-  // ひらがなをカタカナに変換
-  let converted = hiraganaToKatakana(value);
-  // カタカナ、長音記号、中点、全角スペース、半角スペースを残す
-  return converted.replace(/[^ァ-ヶー・　 ]/g, '');
+  // ひらがなをカタカナに変換するだけ（他の文字は残す）
+  return hiraganaToKatakana(value);
+}
+
+// カタカナとスペースのみかどうかを判定（口座名義用）
+export function isKatakanaWithSpaceOnly(value: string): boolean {
+  // 全角カタカナ、長音記号、中点、全角スペース、半角スペースのみ許可
+  return /^[ァ-ヶー・　 ]+$/.test(value);
 }
 
 // 電話番号フォーマット（ハイフン自動挿入）


### PR DESCRIPTION
## Summary
- カタカナ入力欄で「入力時に文字を削除」する方式から「バリデーションエラー表示」方式に変更
- 機種によっては入力制限が入力を阻害する問題を解決
- ひらがなは自動でカタカナに変換、それ以外の文字はそのまま入力可能
- カタカナ以外が含まれていれば赤枠でエラー表示、送信時にエラーメッセージ

## 変更内容
### `utils/inputValidation.ts`
- `formatKatakana`: カタカナ以外を削除 → ひらがな→カタカナ変換のみ
- `formatKatakanaWithSpace`: 同様に変更
- `isKatakanaWithSpaceOnly`: 新規追加（口座名義用バリデーション）

### `app/register/worker/page.tsx`
- セイ・メイ（フリガナ）入力欄にリアルタイムエラー表示追加
- 送信時のカタカナバリデーション追加

### `app/mypage/profile/ProfileEditClient.tsx`
- 姓カナ・名カナ入力欄にリアルタイムエラー表示追加
- 口座名義入力欄にリアルタイムエラー表示追加
- 送信時のカタカナバリデーション追加

## Test plan
- [ ] ワーカー登録画面でフリガナ入力テスト（ひらがな→カタカナ変換確認）
- [ ] ワーカー登録画面で英数字入力時にエラー表示確認
- [ ] プロフィール編集画面でカナ入力テスト
- [ ] 口座名義でスペース付きカタカナ入力テスト
- [ ] 各種機種（iPhone、Android）での入力確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)