### PR TITLE
fix: #24 施設管理画面のパスワード要件を8文字以上に統一

### DIFF
--- a/app/admin/facility/page.tsx
+++ b/app/admin/facility/page.tsx
@@ -574,8 +574,8 @@ export default function FacilityPage() {
       toast.error('パスワードを入力してください');
       return;
     }
-    if (newAccount.password.length < 6) {
-      toast.error('パスワードは6文字以上で入力してください');
+    if (newAccount.password.length < 8) {
+      toast.error('パスワードは8文字以上で入力してください');
       return;
     }
 
@@ -607,8 +607,8 @@ export default function FacilityPage() {
   // パスワード変更
   const handleChangePassword = async (accountId: number) => {
     if (!admin?.facilityId) return;
-    if (!newPassword || newPassword.length < 6) {
-      toast.error('パスワードは6文字以上で入力してください');
+    if (!newPassword || newPassword.length < 8) {
+      toast.error('パスワードは8文字以上で入力してください');
       return;
     }
 
@@ -2139,7 +2139,7 @@ export default function FacilityPage() {
                   value={newAccount.password}
                   onChange={(e) => setNewAccount({ ...newAccount, password: e.target.value })}
                   className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-admin-primary focus:border-transparent"
-                  placeholder="6文字以上"
+                  placeholder="8文字以上"
                 />
               </div>
             </div>
@@ -2179,7 +2179,7 @@ export default function FacilityPage() {
                 value={newPassword}
                 onChange={(e) => setNewPassword(e.target.value)}
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-admin-primary focus:border-transparent"
-                placeholder="6文字以上"
+                placeholder="8文字以上"
               />
             </div>
             <div className="flex gap-3 mt-6">


### PR DESCRIPTION
## Summary
- 施設管理画面（admin/facility）のパスワード要件を6文字から8文字に変更
- システム管理の施設登録（8文字以上）との整合性を確保

## Changes
- アカウント追加時のパスワード検証: 6文字 → 8文字
- パスワード変更時の検証: 6文字 → 8文字
- プレースホルダーテキスト: 「6文字以上」→「8文字以上」

## Test plan
- [ ] 施設管理画面でアカウント追加時、7文字以下のパスワードでエラーが表示されること
- [ ] 施設管理画面でパスワード変更時、7文字以下のパスワードでエラーが表示されること
- [ ] プレースホルダーが「8文字以上」と表示されること

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)