### PR TITLE
perf: 求人・ワーカー一覧のSWRキャッシュ最適化

### DIFF
--- a/hooks/useAdminJobs.ts
+++ b/hooks/useAdminJobs.ts
@@ -109,6 +109,10 @@ const buildUrl = (params: AdminJobsParams): string | null => {
     return `/api/admin/jobs/list?${searchParams.toString()}`;
 };
 
+/**
+ * 施設求人一覧取得フック
+ * 最適化: revalidateOnFocusで画面復帰時に更新されるため、過度なポーリングを削除
+ */
 export function useAdminJobs(params: AdminJobsParams) {
     const url = useMemo(() => buildUrl(params), [params.facilityId, params.page, params.status, params.query, params.sort]);
 
@@ -116,10 +120,12 @@ export function useAdminJobs(params: AdminJobsParams) {
         url,
         fetcher,
         {
-            revalidateOnFocus: true,
+            revalidateOnFocus: true, // タブ復帰時に再取得
             revalidateOnMount: true, // ページに戻った時に必ず再取得
-            dedupingInterval: 2000,
-            refreshInterval: 5000, // 5秒ごとに再取得（バックグラウンド保存対応）
+            revalidateOnReconnect: true, // ネットワーク復帰時に再取得
+            dedupingInterval: 5000, // 5秒間は同一リクエストを重複排除
+            // refreshIntervalを削除: revalidateOnFocusがあるので不要
+            // 必要に応じてmutate()で手動更新可能
         }
     );
 

--- a/hooks/useAdminWorkers.ts
+++ b/hooks/useAdminWorkers.ts
@@ -76,6 +76,10 @@ const buildUrl = (params: AdminWorkersParams): string | null => {
     return `/api/admin/workers/list?${searchParams.toString()}`;
 };
 
+/**
+ * 施設ワーカー一覧取得フック
+ * 最適化: dedupingIntervalを延長して重複リクエストを削減
+ */
 export function useAdminWorkers(params: AdminWorkersParams) {
     const url = useMemo(() => buildUrl(params), [
         params.facilityId,
@@ -91,8 +95,9 @@ export function useAdminWorkers(params: AdminWorkersParams) {
         url,
         fetcher,
         {
-            revalidateOnFocus: true,
-            dedupingInterval: 2000,
+            revalidateOnFocus: true, // タブ復帰時に再取得
+            revalidateOnReconnect: true, // ネットワーク復帰時に再取得
+            dedupingInterval: 5000, // 5秒間は同一リクエストを重複排除
         }
     );
 


### PR DESCRIPTION
## Summary
- 求人一覧（useAdminJobs）の5秒ポーリングを削除し、不要なネットワークリクエストを削減
- dedupingIntervalを2秒→5秒に延長し、重複リクエストを防止
- revalidateOnReconnectを追加してネットワーク復帰時に自動更新

## 変更ファイル
- `hooks/useAdminJobs.ts` - ポーリング削除、dedupingInterval延長
- `hooks/useAdminWorkers.ts` - dedupingInterval延長、revalidateOnReconnect追加

## 最適化効果
- 求人一覧: 5秒ごとのポーリング削除により、1分間で12回→0回のバックグラウンドリクエスト削減
- 両一覧: 重複リクエスト防止期間を2倍に延長

## Test plan
- [ ] 求人一覧の表示が正常に動作することを確認
- [ ] ワーカー一覧の表示が正常に動作することを確認
- [ ] タブ切り替え時にデータが更新されることを確認
- [ ] ページネーション・フィルタリングが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)