### PR TITLE
feat: #27 施設管理画面のヘッダーに施設名を表示

### DIFF
--- a/components/admin/AdminLayout.tsx
+++ b/components/admin/AdminLayout.tsx
@@ -274,7 +274,12 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
         {/* ロゴ・施設名 */}
         <div className="p-3 border-b border-gray-800">
           <div className="flex items-center justify-between">
-            <Link href="/admin/jobs" prefetch={true} className="flex items-center gap-3 flex-1 min-w-0">
+            <Link
+              href="/admin/jobs"
+              prefetch={true}
+              className="flex items-center gap-3 flex-1 min-w-0"
+              title={isCollapsed && facilityName ? facilityName : undefined}
+            >
               <Image
                 src="/images/logo.png"
                 alt="+TASTAS"
@@ -286,6 +291,11 @@ export default function AdminLayout({ children }: AdminLayoutProps) {
                 <div className="overflow-hidden">
                   <h1 className="text-lg font-bold text-white whitespace-nowrap">+TASTAS</h1>
                   <p className="text-xs text-gray-400 whitespace-nowrap">施設管理画面</p>
+                  {facilityName && (
+                    <p className="text-xs text-blue-400 mt-1 truncate" title={facilityName}>
+                      {facilityName}
+                    </p>
+                  )}
                 </div>
               )}
             </Link>


### PR DESCRIPTION
## Summary
- サイドバー上部のロゴエリアに施設名を追加（青色テキスト）
- 長い施設名は省略表示、ホバーで全文表示
- サイドバー折りたたみ時はロゴにツールチップで施設名を表示
- 複数施設を管理する担当者が現在の施設を確認しやすくなる

## 変更内容
### Before
- ヘッダー: 「+TASTAS」「施設管理画面」のみ
- 施設名はサイドバー下部のユーザー情報セクションにのみ表示

### After  
- ヘッダー: 「+TASTAS」「施設管理画面」+ **施設名**（青色）
- サイドバー折りたたみ時もロゴホバーで施設名表示

## Test plan
- [ ] 施設管理者でログイン
- [ ] サイドバー上部のロゴエリアに施設名が表示されることを確認
- [ ] 長い施設名の場合、省略表示（...）されることを確認
- [ ] ホバーで全文がツールチップ表示されることを確認
- [ ] サイドバー折りたたみ時、ロゴホバーで施設名がツールチップ表示されることを確認

Closes #27

🤖 Generated with [Claude Code](https://claude.ai/code)