### PR TITLE
fix: 求人詳細から戻った際に日付選択が保持されるように修正

### DIFF
--- a/components/job/JobListClient.tsx
+++ b/components/job/JobListClient.tsx
@@ -312,10 +312,23 @@ export function JobListClient({
     return filters;
   }, [searchParams]);
 
-  // 日付変更ハンドラ（URL遷移なし、ローカルステートのみ更新）
+  // 日付変更ハンドラ（URLパラメータも更新して履歴に保存）
   const handleDateChange = useCallback((index: number) => {
     setSelectedDateIndex(index);
-  }, []);
+
+    // URLパラメータを更新（ブラウザ履歴に保存）
+    const params = new URLSearchParams(searchParams.toString());
+    if (index === 0) {
+      // デフォルト値（今日）の場合はパラメータを削除
+      params.delete('dateIndex');
+    } else {
+      params.set('dateIndex', String(index));
+    }
+
+    // router.replaceでURLを更新（履歴を置き換え、スクロール位置維持）
+    const newUrl = params.toString() ? `/?${params.toString()}` : '/';
+    router.replace(newUrl, { scroll: false });
+  }, [searchParams, router]);
 
   // 日付ホバー時のプリフェッチ
   const handleDateHover = useCallback((index: number) => {


### PR DESCRIPTION
## Summary
- 求人一覧で日付を選択 → 求人詳細 → 戻るボタン → **選択した日付が保持される**ように修正
- 日付変更時にURLパラメータ（`dateIndex`）を更新し、ブラウザ履歴に保存

## 修正内容
`handleDateChange`で`router.replace`を使用してURLを更新：
- 日付選択時にURL末尾に`?dateIndex=N`を追加
- 今日（index=0）の場合はパラメータを削除してURLをクリーンに保つ
- `scroll: false`でスクロール位置を維持

## 動作フロー
| 操作 | Before | After |
|------|--------|-------|
| 3日後を選択 | URL変化なし | `/?dateIndex=3` |
| 求人詳細を開く | `/jobs/123` | `/jobs/123` |
| 戻るボタン | `/`（今日に戻る）| `/?dateIndex=3`（保持）|

## Test plan
- [ ] 日付を変更してURLに`dateIndex`が反映されることを確認
- [ ] 求人詳細から戻った際、選択していた日付が保持されていることを確認
- [ ] 今日を選択した場合、URLから`dateIndex`が削除されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)