### PR TITLE
perf: シフト管理ページのSWR化

### DIFF
--- a/app/admin/shifts/page.tsx
+++ b/app/admin/shifts/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useMemo } from 'react';
 import {
     ChevronLeft,
     ChevronRight,
@@ -14,30 +14,17 @@ import {
 } from 'lucide-react';
 import Link from 'next/link';
 import { useAuth } from '@/contexts/AuthContext';
-import { getShiftsForFacility, cancelShift } from '@/src/lib/actions';
+import { cancelShift } from '@/src/lib/actions';
+import { useAdminShifts, type Shift } from '@/hooks/useAdminShifts';
 import { getCurrentTime } from '@/utils/debugTime';
 import toast from 'react-hot-toast';
 import { useDebugError, extractDebugInfo } from '@/components/debug/DebugErrorBanner';
 import { format, startOfWeek, endOfWeek, startOfMonth, endOfMonth, eachDayOfInterval, isSameMonth, isSameDay, addMonths, subMonths, addWeeks, subWeeks, getDay } from 'date-fns';
 import { ja } from 'date-fns/locale';
 
-interface Shift {
-    applicationId: number;
-    workDateId: number;
+// Shift型はhooksからimport（workDateはDate型に変換済み）
+interface ShiftWithDate extends Omit<Shift, 'workDate'> {
     workDate: Date;
-    startTime: string;
-    endTime: string;
-    breakTime: number | null;
-    hourlyRate: number;
-    transportationFee: number;
-    workerId: number;
-    workerName: string;
-    workerProfileImage: string | null;
-    qualifications: string[];
-    status: string;
-    jobId: number;
-    weeklyFrequency: number | null;
-    jobType: string;
 }
 
 // Helper functions for timeline view
@@ -69,15 +56,15 @@ function isTimeOverlapping(start1: string, end1: string, start2: string, end2: s
     return e1 > s2 && e2 > s1;
 }
 
-function groupOverlappingShifts(shifts: Shift[]): Shift[][] {
+function groupOverlappingShifts(shifts: ShiftWithDate[]): ShiftWithDate[][] {
     if (shifts.length === 0) return [];
 
     const sorted = [...shifts].sort((a, b) =>
         timeToPixels(a.startTime) - timeToPixels(b.startTime)
     );
 
-    const groups: Shift[][] = [];
-    let currentGroup: Shift[] = [sorted[0]];
+    const groups: ShiftWithDate[][] = [];
+    let currentGroup: ShiftWithDate[] = [sorted[0]];
 
     for (let i = 1; i < sorted.length; i++) {
         const current = sorted[i];
@@ -102,61 +89,35 @@ export default function ShiftManagementPage() {
     const { showDebugError } = useDebugError();
     const [viewMode, setViewMode] = useState<'week' | 'month'>('week');
     const [currentDate, setCurrentDate] = useState(new Date());
-    const [shifts, setShifts] = useState<Shift[]>([]);
-    const [isLoading, setIsLoading] = useState(true);
-    const [selectedShift, setSelectedShift] = useState<Shift | null>(null);
+    const [selectedShift, setSelectedShift] = useState<ShiftWithDate | null>(null);
     const [isDetailModalOpen, setIsDetailModalOpen] = useState(false);
     const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
 
-    const fetchShifts = useCallback(async () => {
-        if (!admin?.facilityId) return;
-
-        setIsLoading(true);
-        try {
-            let start, end;
-            if (viewMode === 'week') {
-                start = startOfWeek(currentDate, { weekStartsOn: 1 });
-                end = endOfWeek(currentDate, { weekStartsOn: 1 });
-            } else {
-                start = startOfMonth(currentDate);
-                end = endOfMonth(currentDate);
-            }
-
-            const searchStart = subWeeks(start, 1);
-            const searchEnd = addWeeks(end, 1);
-
-            const data = await getShiftsForFacility(
-                admin.facilityId,
-                searchStart.toISOString(),
-                searchEnd.toISOString()
-            );
-
-            const parsedData = data.map(d => ({
-                ...d,
-                workDate: new Date(d.workDate)
-            }));
-
-            setShifts(parsedData);
-        } catch (error) {
-            const debugInfo = extractDebugInfo(error);
-            showDebugError({
-                type: 'fetch',
-                operation: 'シフトデータ取得',
-                message: debugInfo.message,
-                details: debugInfo.details,
-                stack: debugInfo.stack,
-                context: { facilityId: admin?.facilityId, viewMode, currentDate: currentDate.toISOString() }
-            });
-            console.error('Failed to fetch shifts:', error);
-            toast.error('シフトの取得に失敗しました');
-        } finally {
-            setIsLoading(false);
+    // 検索範囲を計算
+    const { startDate, endDate } = useMemo(() => {
+        let start, end;
+        if (viewMode === 'week') {
+            start = startOfWeek(currentDate, { weekStartsOn: 1 });
+            end = endOfWeek(currentDate, { weekStartsOn: 1 });
+        } else {
+            start = startOfMonth(currentDate);
+            end = endOfMonth(currentDate);
         }
-    }, [admin?.facilityId, currentDate, viewMode]);
+        // 前後1週間のマージンを追加
+        const searchStart = subWeeks(start, 1);
+        const searchEnd = addWeeks(end, 1);
+        return {
+            startDate: searchStart.toISOString(),
+            endDate: searchEnd.toISOString()
+        };
+    }, [currentDate, viewMode]);
 
-    useEffect(() => {
-        fetchShifts();
-    }, [fetchShifts]);
+    // SWRでシフトデータ取得
+    const { shifts, isLoading, mutate } = useAdminShifts({
+        facilityId: admin?.facilityId,
+        startDate,
+        endDate
+    });
 
     const handlePrev = () => {
         if (viewMode === 'week') {
@@ -188,7 +149,7 @@ export default function ShiftManagementPage() {
             end: endOfWeek(endOfMonth(currentDate), { weekStartsOn: 1 })
         });
 
-    const getShiftsForDay = (date: Date) => {
+    const getShiftsForDay = (date: Date): ShiftWithDate[] => {
         return shifts.filter(s => isSameDay(s.workDate, date));
     };
 
@@ -201,12 +162,12 @@ export default function ShiftManagementPage() {
         return weeks;
     };
 
-    const openDetailModal = (shift: Shift) => {
+    const openDetailModal = (shift: ShiftWithDate) => {
         setSelectedShift(shift);
         setIsDetailModalOpen(true);
     };
 
-    const openCancelModal = (e: React.MouseEvent, shift: Shift) => {
+    const openCancelModal = (e: React.MouseEvent, shift: ShiftWithDate) => {
         e.stopPropagation();
         setSelectedShift(shift);
         setIsCancelModalOpen(true);
@@ -219,7 +180,7 @@ export default function ShiftManagementPage() {
             const result = await cancelShift(selectedShift.applicationId);
             if (result.success) {
                 toast.success('シフトをキャンセル（マッチング解除）しました');
-                fetchShifts();
+                mutate(); // SWRで再取得
                 setIsCancelModalOpen(false);
                 setIsDetailModalOpen(false);
                 setSelectedShift(null);

--- a/app/api/admin/shifts/route.ts
+++ b/app/api/admin/shifts/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getShiftsForFacility } from '@/src/lib/actions';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+    try {
+        const { searchParams } = new URL(request.url);
+        const facilityIdParam = searchParams.get('facilityId');
+        const startDate = searchParams.get('startDate');
+        const endDate = searchParams.get('endDate');
+
+        if (!facilityIdParam) {
+            return NextResponse.json({ error: 'Facility ID is required' }, { status: 400 });
+        }
+
+        const facilityId = parseInt(facilityIdParam);
+        if (isNaN(facilityId)) {
+            return NextResponse.json({ error: 'Invalid facility ID' }, { status: 400 });
+        }
+
+        if (!startDate || !endDate) {
+            return NextResponse.json({ error: 'Start date and end date are required' }, { status: 400 });
+        }
+
+        const shifts = await getShiftsForFacility(facilityId, startDate, endDate);
+
+        return NextResponse.json(shifts, {
+            headers: { 'Cache-Control': 'no-store, max-age=0' },
+        });
+    } catch (error) {
+        console.error('[API /api/admin/shifts] Error:', error);
+        return NextResponse.json(
+            { error: 'Failed to fetch shifts' },
+            { status: 500 }
+        );
+    }
+}

--- a/hooks/useAdminShifts.ts
+++ b/hooks/useAdminShifts.ts
@@ -1,0 +1,82 @@
+'use client';
+
+import useSWR from 'swr';
+import { useMemo } from 'react';
+
+export interface Shift {
+    applicationId: number;
+    workDateId: number;
+    workDate: string; // ISO string
+    startTime: string;
+    endTime: string;
+    breakTime: number | null;
+    hourlyRate: number;
+    transportationFee: number;
+    workerId: number;
+    workerName: string;
+    workerProfileImage: string | null;
+    qualifications: string[];
+    status: string;
+    jobId: number;
+    weeklyFrequency: number | null;
+    jobType: string;
+}
+
+interface AdminShiftsParams {
+    facilityId?: number;
+    startDate: string; // ISO string
+    endDate: string; // ISO string
+}
+
+const fetcher = async (url: string): Promise<Shift[]> => {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error('Failed to fetch');
+    return res.json();
+};
+
+const buildUrl = (params: AdminShiftsParams): string | null => {
+    if (!params.facilityId) return null;
+    const searchParams = new URLSearchParams();
+    searchParams.set('facilityId', String(params.facilityId));
+    searchParams.set('startDate', params.startDate);
+    searchParams.set('endDate', params.endDate);
+    return `/api/admin/shifts?${searchParams.toString()}`;
+};
+
+/**
+ * 施設シフト一覧取得フック
+ * 最適化: SWRによるキャッシュとデータ重複排除
+ */
+export function useAdminShifts(params: AdminShiftsParams) {
+    const url = useMemo(() => buildUrl(params), [
+        params.facilityId,
+        params.startDate,
+        params.endDate
+    ]);
+
+    const { data, error, isLoading, mutate } = useSWR<Shift[]>(
+        url,
+        fetcher,
+        {
+            revalidateOnFocus: true, // タブ復帰時に再取得
+            revalidateOnReconnect: true, // ネットワーク復帰時に再取得
+            dedupingInterval: 5000, // 5秒間は同一リクエストを重複排除
+        }
+    );
+
+    // Date型に変換したシフトデータを返す
+    const shifts = useMemo(() => {
+        if (!data) return [];
+        return data.map(shift => ({
+            ...shift,
+            workDate: new Date(shift.workDate)
+        }));
+    }, [data]);
+
+    return {
+        shifts,
+        isLoading,
+        error,
+        mutate,
+    };
+}


### PR DESCRIPTION
## Summary
- シフト管理ページをuseEffect+fetchからSWRに移行
- 新規SWRフック `useAdminShifts` を作成
- 新規APIエンドポイント `/api/admin/shifts` を作成

## 変更ファイル
- `hooks/useAdminShifts.ts` - 新規SWRフック
- `app/api/admin/shifts/route.ts` - 新規APIエンドポイント
- `app/admin/shifts/page.tsx` - SWRフックを使用するよう更新

## 最適化効果
- SWRキャッシュによるデータ再利用
- dedupingInterval（5秒）で重複リクエスト防止
- revalidateOnFocus/Reconnectでスマートな再取得

## Test plan
- [ ] シフト管理ページの表示が正常に動作することを確認
- [ ] 週表示・月表示の切り替えが正常に動作することを確認
- [ ] シフトキャンセル後にデータが更新されることを確認
- [ ] タブ切り替え時にデータが更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)