### PR TITLE
perf: 施設メッセージ機能のパフォーマンス最適化

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -531,6 +531,8 @@ model Message {
   // 追加インデックス（施設フィルタ用）
   @@index([to_facility_id])
   @@index([from_facility_id])
+  // 施設未読メッセージカウント用
+  @@index([to_facility_id, read_at])
   @@map("messages")
 }
 
@@ -551,6 +553,7 @@ model SystemNotification {
   job               Job?         @relation(fields: [job_id], references: [id], onDelete: SetNull)
 
   @@index([target_type, recipient_id])
+  @@index([target_type, recipient_id, read_at]) // 未読カウント用複合インデックス
   @@index([notification_key])
   @@index([created_at])
   @@map("system_notifications")


### PR DESCRIPTION
## Summary
- 施設メッセージ会話一覧取得のDBクエリを並列化（4回→同時実行）
- select最小化で不要なデータ転送を削減
- SWRキャッシュ戦略を最適化（revalidateOnFocus無効化、dedupingInterval追加）
- 未読カウント用の複合インデックスを追加

## 変更ファイル
- `src/lib/actions/message.ts` - クエリ並列化 + select最小化
- `hooks/useAdminMessages.ts` - SWRキャッシュ戦略最適化
- `prisma/schema.prisma` - DBインデックス追加

## Test plan
- [ ] 施設管理画面でメッセージ一覧の表示速度改善を確認
- [ ] ワーカーとのチャット機能が正常動作することを確認
- [ ] 未読バッジが正しく表示されることを確認
- [ ] お知らせタブが正常に動作することを確認

## 本番反映時の注意
- DBインデックス追加のため `npx prisma db push` が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)