### PR TITLE
fix: #73 iOSでフリガナ入力時に勝手に文字が入る問題を修正

### DIFF
--- a/app/mypage/profile/ProfileEditClient.tsx
+++ b/app/mypage/profile/ProfileEditClient.tsx
@@ -6,9 +6,10 @@ import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { updateUserProfile } from '@/src/lib/actions';
 import { validateFile, getSafeImageUrl, isValidImageUrl } from '@/utils/fileValidation';
-import { formatKatakana, formatKatakanaWithSpace, formatPhoneNumber, isKatakanaOnly, isKatakanaWithSpaceOnly } from '@/utils/inputValidation';
+import { formatPhoneNumber, isKatakanaOnly, isKatakanaWithSpaceOnly } from '@/utils/inputValidation';
 import toast from 'react-hot-toast';
 import AddressSelector from '@/components/ui/AddressSelector';
+import { KatakanaInput, KatakanaWithSpaceInput } from '@/components/ui/KatakanaInput';
 import { QUALIFICATION_GROUPS } from '@/constants/qualifications';
 import { useDebugError, extractDebugInfo } from '@/components/debug/DebugErrorBanner';
 
@@ -705,13 +706,9 @@ export default function ProfileEditClient({ userProfile }: ProfileEditClientProp
             </div>
             <div>
               <label className="block text-sm font-medium mb-2">姓（カナ） <span className="text-red-500">*</span></label>
-              <input
-                type="text"
+              <KatakanaInput
                 value={formData.lastNameKana}
-                onChange={(e) => {
-                  const value = formatKatakana(e.target.value);
-                  setFormData({ ...formData, lastNameKana: value });
-                }}
+                onChange={(value) => setFormData({ ...formData, lastNameKana: value })}
                 className={`w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent ${showErrors && !formData.lastNameKana ? 'border-red-500 bg-red-50' : formData.lastNameKana && !isKatakanaOnly(formData.lastNameKana) ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
                 placeholder="ヤマダ"
               />
@@ -725,13 +722,9 @@ export default function ProfileEditClient({ userProfile }: ProfileEditClientProp
             </div>
             <div>
               <label className="block text-sm font-medium mb-2">名（カナ） <span className="text-red-500">*</span></label>
-              <input
-                type="text"
+              <KatakanaInput
                 value={formData.firstNameKana}
-                onChange={(e) => {
-                  const value = formatKatakana(e.target.value);
-                  setFormData({ ...formData, firstNameKana: value });
-                }}
+                onChange={(value) => setFormData({ ...formData, firstNameKana: value })}
                 className={`w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent ${showErrors && !formData.firstNameKana ? 'border-red-500 bg-red-50' : formData.firstNameKana && !isKatakanaOnly(formData.firstNameKana) ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
                 placeholder="タロウ"
               />
@@ -1288,10 +1281,9 @@ export default function ProfileEditClient({ userProfile }: ProfileEditClientProp
               </div>
               <div>
                 <label className="block text-sm font-medium mb-2">口座名義（カナ） <span className="text-red-500">*</span></label>
-                <input
-                  type="text"
+                <KatakanaWithSpaceInput
                   value={formData.accountName}
-                  onChange={(e) => setFormData({ ...formData, accountName: formatKatakanaWithSpace(e.target.value) })}
+                  onChange={(value) => setFormData({ ...formData, accountName: value })}
                   placeholder="ヤマダ タロウ"
                   className={`w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent ${showErrors && !formData.accountName ? 'border-red-500 bg-red-50' : formData.accountName && !isKatakanaWithSpaceOnly(formData.accountName) ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
                 />

--- a/app/register/worker/page.tsx
+++ b/app/register/worker/page.tsx
@@ -7,8 +7,9 @@ import Link from 'next/link';
 import toast from 'react-hot-toast';
 import { useAuth } from '@/contexts/AuthContext';
 import { compressImage, MAX_FILE_SIZE, formatFileSize } from '@/utils/fileValidation';
-import { formatKatakana, formatPhoneNumber, isValidEmail, isValidPhoneNumber, isKatakanaOnly } from '@/utils/inputValidation';
+import { formatPhoneNumber, isValidEmail, isValidPhoneNumber, isKatakanaOnly } from '@/utils/inputValidation';
 import AddressSelector from '@/components/ui/AddressSelector';
+import { KatakanaInput } from '@/components/ui/KatakanaInput';
 import { QUALIFICATION_GROUPS } from '@/constants/qualifications';
 import { useDebugError, extractDebugInfo } from '@/components/debug/DebugErrorBanner';
 
@@ -389,16 +390,15 @@ export default function WorkerRegisterPage() {
                     <p className="text-red-500 text-xs mt-1">名を入力してください</p>
                   )}
                 </div>
-                {/* フリガナ（姓名の直後） */}
+                {/* フリガナ（姓名の直後） - iOS IME対応コンポーネント使用 */}
                 <div>
                   <label className="block text-sm font-medium text-gray-700 mb-1">
                     セイ（フリガナ） <span className="text-red-500">*</span>
                   </label>
-                  <input
-                    type="text"
+                  <KatakanaInput
                     required
                     value={formData.lastNameKana}
-                    onChange={(e) => setFormData({ ...formData, lastNameKana: formatKatakana(e.target.value) })}
+                    onChange={(value) => setFormData({ ...formData, lastNameKana: value })}
                     className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary ${showErrors && !formData.lastNameKana ? 'border-red-500 bg-red-50' : formData.lastNameKana && !isKatakanaOnly(formData.lastNameKana) ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
                     placeholder="ヤマダ"
                   />
@@ -414,11 +414,10 @@ export default function WorkerRegisterPage() {
                   <label className="block text-sm font-medium text-gray-700 mb-1">
                     メイ（フリガナ） <span className="text-red-500">*</span>
                   </label>
-                  <input
-                    type="text"
+                  <KatakanaInput
                     required
                     value={formData.firstNameKana}
-                    onChange={(e) => setFormData({ ...formData, firstNameKana: formatKatakana(e.target.value) })}
+                    onChange={(value) => setFormData({ ...formData, firstNameKana: value })}
                     className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary ${showErrors && !formData.firstNameKana ? 'border-red-500 bg-red-50' : formData.firstNameKana && !isKatakanaOnly(formData.firstNameKana) ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
                     placeholder="タロウ"
                   />

--- a/components/ui/KatakanaInput.tsx
+++ b/components/ui/KatakanaInput.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useState, useRef, useCallback, InputHTMLAttributes } from 'react';
+import { formatKatakana, formatKatakanaWithSpace } from '@/utils/inputValidation';
+
+interface KatakanaInputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'value'> {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+/**
+ * iOSのIME入力問題に対応したカタカナ入力コンポーネント
+ *
+ * 問題: iOSではIME入力中（変換確定前）にonChangeが発火し、
+ * formatKatakanaによる変換がIMEのcomposition状態と干渉して
+ * 「勝手に文字が入力される」問題が発生する。
+ *
+ * 解決策: onCompositionStart/Endを使用してIME入力中は
+ * 変換処理をスキップし、入力確定後にのみ変換を行う。
+ */
+export function KatakanaInput({ value, onChange, ...props }: KatakanaInputProps) {
+  // IME入力中かどうかを追跡
+  const isComposingRef = useRef(false);
+  // ローカルの入力値（IME入力中は変換せずに保持）
+  const [localValue, setLocalValue] = useState(value);
+
+  // 外部からの値変更に追従
+  if (value !== localValue && !isComposingRef.current) {
+    setLocalValue(value);
+  }
+
+  const handleCompositionStart = useCallback(() => {
+    isComposingRef.current = true;
+  }, []);
+
+  const handleCompositionEnd = useCallback((e: React.CompositionEvent<HTMLInputElement>) => {
+    isComposingRef.current = false;
+    // IME入力確定時にカタカナ変換を適用
+    const convertedValue = formatKatakana(e.currentTarget.value);
+    setLocalValue(convertedValue);
+    onChange(convertedValue);
+  }, [onChange]);
+
+  const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value;
+
+    if (isComposingRef.current) {
+      // IME入力中は変換せずにそのまま表示
+      setLocalValue(newValue);
+    } else {
+      // 通常入力時（英数字直接入力など）は即座に変換
+      const convertedValue = formatKatakana(newValue);
+      setLocalValue(convertedValue);
+      onChange(convertedValue);
+    }
+  }, [onChange]);
+
+  return (
+    <input
+      {...props}
+      type="text"
+      value={localValue}
+      onChange={handleChange}
+      onCompositionStart={handleCompositionStart}
+      onCompositionEnd={handleCompositionEnd}
+    />
+  );
+}
+
+/**
+ * スペース付きカタカナ入力コンポーネント（口座名義用）
+ * KatakanaInputと同様のIME対応を行い、スペースを許容する
+ */
+export function KatakanaWithSpaceInput({ value, onChange, ...props }: KatakanaInputProps) {
+  const isComposingRef = useRef(false);
+  const [localValue, setLocalValue] = useState(value);
+
+  if (value !== localValue && !isComposingRef.current) {
+    setLocalValue(value);
+  }
+
+  const handleCompositionStart = useCallback(() => {
+    isComposingRef.current = true;
+  }, []);
+
+  const handleCompositionEnd = useCallback((e: React.CompositionEvent<HTMLInputElement>) => {
+    isComposingRef.current = false;
+    const convertedValue = formatKatakanaWithSpace(e.currentTarget.value);
+    setLocalValue(convertedValue);
+    onChange(convertedValue);
+  }, [onChange]);
+
+  const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value;
+
+    if (isComposingRef.current) {
+      setLocalValue(newValue);
+    } else {
+      const convertedValue = formatKatakanaWithSpace(newValue);
+      setLocalValue(convertedValue);
+      onChange(convertedValue);
+    }
+  }, [onChange]);
+
+  return (
+    <input
+      {...props}
+      type="text"
+      value={localValue}
+      onChange={handleChange}
+      onCompositionStart={handleCompositionStart}
+      onCompositionEnd={handleCompositionEnd}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- iOSのIME入力問題に対応したKatakanaInputコンポーネントを作成
- onCompositionStart/Endを使用してIME入力中は変換処理をスキップ
- ワーカー登録・プロフィール編集のフリガナ入力欄を修正

## 原因
iOSではIME入力中（変換確定前）にReactのonChangeイベントが発火し、formatKatakana関数による変換処理がIMEのcomposition状態と干渉して「勝手に文字が入力される」問題が発生していた。

## 対応
- `components/ui/KatakanaInput.tsx` を新規作成
- `onCompositionStart/End`イベントでIME入力中を検知
- IME入力中は変換せず、確定時のみカタカナ変換を適用

## 影響範囲
- `/register/worker` ワーカー登録ページ
- `/mypage/profile` プロフィール編集ページ

## Test plan
- [ ] iPhone SE (iOS 18.4) でフリガナ入力が正常に動作することを確認
- [ ] PCブラウザでのフリガナ入力が正常に動作することを確認
- [ ] ひらがな入力がカタカナに自動変換されることを確認

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)