### PR TITLE
fix: 工事中ページの戻るボタンをブラウザ履歴に対応

### DIFF
--- a/app/under-construction/page.tsx
+++ b/app/under-construction/page.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import Link from 'next/link';
-import { useSearchParams } from 'next/navigation';
+import { useSearchParams, useRouter } from 'next/navigation';
 import { ChevronLeft } from 'lucide-react';
 import { Button } from '@/components/ui/Button';
 
 export default function UnderConstruction() {
   const searchParams = useSearchParams();
+  const router = useRouter();
   const page = searchParams.get('page') || 'このページ';
 
   const pageNames: Record<string, string> = {
@@ -20,14 +21,23 @@ export default function UnderConstruction() {
 
   const pageName = pageNames[page] || page;
 
+  const handleBack = () => {
+    // ブラウザ履歴がある場合は戻る、なければホームへ
+    if (window.history.length > 1) {
+      router.back();
+    } else {
+      router.push('/');
+    }
+  };
+
   return (
     <div className="min-h-screen bg-white">
       {/* ヘッダー */}
       <div className="sticky top-0 bg-white border-b border-gray-200">
         <div className="px-4 py-3 flex items-center">
-          <Link href="/mypage">
+          <button onClick={handleBack} className="p-1 -ml-1">
             <ChevronLeft className="w-6 h-6" />
-          </Link>
+          </button>
           <h1 className="flex-1 text-center text-lg">{pageName}</h1>
           <div className="w-6" />
         </div>


### PR DESCRIPTION
## Summary
- 工事中ページの戻る矢印が常に`/mypage`にリダイレクトしていた問題を修正
- `router.back()`を使用してブラウザ履歴で前のページに戻るように変更
- 履歴がない場合はホーム(`/`)へ遷移

## Test plan
- [ ] 求人一覧から工事中ページに遷移し、戻るボタンで求人一覧に戻ることを確認
- [ ] 直接URL入力で工事中ページにアクセスし、戻るボタンでホームに遷移することを確認

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)