### PR TITLE
feat: 実働時間の自動計算・表示機能を追加 (#48)

### DIFF
--- a/components/admin/JobForm.tsx
+++ b/components/admin/JobForm.tsx
@@ -11,7 +11,7 @@ import { useDebugError, extractDebugInfo } from '@/components/debug/DebugErrorBa
 import AddressSelector from '@/components/ui/AddressSelector';
 import { JobConfirmModal } from '@/components/admin/JobConfirmModal';
 import { JobPreviewModal } from '@/components/admin/JobPreviewModal';
-import { calculateDailyWage } from '@/utils/salary';
+import { calculateDailyWage, calculateWorkingHours } from '@/utils/salary';
 import { getCurrentTime } from '@/utils/debugTime';
 import { validateImageFiles, validateAttachmentFiles } from '@/utils/fileValidation';
 import { directUploadMultiple } from '@/utils/directUpload';
@@ -231,6 +231,22 @@ export default function JobForm({ mode, jobId, initialData, isOfferMode = false,
         formData.hourlyWage,
         formData.transportationFee
     );
+
+    // 実働時間を計算
+    const workingHours = calculateWorkingHours(
+        formData.startTime,
+        formData.endTime,
+        formData.breakTime
+    );
+
+    // 実働時間を「X時間Y分」形式でフォーマット
+    const formatWorkingHours = (hours: number): string => {
+        if (hours <= 0) return '0時間';
+        const h = Math.floor(hours);
+        const m = Math.round((hours - h) * 60);
+        if (m === 0) return `${h}時間`;
+        return `${h}時間${m}分`;
+    };
 
     const requiresGenderSpecification = formData.workContent.includes('入浴介助(大浴場)') ||
         formData.workContent.includes('入浴介助(全般)') ||
@@ -1823,6 +1839,19 @@ export default function JobForm({ mode, jobId, initialData, isOfferMode = false,
                                         ))}
                                     </select>
                                 </div>
+                            </div>
+
+                            {/* 実働時間表示 */}
+                            <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+                                <div className="flex items-center justify-between">
+                                    <span className="text-sm font-medium text-gray-700">実働時間</span>
+                                    <span className="text-lg font-bold text-blue-600" data-testid="working-hours-display">
+                                        {formatWorkingHours(workingHours)}
+                                    </span>
+                                </div>
+                                <p className="text-xs text-gray-500 mt-1">
+                                    ※ 開始時刻・終了時刻・休憩時間から自動計算されます
+                                </p>
                             </div>
 
                             <div className="grid grid-cols-4 gap-4">

--- a/components/admin/JobTemplateForm.tsx
+++ b/components/admin/JobTemplateForm.tsx
@@ -7,7 +7,7 @@ import { useSWRConfig } from 'swr';
 import { useAuth } from '@/contexts/AuthContext';
 import { Upload, X } from 'lucide-react';
 import { TemplatePreviewModal } from '@/components/admin/TemplatePreviewModal';
-import { calculateDailyWage } from '@/utils/salary';
+import { calculateDailyWage, calculateWorkingHours } from '@/utils/salary';
 import { validateImageFiles, validateAttachmentFiles } from '@/utils/fileValidation';
 import toast from 'react-hot-toast';
 import { directUploadMultiple } from '@/utils/directUpload';
@@ -282,6 +282,22 @@ export default function JobTemplateForm({ mode, templateId, initialData }: JobTe
         formData.hourlyWage,
         formData.transportationFee
     );
+
+    // 実働時間を計算
+    const workingHours = calculateWorkingHours(
+        formData.startTime,
+        formData.endTime,
+        formData.breakTime
+    );
+
+    // 実働時間を「X時間Y分」形式でフォーマット
+    const formatWorkingHours = (hours: number): string => {
+        if (hours <= 0) return '0時間';
+        const h = Math.floor(hours);
+        const m = Math.round((hours - h) * 60);
+        if (m === 0) return `${h}時間`;
+        return `${h}時間${m}分`;
+    };
 
     const requiresGenderSpecification = formData.workContent.includes('入浴介助(大浴場)') ||
         formData.workContent.includes('入浴介助(全般)') ||
@@ -768,6 +784,19 @@ export default function JobTemplateForm({ mode, templateId, initialData }: JobTe
                                         ))}
                                     </select>
                                 </div>
+                            </div>
+
+                            {/* 実働時間表示 */}
+                            <div className="bg-blue-50 border border-blue-200 rounded-lg p-4">
+                                <div className="flex items-center justify-between">
+                                    <span className="text-sm font-medium text-gray-700">実働時間</span>
+                                    <span className="text-lg font-bold text-blue-600" data-testid="working-hours-display">
+                                        {formatWorkingHours(workingHours)}
+                                    </span>
+                                </div>
+                                <p className="text-xs text-gray-500 mt-1">
+                                    ※ 開始時刻・終了時刻・休憩時間から自動計算されます
+                                </p>
                             </div>
 
                             <div className="grid grid-cols-2 gap-4">

