### PR TITLE
feat: メール認証機能を追加

### DIFF
--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -3,6 +3,7 @@ import bcrypt from 'bcryptjs';
 import { Prisma } from '@prisma/client';
 import prisma from '@/lib/prisma';
 import { sendAdminNewWorkerNotification } from '@/src/lib/actions/notification';
+import { sendVerificationEmail } from '@/src/lib/auth/email-verification';
 
 export async function POST(request: NextRequest) {
   try {
@@ -80,6 +81,18 @@ export async function POST(request: NextRequest) {
       },
     });
 
+    // 認証メールを送信
+    const verificationResult = await sendVerificationEmail(
+      user.id,
+      user.email,
+      user.name
+    );
+
+    if (!verificationResult.success) {
+      console.error('Failed to send verification email:', verificationResult.error);
+      // 認証メール送信に失敗してもユーザー登録は成功とする
+    }
+
     // 管理者に新規ワーカー登録を通知
     await sendAdminNewWorkerNotification(
       user.id,
@@ -88,12 +101,13 @@ export async function POST(request: NextRequest) {
     );
 
     return NextResponse.json({
-      message: '登録が完了しました',
+      message: '登録が完了しました。確認メールをお送りしましたので、メール内のリンクをクリックして認証を完了してください。',
       user: {
         id: user.id,
         email: user.email,
         name: user.name,
       },
+      requiresVerification: true,
     });
   } catch (error) {
     console.error('Registration error:', error);

--- a/app/api/auth/resend-verification/route.ts
+++ b/app/api/auth/resend-verification/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { resendVerificationEmail } from '@/src/lib/auth/email-verification';
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { email } = body;
+
+    if (!email) {
+      return NextResponse.json(
+        { error: 'メールアドレスを入力してください。' },
+        { status: 400 }
+      );
+    }
+
+    const result = await resendVerificationEmail(email);
+
+    if (!result.success) {
+      return NextResponse.json(
+        { error: result.error },
+        { status: 400 }
+      );
+    }
+
+    // セキュリティのため、ユーザーの存在有無に関わらず成功メッセージを返す
+    return NextResponse.json({
+      success: true,
+      message: '確認メールを送信しました。',
+    });
+  } catch (error) {
+    console.error('Resend verification error:', error);
+    return NextResponse.json(
+      { error: 'システムエラーが発生しました。' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/auth/verify/route.ts
+++ b/app/api/auth/verify/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { verifyEmailToken } from '@/src/lib/auth/email-verification';
+
+export async function GET(request: NextRequest) {
+  try {
+    const token = request.nextUrl.searchParams.get('token');
+
+    if (!token) {
+      return NextResponse.json(
+        { error: '認証トークンが指定されていません。' },
+        { status: 400 }
+      );
+    }
+
+    const result = await verifyEmailToken(token);
+
+    if (!result.success) {
+      return NextResponse.json(
+        { error: result.error },
+        { status: 400 }
+      );
+    }
+
+    return NextResponse.json({
+      success: true,
+      message: 'メールアドレスの認証が完了しました。',
+    });
+  } catch (error) {
+    console.error('Email verification error:', error);
+    return NextResponse.json(
+      { error: 'システムエラーが発生しました。' },
+      { status: 500 }
+    );
+  }
+}

--- a/app/auth/resend-verification/page.tsx
+++ b/app/auth/resend-verification/page.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { useState, useEffect, Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import { Mail, CheckCircle, AlertCircle, ArrowLeft } from 'lucide-react';
+
+function ResendVerificationForm() {
+  const searchParams = useSearchParams();
+  const initialEmail = searchParams.get('email') || '';
+
+  const [email, setEmail] = useState(initialEmail);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [success, setSuccess] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setSuccess(false);
+
+    if (!email) {
+      setError('メールアドレスを入力してください');
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const response = await fetch('/api/auth/resend-verification', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        setError(data.error || '再送信に失敗しました');
+      } else {
+        setSuccess(true);
+      }
+    } catch (err) {
+      setError('システムエラーが発生しました');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (success) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+        <div className="max-w-md w-full bg-white rounded-lg shadow-lg p-8 text-center">
+          <CheckCircle className="w-16 h-16 text-green-500 mx-auto mb-4" />
+          <h1 className="text-2xl font-bold text-gray-900 mb-2">
+            メールを送信しました
+          </h1>
+          <p className="text-gray-600 mb-6">
+            確認メールを送信しました。
+            メール内のリンクをクリックして認証を完了してください。
+          </p>
+          <p className="text-sm text-gray-500 mb-6">
+            メールが届かない場合は、迷惑メールフォルダを確認してください。
+          </p>
+          <Link
+            href="/login"
+            className="inline-block bg-blue-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-blue-700 transition"
+          >
+            ログインページへ
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+      <div className="max-w-md w-full bg-white rounded-lg shadow-lg p-8">
+        <Link
+          href="/login"
+          className="inline-flex items-center text-gray-600 hover:text-gray-900 mb-6"
+        >
+          <ArrowLeft className="w-4 h-4 mr-2" />
+          ログインに戻る
+        </Link>
+
+        <h1 className="text-2xl font-bold text-gray-900 mb-2">
+          確認メールの再送信
+        </h1>
+        <p className="text-gray-600 mb-6">
+          登録したメールアドレスを入力してください。
+          確認メールを再送信します。
+        </p>
+
+        {error && (
+          <div className="mb-4 p-3 bg-red-50 border border-red-200 rounded-lg flex items-start gap-2">
+            <AlertCircle className="w-5 h-5 text-red-500 flex-shrink-0 mt-0.5" />
+            <p className="text-red-700 text-sm">{error}</p>
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              メールアドレス
+            </label>
+            <div className="relative">
+              <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                placeholder="yamada.taro@example.com"
+              />
+            </div>
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="w-full py-3 bg-blue-600 text-white rounded-lg font-bold hover:bg-blue-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isSubmitting ? '送信中...' : '確認メールを再送信'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default function ResendVerificationPage() {
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="text-gray-500">読み込み中...</div>
+      </div>
+    }>
+      <ResendVerificationForm />
+    </Suspense>
+  );
+}

--- a/app/auth/verify/page.tsx
+++ b/app/auth/verify/page.tsx
@@ -1,0 +1,92 @@
+import { verifyEmailToken } from '@/src/lib/auth/email-verification';
+import Link from 'next/link';
+import { CheckCircle, XCircle, AlertCircle } from 'lucide-react';
+
+interface Props {
+  searchParams: Promise<{ token?: string }>;
+}
+
+export default async function VerifyEmailPage({ searchParams }: Props) {
+  const params = await searchParams;
+  const token = params.token;
+
+  // トークンがない場合
+  if (!token) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+        <div className="max-w-md w-full bg-white rounded-lg shadow-lg p-8 text-center">
+          <AlertCircle className="w-16 h-16 text-yellow-500 mx-auto mb-4" />
+          <h1 className="text-2xl font-bold text-gray-900 mb-2">
+            認証リンクが無効です
+          </h1>
+          <p className="text-gray-600 mb-6">
+            認証リンクが正しくありません。
+            メールに記載されたリンクを再度クリックしてください。
+          </p>
+          <Link
+            href="/login"
+            className="inline-block bg-blue-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-blue-700 transition"
+          >
+            ログインページへ
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  // トークン検証
+  const result = await verifyEmailToken(token);
+
+  // 検証成功
+  if (result.success) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+        <div className="max-w-md w-full bg-white rounded-lg shadow-lg p-8 text-center">
+          <CheckCircle className="w-16 h-16 text-green-500 mx-auto mb-4" />
+          <h1 className="text-2xl font-bold text-gray-900 mb-2">
+            認証完了
+          </h1>
+          <p className="text-gray-600 mb-6">
+            メールアドレスの認証が完了しました。
+            ログインしてサービスをご利用ください。
+          </p>
+          <Link
+            href="/login"
+            className="inline-block bg-blue-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-blue-700 transition"
+          >
+            ログインする
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  // 検証失敗
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+      <div className="max-w-md w-full bg-white rounded-lg shadow-lg p-8 text-center">
+        <XCircle className="w-16 h-16 text-red-500 mx-auto mb-4" />
+        <h1 className="text-2xl font-bold text-gray-900 mb-2">
+          認証に失敗しました
+        </h1>
+        <p className="text-gray-600 mb-6">
+          {result.error || '認証リンクが無効または期限切れです。'}
+        </p>
+        <div className="space-y-3">
+          <Link
+            href="/auth/resend-verification"
+            className="block w-full bg-blue-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-blue-700 transition"
+          >
+            認証メールを再送信
+          </Link>
+          <Link
+            href="/login"
+            className="block w-full bg-gray-100 text-gray-700 px-6 py-3 rounded-lg font-medium hover:bg-gray-200 transition"
+          >
+            ログインページへ
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -25,6 +25,11 @@ export const authOptions: NextAuthOptions = {
           throw new Error('メールアドレスまたはパスワードが正しくありません');
         }
 
+        // メールアドレス未認証チェック
+        if (!user.email_verified) {
+          throw new Error('EMAIL_NOT_VERIFIED');
+        }
+
         // テストユーザーログイン用の特別パスワード（開発環境のみ）
         // パスワードがこの値の場合はハッシュチェックをスキップ
         const MAGIC_PASSWORD = process.env.NODE_ENV === 'production'

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -70,6 +70,13 @@ model User {
   /// メッセージスレッド
   messageThreads         MessageThread[]
 
+  /// メール認証済みフラグ
+  email_verified            Boolean        @default(false) @map("email_verified")
+  /// メール認証トークン
+  verification_token        String?        @map("verification_token")
+  /// 認証トークンの有効期限
+  verification_token_expires DateTime?     @map("verification_token_expires")
+
   is_suspended           Boolean        @default(false) @map("is_suspended")
   suspended_at           DateTime?      @map("suspended_at")
   /// 退会日時（nullなら退会していない）

--- a/src/lib/auth/email-verification.ts
+++ b/src/lib/auth/email-verification.ts
@@ -1,0 +1,212 @@
+import { prisma } from '@/lib/prisma';
+import { Resend } from 'resend';
+import crypto from 'crypto';
+
+const resend = new Resend(process.env.RESEND_API_KEY);
+const FROM_EMAIL = process.env.RESEND_FROM_EMAIL || 'noreply@tastas.site';
+const APP_URL = process.env.NEXTAUTH_URL || 'https://tastas.jp';
+
+// トークン有効期限（24時間）
+const TOKEN_EXPIRY_HOURS = 24;
+
+/**
+ * セキュアな認証トークンを生成
+ */
+export function generateVerificationToken(): string {
+  return crypto.randomBytes(32).toString('hex');
+}
+
+/**
+ * ユーザーに認証トークンを設定し、認証メールを送信
+ */
+export async function sendVerificationEmail(
+  userId: number,
+  email: string,
+  name: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    // トークン生成
+    const token = generateVerificationToken();
+    const expiresAt = new Date(Date.now() + TOKEN_EXPIRY_HOURS * 60 * 60 * 1000);
+
+    // ユーザーにトークンを保存
+    await prisma.user.update({
+      where: { id: userId },
+      data: {
+        verification_token: token,
+        verification_token_expires: expiresAt,
+      },
+    });
+
+    // 認証URL
+    const verificationUrl = `${APP_URL}/auth/verify?token=${token}`;
+
+    // メール送信が無効化されている場合はログのみ
+    if (process.env.DISABLE_EMAIL_SENDING === 'true') {
+      console.log('[Email Verification] Sending disabled, logging only:', {
+        to: email,
+        verificationUrl,
+      });
+      return { success: true };
+    }
+
+    // メール送信
+    const { error } = await resend.emails.send({
+      from: `+TASTAS <${FROM_EMAIL}>`,
+      to: [email],
+      subject: '【+TASTAS】メールアドレスの確認',
+      html: formatVerificationEmailHtml(name, verificationUrl),
+      text: formatVerificationEmailText(name, verificationUrl),
+    });
+
+    if (error) {
+      console.error('[Email Verification] Failed to send:', error);
+      return { success: false, error: error.message };
+    }
+
+    console.log('[Email Verification] Sent successfully to:', email);
+    return { success: true };
+  } catch (error: any) {
+    console.error('[Email Verification] Error:', error);
+    return { success: false, error: error.message };
+  }
+}
+
+/**
+ * 認証トークンを検証し、ユーザーを認証済みに更新
+ */
+export async function verifyEmailToken(
+  token: string
+): Promise<{ success: boolean; error?: string; userId?: number }> {
+  try {
+    // トークンでユーザーを検索
+    const user = await prisma.user.findFirst({
+      where: {
+        verification_token: token,
+        email_verified: false,
+      },
+    });
+
+    if (!user) {
+      return { success: false, error: '無効な認証リンクです。' };
+    }
+
+    // 有効期限チェック
+    if (user.verification_token_expires && user.verification_token_expires < new Date()) {
+      return { success: false, error: '認証リンクの有効期限が切れています。再送信してください。' };
+    }
+
+    // 認証済みに更新
+    await prisma.user.update({
+      where: { id: user.id },
+      data: {
+        email_verified: true,
+        verification_token: null,
+        verification_token_expires: null,
+      },
+    });
+
+    console.log('[Email Verification] User verified:', user.id);
+    return { success: true, userId: user.id };
+  } catch (error: any) {
+    console.error('[Email Verification] Verification error:', error);
+    return { success: false, error: 'システムエラーが発生しました。' };
+  }
+}
+
+/**
+ * 認証メールを再送信
+ */
+export async function resendVerificationEmail(
+  email: string
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    // メールアドレスでユーザーを検索
+    const user = await prisma.user.findUnique({
+      where: { email },
+    });
+
+    if (!user) {
+      // セキュリティのため、ユーザーが存在しない場合もエラーを返さない
+      return { success: true };
+    }
+
+    if (user.email_verified) {
+      return { success: false, error: 'このメールアドレスは既に認証済みです。' };
+    }
+
+    // 再送信
+    return await sendVerificationEmail(user.id, user.email, user.name);
+  } catch (error: any) {
+    console.error('[Email Verification] Resend error:', error);
+    return { success: false, error: error.message };
+  }
+}
+
+/**
+ * 認証メールのHTML本文
+ */
+function formatVerificationEmailHtml(name: string, verificationUrl: string): string {
+  return `
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+</head>
+<body style="font-family: 'Helvetica Neue', Arial, 'Hiragino Sans', sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;">
+    <div style="background-color: #f8f9fa; padding: 30px; border-radius: 8px;">
+        <h2 style="color: #2563eb; margin-bottom: 20px;">メールアドレスの確認</h2>
+
+        <p>${name} 様</p>
+
+        <p>+TASTASへのご登録ありがとうございます。</p>
+
+        <p>下記のボタンをクリックして、メールアドレスの確認を完了してください。</p>
+
+        <div style="text-align: center; margin: 30px 0;">
+            <a href="${verificationUrl}"
+               style="display: inline-block; background-color: #2563eb; color: white; text-decoration: none;
+                      padding: 14px 28px; border-radius: 6px; font-weight: bold;">
+                メールアドレスを確認する
+            </a>
+        </div>
+
+        <p style="font-size: 14px; color: #666;">
+            ボタンがクリックできない場合は、以下のURLをブラウザにコピー＆ペーストしてください：<br>
+            <a href="${verificationUrl}" style="color: #2563eb; word-break: break-all;">${verificationUrl}</a>
+        </p>
+
+        <p style="font-size: 14px; color: #666; margin-top: 20px;">
+            ※このリンクは24時間有効です。<br>
+            ※このメールに心当たりがない場合は、お手数ですが削除してください。
+        </p>
+    </div>
+
+    <div style="margin-top: 20px; padding-top: 20px; border-top: 1px solid #eee; font-size: 12px; color: #666;">
+        <p>このメールは +TASTAS より自動送信されています。</p>
+    </div>
+</body>
+</html>`;
+}
+
+/**
+ * 認証メールのプレーンテキスト本文
+ */
+function formatVerificationEmailText(name: string, verificationUrl: string): string {
+  return `
+${name} 様
+
++TASTASへのご登録ありがとうございます。
+
+下記のURLをクリックして、メールアドレスの確認を完了してください：
+
+${verificationUrl}
+
+※このリンクは24時間有効です。
+※このメールに心当たりがない場合は、お手数ですが削除してください。
+
+---
+このメールは +TASTAS より自動送信されています。
+`;
+}


### PR DESCRIPTION
## Summary
- 新規ワーカー登録時にメールアドレス認証を必須化
- 認証メール送信・トークン検証・再送信機能を実装
- 未認証ユーザーのログインをブロック

## 変更内容
### 新規ファイル
- `src/lib/auth/email-verification.ts` - 認証サービス（トークン生成・メール送信・検証）
- `app/api/auth/verify/route.ts` - 認証APIエンドポイント
- `app/api/auth/resend-verification/route.ts` - 再送信API
- `app/auth/verify/page.tsx` - 認証結果表示ページ
- `app/auth/resend-verification/page.tsx` - 再送信フォームページ

### 変更ファイル
- `prisma/schema.prisma` - email_verified, verification_token, verification_token_expires追加
- `app/api/auth/register/route.ts` - 登録時に認証メール送信
- `lib/auth.ts` - 未認証ユーザーのログインブロック
- `app/login/page.tsx` - 未認証エラー時に再送信リンク表示

## 認証フロー
1. 新規登録 → 認証メール送信（24時間有効）
2. メール内リンクをクリック → `/auth/verify?token=xxx` で認証完了
3. 未認証でログイン試行 → エラー表示 + 再送信リンク

## Test plan
- [ ] 新規ワーカー登録時に認証メールが送信されること
- [ ] 認証リンククリックで認証完了すること
- [ ] 未認証ユーザーがログインできないこと
- [ ] 再送信機能が動作すること
- [ ] 既存ユーザー（認証済み）が正常にログインできること

## DB変更
- ⚠️ 本番反映には `npx prisma db push` が必要です

🤖 Generated with [Claude Code](https://claude.com/claude-code)