### PR TITLE
fix: ログイン1回目失敗問題の対策

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { Mail, Lock, Eye, EyeOff } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
+import { getCsrfToken } from 'next-auth/react';
 import toast from 'react-hot-toast';
 import { getTestUsers } from '@/src/lib/actions';
 import { useDebugError, extractDebugInfo } from '@/components/debug/DebugErrorBanner';
@@ -27,6 +28,15 @@ export default function WorkerLogin() {
   const [isEmailNotVerified, setIsEmailNotVerified] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [testUsers, setTestUsers] = useState<TestUser[]>([]);
+  const [csrfReady, setCsrfReady] = useState(false);
+
+  // CSRFトークンを事前取得（1回目ログイン失敗問題の対策）
+  useEffect(() => {
+    getCsrfToken().then(() => {
+      console.log('[Login] CSRF token ready');
+      setCsrfReady(true);
+    });
+  }, []);
 
   // テストユーザーをDBから取得
   useEffect(() => {

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -130,18 +130,24 @@ function AuthContextProvider({ children }: { children: ReactNode }) {
   // ワーカーログイン
   const login = async (email: string, password: string) => {
     try {
+      console.log('[AuthContext] login started', { email });
       const result = await signIn('credentials', {
         email,
         password,
         redirect: false,
       });
+      console.log('[AuthContext] signIn result:', result);
 
-      if (result?.error) {
-        return { success: false, error: result.error };
+      // result.ok が false の場合も失敗として扱う
+      if (!result?.ok || result?.error) {
+        console.log('[AuthContext] login failed:', result?.error);
+        return { success: false, error: result?.error || 'ログインに失敗しました' };
       }
 
+      console.log('[AuthContext] login success');
       return { success: true };
     } catch (error) {
+      console.error('[AuthContext] login error:', error);
       return { success: false, error: 'ログイン中にエラーが発生しました' };
     }
   };


### PR DESCRIPTION
## Summary

- ログインページでCSRFトークンを事前取得するように修正
- `signIn`結果の`result.ok`もチェックするように修正
- デバッグログを追加

## 問題

ログインを試すと必ず1回目は失敗し、2回目で成功する

## 原因（推定）

NextAuthのCSRFトークンが初回リクエスト時に取得されておらず、1回目のログインが失敗していた可能性

## 修正内容

1. **`app/login/page.tsx`**
   - ページロード時に`getCsrfToken()`を呼び出してCSRFトークンを事前取得

2. **`contexts/AuthContext.tsx`**
   - `signIn`結果の`result.ok`もチェック
   - デバッグログを追加

## Test plan

- [ ] ログインページを開く
- [ ] コンソールで `[Login] CSRF token ready` が表示されることを確認
- [ ] 1回目のログインで成功することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)