### PR TITLE
fix: トップページと求人ページを公開パスに追加

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -4,10 +4,13 @@ import { getToken } from 'next-auth/jwt';
 
 // 認証不要なパス
 const publicPaths = [
+  '/', // トップページ（求人一覧）
+  '/jobs', // 求人関連ページ
   '/login',
   '/register',
   '/admin/login',
   '/api/auth',
+  '/api/jobs', // 求人API
   '/auth', // メール認証関連（/auth/verify, /auth/verify-pending, /auth/resend-verification）
   '/dev-portal', // 開発用ポータル
   '/password-reset', // パスワードリセット
@@ -51,7 +54,8 @@ export async function middleware(request: NextRequest) {
   }
 
   // 公開ページはそのまま通す
-  if (publicPaths.some((path) => pathname.startsWith(path))) {
+  // '/' は完全一致、それ以外は前方一致でチェック
+  if (publicPaths.some((path) => path === '/' ? pathname === '/' : pathname.startsWith(path))) {
     return NextResponse.next();
   }
 


### PR DESCRIPTION
## Summary

トップページ（求人一覧）と求人関連ページを認証不要なパスに追加

## 問題

- 未認証ユーザーがトップページにアクセスすると `/login` にリダイレクトされていた
- 求人一覧は未認証でも閲覧できるべき

## 修正内容

`publicPaths` に以下を追加:
- `/` - トップページ（求人一覧）
- `/jobs` - 求人関連ページ
- `/api/jobs` - 求人API

## Test plan

- [ ] 未認証状態で `https://share-worker-app.vercel.app/` にアクセス
- [ ] 求人一覧が表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)