### PR TITLE
feat: ページアクセス時のオンデマンドステータス更新を追加

### DIFF
--- a/src/lib/actions/application-admin.ts
+++ b/src/lib/actions/application-admin.ts
@@ -12,6 +12,7 @@ import {
 } from './notification';
 import { sendNotification } from '../notification-service';
 import { getAuthenticatedUser } from './helpers';
+import { updateApplicationStatuses } from '../status-updater';
 
 /**
  * 施設管理用: 施設に届いた応募一覧を取得
@@ -19,6 +20,9 @@ import { getAuthenticatedUser } from './helpers';
 export async function getFacilityApplications(facilityId: number) {
     try {
         console.log('[getFacilityApplications] Fetching applications for facility:', facilityId);
+
+        // アクセス時にステータスをリアルタイム更新
+        await updateApplicationStatuses({ facilityId });
 
         const applications = await prisma.application.findMany({
             where: {

--- a/src/lib/actions/application-worker.ts
+++ b/src/lib/actions/application-worker.ts
@@ -10,6 +10,7 @@ import {
     sendApplicationNotificationMultiple,
 } from './notification';
 import { sendNearbyJobNotifications, sendNotification } from '../notification-service';
+import { updateApplicationStatuses } from '../status-updater';
 
 /**
  * ユーザーが応募した仕事の一覧を取得
@@ -18,6 +19,9 @@ export async function getMyApplications(options?: { limit?: number; offset?: num
     try {
         const user = await getAuthenticatedUser();
         console.log('[getMyApplications] Fetching applications for user:', user.id);
+
+        // アクセス時にステータスをリアルタイム更新
+        await updateApplicationStatuses({ userId: user.id });
 
         const limit = options?.limit ?? 50; // デフォルト50件
         const offset = options?.offset ?? 0;

--- a/src/lib/status-updater.ts
+++ b/src/lib/status-updater.ts
@@ -1,0 +1,90 @@
+import { prisma } from '@/lib/prisma';
+
+/**
+ * アプリケーションのステータスをリアルタイムで更新
+ * - SCHEDULED → WORKING: 勤務開始時刻を過ぎた場合
+ * - WORKING → COMPLETED_RATED: 勤務終了 + 双方レビュー完了
+ *
+ * @param options.userId - ワーカーIDで絞り込み（ワーカー側で使用）
+ * @param options.facilityId - 施設IDで絞り込み（施設側で使用）
+ */
+export async function updateApplicationStatuses(options?: {
+    userId?: number;
+    facilityId?: number;
+}): Promise<{ scheduledToWorking: number; workingToCompleted: number }> {
+    const now = new Date();
+    const currentTime = now.toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit' });
+
+    // ベースのwhere条件
+    const baseWhereScheduled: Record<string, unknown> = {
+        status: 'SCHEDULED',
+        workDate: {
+            work_date: { lte: now },
+            job: {
+                start_time: { lte: currentTime },
+            },
+        },
+    };
+
+    const baseWhereWorking: Record<string, unknown> = {
+        status: 'WORKING',
+        worker_review_status: 'COMPLETED',
+        facility_review_status: 'COMPLETED',
+        workDate: {
+            work_date: { lte: now },
+            job: {
+                end_time: { lte: currentTime },
+            },
+        },
+    };
+
+    // ユーザーIDまたは施設IDで絞り込み
+    if (options?.userId) {
+        baseWhereScheduled.user_id = options.userId;
+        baseWhereWorking.user_id = options.userId;
+    }
+
+    if (options?.facilityId) {
+        baseWhereScheduled.workDate = {
+            ...(baseWhereScheduled.workDate as object),
+            job: {
+                ...((baseWhereScheduled.workDate as { job: object }).job),
+                facility_id: options.facilityId,
+            },
+        };
+        baseWhereWorking.workDate = {
+            ...(baseWhereWorking.workDate as object),
+            job: {
+                ...((baseWhereWorking.workDate as { job: object }).job),
+                facility_id: options.facilityId,
+            },
+        };
+    }
+
+    // 1. SCHEDULED → WORKING
+    const scheduledToWorking = await prisma.application.updateMany({
+        where: baseWhereScheduled as Parameters<typeof prisma.application.updateMany>[0]['where'],
+        data: { status: 'WORKING' },
+    });
+
+    // 2. WORKING → COMPLETED_RATED
+    const workingToCompleted = await prisma.application.updateMany({
+        where: baseWhereWorking as Parameters<typeof prisma.application.updateMany>[0]['where'],
+        data: { status: 'COMPLETED_RATED' },
+    });
+
+    // ログ出力（デバッグ用）
+    if (scheduledToWorking.count > 0 || workingToCompleted.count > 0) {
+        console.log('[STATUS-UPDATER] Updated:', {
+            userId: options?.userId,
+            facilityId: options?.facilityId,
+            scheduledToWorking: scheduledToWorking.count,
+            workingToCompleted: workingToCompleted.count,
+        });
+    }
+
+    return {
+        scheduledToWorking: scheduledToWorking.count,
+        workingToCompleted: workingToCompleted.count,
+    };
+}


### PR DESCRIPTION
## 概要
ユーザーがページにアクセスした瞬間にステータスを更新する機能を追加。
これにより、cronの15分間隔に依存せず、常に最新のステータスが表示されます。

## 変更内容

### 新規ファイル
- `src/lib/status-updater.ts` - 共通ステータス更新ユーティリティ

### 更新ファイル
- `src/lib/actions/application-worker.ts` - ワーカー側でアクセス時に更新
- `src/lib/actions/application-admin.ts` - 施設側でアクセス時に更新

## 動作

| タイミング | 更新対象 |
|-----------|---------|
| ワーカーが応募一覧を開く | 自分の応募のみ |
| 施設が応募一覧を開く | 自施設の応募のみ |
| cron（15分ごと） | 全体（バックグラウンド） |

## メリット
- ユーザーが画面を見た時点で最新ステータス
- 「予定のまま？」という問い合わせを防止
- cronは引き続きバックグラウンド更新として機能

🤖 Generated with [Claude Code](https://claude.com/claude-code)