### PR TITLE
fix: /auth パスを公開パスに追加して認証リンクの404を修正

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -8,6 +8,7 @@ const publicPaths = [
   '/register',
   '/admin/login',
   '/api/auth',
+  '/auth', // メール認証関連（/auth/verify, /auth/verify-pending, /auth/resend-verification）
   '/dev-portal', // 開発用ポータル
   '/password-reset', // パスワードリセット
   '/faq',


### PR DESCRIPTION
## Summary

- ミドルウェアで `/auth/verify` がブロックされ404になっていた問題を修正
- メール認証関連のページに未認証でもアクセスできるよう `publicPaths` に `/auth` を追加

## 原因

`/auth/verify?token=...` にアクセスすると、ミドルウェアが認証を要求し `/login` にリダイレクト → 結果として404が表示されていた

## 影響範囲

以下のページが未認証でもアクセス可能になる:
- `/auth/verify` - メール認証確認
- `/auth/verify-pending` - 認証待ち画面
- `/auth/resend-verification` - 認証メール再送信

## Test plan

- [ ] https://stg-share-worker.vercel.app/auth/verify?token=... にアクセスして認証ページが表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)