### PR TITLE
fix: #57 メッセージからお仕事詳細へのリンクを同じタブで開く

### DIFF
--- a/app/messages/MessagesClient.tsx
+++ b/app/messages/MessagesClient.tsx
@@ -459,8 +459,8 @@ export default function MessagesClient({ initialConversations, userId }: Message
 
   // テキスト内のURLをリンクに変換する関数
   const renderContentWithLinks = (content: string, linkColorStyle: 'default' | 'light' = 'default') => {
-    // 外部URL、www、アプリ内パス（/jobs/123など）を検出
-    const urlRegex = /(https?:\/\/[^\s]+|www\.[^\s]+|\/jobs\/\d+)/g;
+    // 外部URL、www、アプリ内パス（/jobs/123, /my-jobs/123など）を検出
+    const urlRegex = /(https?:\/\/[^\s]+|www\.[^\s]+|\/(?:jobs|my-jobs)\/\d+)/g;
     const parts = content.split(urlRegex);
 
     const linkClassName = linkColorStyle === 'light'


### PR DESCRIPTION
## 概要
メッセージ画面内のお仕事詳細リンクが同じタブで開くように修正

## 変更内容
- 内部リンク検出の正規表現を拡張
- `/jobs/[id]` に加えて `/my-jobs/[id]` も対象に
- 外部リンク（http/https）は別タブ、内部リンクは同じタブで開く

## 対象Issue
#57 メッセージからお仕事詳細へのリンク（同じタブで開きたい）

## テスト
- [x] npm run build 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)