### PR TITLE
perf: 施設通知ページをSWR化してパフォーマンス最適化

### DIFF
--- a/app/api/admin/notifications/route.ts
+++ b/app/api/admin/notifications/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getFacilityNotifications } from '@/src/lib/actions';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+    const { searchParams } = new URL(request.url);
+    const facilityIdParam = searchParams.get('facilityId');
+
+    if (!facilityIdParam) {
+        return NextResponse.json(
+            { error: 'facilityId is required' },
+            { status: 400 }
+        );
+    }
+
+    const facilityId = parseInt(facilityIdParam, 10);
+    if (isNaN(facilityId)) {
+        return NextResponse.json(
+            { error: 'facilityId must be a number' },
+            { status: 400 }
+        );
+    }
+
+    try {
+        const notifications = await getFacilityNotifications(facilityId);
+        return NextResponse.json(notifications, {
+            headers: {
+                'Cache-Control': 'no-store, max-age=0',
+            },
+        });
+    } catch (error) {
+        console.error('[GET /api/admin/notifications] Error:', error);
+        return NextResponse.json(
+            { error: 'Failed to fetch notifications' },
+            { status: 500 }
+        );
+    }
+}

--- a/hooks/useAdminNotifications.ts
+++ b/hooks/useAdminNotifications.ts
@@ -1,0 +1,45 @@
+'use client';
+
+import useSWR from 'swr';
+
+export interface AdminNotification {
+    id: number;
+    type: string;
+    title: string;
+    message: string;
+    link: string | null;
+    isRead: boolean;
+    createdAt: string;
+}
+
+const fetcher = async (url: string): Promise<AdminNotification[]> => {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error('Failed to fetch');
+    return res.json();
+};
+
+/**
+ * 施設通知一覧取得フック
+ * 最適化: SWRによるキャッシュとデータ重複排除
+ */
+export function useAdminNotifications(facilityId?: number) {
+    const url = facilityId ? `/api/admin/notifications?facilityId=${facilityId}` : null;
+
+    const { data, error, isLoading, mutate } = useSWR<AdminNotification[]>(
+        url,
+        fetcher,
+        {
+            revalidateOnFocus: true, // タブ復帰時に再取得
+            revalidateOnReconnect: true, // ネットワーク復帰時に再取得
+            dedupingInterval: 5000, // 5秒間は同一リクエストを重複排除
+            refreshInterval: 60000, // 1分ごとにポーリング（通知は適度にリアルタイム性が必要）
+        }
+    );
+
+    return {
+        notifications: data ?? [],
+        isLoading,
+        error,
+        mutate,
+    };
+}


### PR DESCRIPTION
## Summary
- 施設通知ページ（/admin/notifications）のデータ取得をSWRに変更
- `useAdminNotifications`フックを新規作成
- APIエンドポイント `/api/admin/notifications` を追加
- 既読処理を楽観的更新に変更

## Changes
- `hooks/useAdminNotifications.ts` - SWRフック新規作成
- `app/api/admin/notifications/route.ts` - APIエンドポイント追加
- `app/admin/notifications/page.tsx` - SWRフック使用に変更

## Performance Improvements
- ページ間遷移時のデータ再取得を削減（SWRキャッシュ活用）
- 重複リクエストの自動排除（dedupingInterval: 5秒）
- 1分間隔の自動更新でリアルタイム性を維持

## Test plan
- [ ] 施設通知ページの表示確認
- [ ] 既読処理が正常に動作すること
- [ ] ページ遷移後のキャッシュ動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)