### PR TITLE
feat: #7 時給入力欄にコンマ付きフォーマット表示を追加

### DIFF
--- a/components/admin/JobForm.tsx
+++ b/components/admin/JobForm.tsx
@@ -1944,6 +1944,9 @@ export default function JobForm({ mode, jobId, initialData, isOfferMode = false,
                                     onChange={(e) => handleInputChange('hourlyWage', Number(e.target.value))}
                                     className={`w-full px-3 py-2 text-sm border rounded focus:outline-none focus:ring-2 focus:ring-blue-600 ${showErrors && (!formData.hourlyWage || formData.hourlyWage <= 0) ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
                                 />
+                                {formData.hourlyWage > 0 && (
+                                    <p className="text-blue-600 text-xs mt-1">¥{formData.hourlyWage.toLocaleString()}</p>
+                                )}
                                 {showErrors && (!formData.hourlyWage || formData.hourlyWage <= 0) && (
                                     <p className="text-red-500 text-xs mt-1">時給を入力してください</p>
                                 )}

--- a/components/admin/JobTemplateForm.tsx
+++ b/components/admin/JobTemplateForm.tsx
@@ -877,6 +877,9 @@ export default function JobTemplateForm({ mode, templateId, initialData }: JobTe
                                     onChange={(e) => handleInputChange('hourlyWage', Number(e.target.value))}
                                     className={`w-full px-3 py-2 text-sm border rounded focus:outline-none focus:ring-2 focus:ring-blue-600 ${showErrors && formData.hourlyWage <= 0 ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
                                 />
+                                {formData.hourlyWage > 0 && (
+                                    <p className="text-blue-600 text-xs mt-1">¥{formData.hourlyWage.toLocaleString()}</p>
+                                )}
                                 {showErrors && formData.hourlyWage <= 0 && (
                                     <p className="text-red-500 text-xs mt-1">時給を入力してください</p>
                                 )}


### PR DESCRIPTION
## Summary
- 求人作成フォーム（JobForm）の時給入力欄下にフォーマット済み金額を表示
- テンプレート作成フォーム（JobTemplateForm）にも同様の表示を追加
- 入力値が0より大きい場合のみ「¥1,200」形式で表示

## 変更ファイル
- `components/admin/JobForm.tsx`
- `components/admin/JobTemplateForm.tsx`

## Test plan
- [ ] 施設管理者でログイン
- [ ] 求人作成画面で時給入力欄に「1200」と入力
- [ ] 入力欄下に「¥1,200」と表示されることを確認
- [ ] テンプレート作成画面でも同様に確認

Closes #7

🤖 Generated with [Claude Code](https://claude.ai/code)