### PR TITLE
feat: #71 Resendによるメール送信基盤を実装

### DIFF
--- a/app/api/dev/test-email/route.ts
+++ b/app/api/dev/test-email/route.ts
@@ -1,0 +1,126 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { Resend } from 'resend';
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+const FROM_EMAIL = process.env.RESEND_FROM_EMAIL || 'noreply@tastas.site';
+
+/**
+ * メール送信テスト用APIエンドポイント
+ * 開発環境でのみ使用可能
+ *
+ * POST /api/dev/test-email
+ * Body: { to: string, subject?: string, body?: string }
+ */
+export async function POST(request: NextRequest) {
+    // 開発環境チェック
+    if (process.env.NODE_ENV === 'production') {
+        return NextResponse.json(
+            { error: 'This endpoint is only available in development' },
+            { status: 403 }
+        );
+    }
+
+    try {
+        const body = await request.json();
+        const { to, subject, body: emailBody } = body;
+
+        if (!to) {
+            return NextResponse.json(
+                { error: 'to is required' },
+                { status: 400 }
+            );
+        }
+
+        const testSubject = subject || '【テスト】+TASTAS メール送信テスト';
+        const testBody = emailBody || `
+これはテストメールです。
+
++TASTAS からのメール送信が正常に動作しています。
+
+送信日時: ${new Date().toLocaleString('ja-JP', { timeZone: 'Asia/Tokyo' })}
+送信先: ${to}
+送信元: ${FROM_EMAIL}
+
+---
++TASTAS 運営
+        `.trim();
+
+        const { data, error } = await resend.emails.send({
+            from: `+TASTAS <${FROM_EMAIL}>`,
+            to: [to],
+            subject: testSubject,
+            html: `
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="font-family: 'Helvetica Neue', Arial, 'Hiragino Sans', sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+    <div style="background-color: #e8f5e9; padding: 20px; border-radius: 8px; border-left: 4px solid #4caf50;">
+        <h2 style="color: #2e7d32; margin-top: 0;">✅ メール送信テスト成功</h2>
+        ${testBody.replace(/\n/g, '<br>')}
+    </div>
+    <div style="margin-top: 20px; padding-top: 20px; border-top: 1px solid #eee; font-size: 12px; color: #666;">
+        <p>このメールは開発環境からのテスト送信です。</p>
+    </div>
+</body>
+</html>`,
+            text: testBody,
+        });
+
+        if (error) {
+            console.error('[Test Email] Failed:', error);
+            return NextResponse.json(
+                { error: error.message },
+                { status: 500 }
+            );
+        }
+
+        console.log('[Test Email] Sent successfully:', data);
+        return NextResponse.json({
+            success: true,
+            messageId: data?.id,
+            to,
+            from: FROM_EMAIL,
+        });
+    } catch (error: any) {
+        console.error('[Test Email] Error:', error);
+        return NextResponse.json(
+            { error: error.message || 'Unknown error' },
+            { status: 500 }
+        );
+    }
+}
+
+/**
+ * GET: API情報を返す
+ */
+export async function GET() {
+    if (process.env.NODE_ENV === 'production') {
+        return NextResponse.json(
+            { error: 'This endpoint is only available in development' },
+            { status: 403 }
+        );
+    }
+
+    return NextResponse.json({
+        endpoint: '/api/dev/test-email',
+        method: 'POST',
+        description: 'Test email sending with Resend',
+        body: {
+            to: 'string (required) - recipient email address',
+            subject: 'string (optional) - email subject',
+            body: 'string (optional) - email body text',
+        },
+        example: {
+            to: 'test@example.com',
+            subject: 'テストメール',
+            body: 'これはテストです',
+        },
+        config: {
+            from: FROM_EMAIL,
+            resendConfigured: !!process.env.RESEND_API_KEY,
+        },
+    });
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -23,6 +23,7 @@ const ignoredPaths = [
   '/api/auth',
   '/api/admin',
   '/api/debug', // デバッグ用API
+  '/api/dev', // 開発用API（テストメール送信など）
   '/api/error-messages', // エラーメッセージ設定（認証不要）
   '/rogo', // ロゴ画像
   '/images', // 画像ファイル

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "react-chartjs-2": "^5.3.1",
         "react-dom": "^18",
         "react-hot-toast": "^2.6.0",
+        "resend": "^6.6.0",
         "swr": "^2.3.8",
         "tailwindcss": "^3.4.18",
         "typescript": "^5",
@@ -4591,6 +4592,12 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@supabase/auth-js": {
       "version": "2.64.4",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.64.4.tgz",
@@ -6589,6 +6596,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.0.tgz",
@@ -6838,6 +6851,12 @@
         "iobuffer": "^5.3.2",
         "pako": "^2.1.0"
       }
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fast-uri": {
       "version": "3.1.0",
@@ -9428,6 +9447,12 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -9702,6 +9727,32 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "license": "ISC"
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
+    },
+    "node_modules/resend": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.6.0.tgz",
+      "integrity": "sha512-d1WoOqSxj5x76JtQMrieNAG1kZkh4NU4f+Je1yq4++JsDpLddhEwnJlNfvkCzvUuZy9ZquWmMMAm2mENd2JvRw==",
+      "license": "MIT",
+      "dependencies": {
+        "svix": "1.76.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -10518,6 +10569,42 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/svix": {
+      "version": "1.76.1",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.76.1.tgz",
+      "integrity": "sha512-CRuDWBTgYfDnBLRaZdKp9VuoPcNUq9An14c/k+4YJ15Qc5Grvf66vp0jvTltd4t7OIRj+8lM1DAgvSgvf7hdLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "@types/node": "^22.7.5",
+        "es6-promise": "^4.2.8",
+        "fast-sha256": "^1.3.0",
+        "url-parse": "^1.5.10",
+        "uuid": "^10.0.0"
+      }
+    },
+    "node_modules/svix/node_modules/@types/node": {
+      "version": "22.19.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.3.tgz",
+      "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/svix/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/swr": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.8.tgz",
@@ -11102,6 +11189,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react-chartjs-2": "^5.3.1",
     "react-dom": "^18",
     "react-hot-toast": "^2.6.0",
+    "resend": "^6.6.0",
     "swr": "^2.3.8",
     "tailwindcss": "^3.4.18",
     "typescript": "^5",


### PR DESCRIPTION
## Summary

- Resendパッケージを追加してメール送信機能を実装
- `notification-service.ts`の`sendEmailNotification`関数を実際のメール送信に変更
- 開発用テストエンドポイント `/api/dev/test-email` を追加

## 変更内容

### 追加ファイル
- `app/api/dev/test-email/route.ts` - 開発環境専用のメール送信テストAPI

### 変更ファイル
- `src/lib/notification-service.ts` - Resend連携実装
- `middleware.ts` - `/api/dev` を認証バイパスに追加
- `package.json` - resendパッケージ追加

## 環境変数（Vercel設定必要）

| 変数名 | 説明 |
|--------|------|
| `RESEND_API_KEY` | Resend APIキー |
| `RESEND_FROM_EMAIL` | 送信元メールアドレス（例: noreply@tastas.site） |

## Test plan

- [x] ローカルでビルドが通ること
- [x] `/api/dev/test-email` でテストメール送信を確認済み
- [ ] Vercelプレビュー環境で動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)