### PR TITLE
fix: #11 締切済みの場合「募集終了」と表示するよう修正

### DIFF
--- a/components/job/JobCard.tsx
+++ b/components/job/JobCard.tsx
@@ -209,7 +209,7 @@ const JobCardComponent: React.FC<JobCardProps> = ({ job, facility, selectedDate,
                 ? 'bg-red-500 text-white'
                 : 'bg-gray-300 text-gray-800'
                 }`}>
-                締切まで{deadlineText}
+                {deadlineText === '締切済み' ? '募集終了' : `締切まで${deadlineText}`}
               </span>
             </div>
 
@@ -328,7 +328,7 @@ const JobCardComponent: React.FC<JobCardProps> = ({ job, facility, selectedDate,
                 ? 'bg-red-500 text-white'
                 : 'bg-gray-300 text-gray-800'
                 }`}>
-                締切まで{deadlineText}
+                {deadlineText === '締切済み' ? '募集終了' : `締切まで${deadlineText}`}
               </span>
             </div>
 

--- a/components/job/JobDetailClient.tsx
+++ b/components/job/JobDetailClient.tsx
@@ -546,7 +546,7 @@ export function JobDetailClient({ job, facility, relatedJobs: _relatedJobs, faci
             ? 'bg-red-500 text-white'
             : 'bg-gray-300 text-gray-800'
             }`}>
-            締切まで{getDeadlineText(job.deadline)}
+            {getDeadlineText(job.deadline) === '締切済み' ? '募集終了' : `締切まで${getDeadlineText(job.deadline)}`}
           </span>
           <Badge variant="red">
             募集人数 {job.appliedCount}/{job.recruitmentCount}人


### PR DESCRIPTION
## Summary
- 「締切まで締切済み」という不自然な日本語になっていた問題を修正
- `getDeadlineText()`が「締切済み」を返す場合は「募集終了」と表示するよう変更

## 変更ファイル
- `components/job/JobCard.tsx` - PC版・モバイル版の締切表示
- `components/job/JobDetailClient.tsx` - 求人詳細画面の締切表示

## Before/After
- Before: `締切まで締切済み`
- After: `募集終了`

🤖 Generated with [Claude Code](https://claude.com/claude-code)