--- a/tests/e2e/fix/working-hours-calc.spec.ts
+++ b/tests/e2e/fix/working-hours-calc.spec.ts
@@ -1,0 +1,67 @@
+import { test, expect } from '@playwright/test';
+import { loginAsFacilityAdmin } from '../fixtures/auth.fixture';
+
+/**
+ * #48 実働時間自動計算機能のE2Eテスト
+ * テンプレート作成画面・求人作成画面で勤務時間から実働時間が自動計算されることを確認
+ *
+ * 前提条件:
+ * - データベースにテスト管理者アカウントが存在すること（prisma/seed.ts を実行）
+ * - admin1@facility.com / password123 でログイン可能であること
+ */
+
+test.describe('実働時間自動計算機能', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsFacilityAdmin(page);
+  });
+
+  test('テンプレート作成画面で実働時間が表示される', async ({ page }) => {
+    // テンプレート作成画面に遷移
+    await page.goto('/admin/jobs/templates/new');
+    await page.waitForLoadState('networkidle');
+
+    // 実働時間表示が存在することを確認
+    const workingHoursDisplay = page.locator('[data-testid="working-hours-display"]');
+    await expect(workingHoursDisplay).toBeVisible({ timeout: 10000 });
+
+    // デフォルト値（06:00-15:00、休憩0分）で実働時間が9時間と表示されることを確認
+    await expect(workingHoursDisplay).toContainText('9時間');
+  });
+
+  test('テンプレート作成画面で休憩時間変更時に実働時間が再計算される', async ({ page }) => {
+    await page.goto('/admin/jobs/templates/new');
+    await page.waitForLoadState('networkidle');
+
+    const workingHoursDisplay = page.locator('[data-testid="working-hours-display"]');
+    await expect(workingHoursDisplay).toBeVisible({ timeout: 10000 });
+
+    // 初期状態の実働時間を確認（9時間）
+    await expect(workingHoursDisplay).toContainText('9時間');
+
+    // 休憩時間を60分に変更
+    const breakTimeSelect = page.locator('select').filter({ hasText: /なし|0分/ }).first();
+    await breakTimeSelect.selectOption('60');
+
+    // 実働時間が更新されることを確認（06:00-15:00で休憩60分 = 8時間）
+    await expect(workingHoursDisplay).toContainText('8時間');
+  });
+
+  test('求人作成画面で実働時間が表示される', async ({ page }) => {
+    // 求人作成画面に遷移
+    await page.goto('/admin/jobs/new');
+    await page.waitForLoadState('networkidle');
+
+    // 実働時間表示が存在することを確認
+    const workingHoursDisplay = page.locator('[data-testid="working-hours-display"]');
+    await expect(workingHoursDisplay).toBeVisible({ timeout: 10000 });
+  });
+
+  test('自動計算の説明テキストが表示される', async ({ page }) => {
+    await page.goto('/admin/jobs/templates/new');
+    await page.waitForLoadState('networkidle');
+
+    // 説明テキストが表示されることを確認
+    const descriptionText = page.locator('text=開始時刻・終了時刻・休憩時間から自動計算されます');
+    await expect(descriptionText).toBeVisible({ timeout: 10000 });
+  });
+});


### PR DESCRIPTION
## Summary
- テンプレート作成画面・求人作成画面で、開始時刻・終了時刻・休憩時間から実働時間を自動計算し表示する機能を実装
- 既存の`calculateWorkingHours`関数（utils/salary.ts）を活用
- 青色のハイライトボックスで実働時間をリアルタイム表示
- 「翌」付き時刻（日跨ぎ勤務）にも対応

## Changed Files
- `components/admin/JobTemplateForm.tsx` - 実働時間の計算と表示UIを追加
- `components/admin/JobForm.tsx` - 同様の機能を追加
- `tests/e2e/fix/working-hours-calc.spec.ts` - E2Eテストを追加

## Test plan
- [ ] テンプレート作成画面で実働時間が表示される
- [ ] 開始時刻・終了時刻・休憩時間を変更すると実働時間が再計算される
- [ ] 求人作成画面でも同様に動作する
- [ ] 日跨ぎ勤務（例: 22:00-翌06:00）で正しく計算される

## Note
- E2Eテストはテストアカウントが必要です（`npx tsx prisma/seed.ts`でDBをシードしてください）

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)