### PR TITLE
feat: #71 レビュー関連の通知機能を追加

### DIFF
--- a/src/lib/actions/application-admin.ts
+++ b/src/lib/actions/application-admin.ts
@@ -7,6 +7,7 @@ import {
     sendMatchingNotification,
     sendReviewRequestNotification,
     sendCancelNotification,
+    sendFacilityReviewRequestNotification,
 } from './notification';
 import { sendNotification } from '../notification-service';
 import { getAuthenticatedUser } from './helpers';
@@ -261,9 +262,17 @@ export async function updateApplicationStatus(
         }
 
         if (newStatus === 'COMPLETED_PENDING') {
+            // ワーカーへレビュー依頼
             await sendReviewRequestNotification(
                 application.user_id,
                 application.workDate.job.facility.facility_name,
+                application.workDate.job.title,
+                applicationId
+            );
+            // 施設へレビュー依頼
+            await sendFacilityReviewRequestNotification(
+                facilityId,
+                application.user.name,
                 application.workDate.job.title,
                 applicationId
             );

--- a/src/lib/actions/review-admin.ts
+++ b/src/lib/actions/review-admin.ts
@@ -3,6 +3,7 @@
 import { prisma } from '@/lib/prisma';
 import { unstable_noStore, revalidatePath } from 'next/cache';
 import { getCurrentTime, getTodayStart, type WorkerListItem, type WorkerListSearchParams, type WorkerListStatus } from './helpers';
+import { sendReviewReceivedNotificationToWorker } from './notification';
 
 /**
  * 施設管理者用: ワーカーの詳細情報を取得（統計・評価・キャンセル率含む）
@@ -946,6 +947,18 @@ export async function submitFacilityReviewForWorker(
         });
       }
     });
+
+    // ワーカーへレビュー受信通知を送信
+    const facility = await prisma.facility.findUnique({
+      where: { id: facilityId },
+      select: { facility_name: true },
+    });
+    if (facility) {
+      await sendReviewReceivedNotificationToWorker(
+        application.user_id,
+        facility.facility_name
+      );
+    }
 
     console.log('[submitFacilityReviewForWorker] Review submitted successfully');
 

--- a/src/lib/actions/review-worker.ts
+++ b/src/lib/actions/review-worker.ts
@@ -3,6 +3,7 @@
 import { prisma } from '@/lib/prisma';
 import { revalidatePath } from 'next/cache';
 import { getAuthenticatedUser, getCurrentTime } from './helpers';
+import { sendReviewReceivedNotificationToFacility } from './notification';
 
 /**
  * 年代を計算する内部ヘルパー
@@ -251,14 +252,3 @@ export async function getFacilityReviews(facilityId: number) {
     }
 }
 
-/**
- * 施設向けレビュー受信通知（プレースホルダー）
- */
-async function sendReviewReceivedNotificationToFacility(
-    _facilityId: number,
-    _workerName: string,
-    _rating: number
-) {
-    console.log('[sendReviewReceivedNotificationToFacility] Facility notifications not yet implemented');
-    return null;
-}


### PR DESCRIPTION
## Summary
- FACILITY_REVIEW_REQUEST: 勤務完了時に施設へレビュー依頼通知を送信
- WORKER_REVIEW_RECEIVED: 施設がワーカーをレビューした時にワーカーへ通知
- FACILITY_REVIEW_RECEIVED: ワーカーが施設をレビューした時に施設へ通知

## 変更ファイル
- `src/lib/actions/notification.ts` - 3つの通知関数を追加
- `src/lib/actions/application-admin.ts` - COMPLETED_PENDING時に施設へレビュー依頼送信
- `src/lib/actions/review-admin.ts` - 施設レビュー投稿時にワーカーへ通知
- `src/lib/actions/review-worker.ts` - 重複プレースホルダー関数を削除

## Test plan
- [ ] 勤務完了時に施設へレビュー依頼メールが届くこと
- [ ] 施設がワーカーをレビュー投稿時にワーカーへメールが届くこと
- [ ] ワーカーが施設をレビュー投稿時に施設へメールが届くこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)