### PR TITLE
perf: 施設レビューページをSWR化してパフォーマンス最適化

### DIFF
--- a/app/api/admin/reviews/route.ts
+++ b/app/api/admin/reviews/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getFacilityReviewsForAdmin, getFacilityReviewStats } from '@/src/lib/actions';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+    const { searchParams } = new URL(request.url);
+    const facilityIdParam = searchParams.get('facilityId');
+
+    if (!facilityIdParam) {
+        return NextResponse.json(
+            { error: 'facilityId is required' },
+            { status: 400 }
+        );
+    }
+
+    const facilityId = parseInt(facilityIdParam, 10);
+    if (isNaN(facilityId)) {
+        return NextResponse.json(
+            { error: 'facilityId must be a number' },
+            { status: 400 }
+        );
+    }
+
+    try {
+        // Promise.allで並列取得
+        const [reviews, stats] = await Promise.all([
+            getFacilityReviewsForAdmin(facilityId),
+            getFacilityReviewStats(facilityId),
+        ]);
+
+        return NextResponse.json(
+            { reviews, stats },
+            {
+                headers: {
+                    'Cache-Control': 'no-store, max-age=0',
+                },
+            }
+        );
+    } catch (error) {
+        console.error('[GET /api/admin/reviews] Error:', error);
+        return NextResponse.json(
+            { error: 'Failed to fetch reviews' },
+            { status: 500 }
+        );
+    }
+}

--- a/hooks/useAdminReviews.ts
+++ b/hooks/useAdminReviews.ts
@@ -1,0 +1,58 @@
+'use client';
+
+import useSWR from 'swr';
+
+export interface AdminReview {
+    id: number;
+    rating: number;
+    goodPoints: string | null;
+    improvements: string | null;
+    createdAt: string;
+    userName: string;
+    userQualifications: string[];
+    jobTitle: string;
+    jobDate: string;
+}
+
+export interface AdminReviewStats {
+    averageRating: number;
+    totalCount: number;
+    distribution: { 5: number; 4: number; 3: number; 2: number; 1: number };
+}
+
+interface AdminReviewsResponse {
+    reviews: AdminReview[];
+    stats: AdminReviewStats;
+}
+
+const fetcher = async (url: string): Promise<AdminReviewsResponse> => {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error('Failed to fetch');
+    return res.json();
+};
+
+/**
+ * 施設レビュー一覧と統計情報取得フック
+ * 最適化: SWRによるキャッシュとデータ重複排除
+ */
+export function useAdminReviews(facilityId?: number) {
+    const url = facilityId ? `/api/admin/reviews?facilityId=${facilityId}` : null;
+
+    const { data, error, isLoading, mutate } = useSWR<AdminReviewsResponse>(
+        url,
+        fetcher,
+        {
+            revalidateOnFocus: true, // タブ復帰時に再取得
+            revalidateOnReconnect: true, // ネットワーク復帰時に再取得
+            dedupingInterval: 5000, // 5秒間は同一リクエストを重複排除
+        }
+    );
+
+    return {
+        reviews: data?.reviews ?? [],
+        stats: data?.stats ?? null,
+        isLoading,
+        error,
+        mutate,
+    };
+}


### PR DESCRIPTION
## Summary
- 施設レビューページ（/admin/reviews）のデータ取得をSWRに変更
- `useAdminReviews`フックを新規作成
- APIエンドポイント `/api/admin/reviews` を追加（reviews+statsを1リクエストで取得）
- ソート処理をuseMemoでメモ化

## Changes
- `hooks/useAdminReviews.ts` - SWRフック新規作成
- `app/api/admin/reviews/route.ts` - APIエンドポイント追加
- `app/admin/reviews/page.tsx` - SWRフック使用に変更

## Performance Improvements
- ページ間遷移時のデータ再取得を削減（SWRキャッシュ活用）
- 重複リクエストの自動排除（dedupingInterval: 5秒）
- reviews + stats を1回のAPIリクエストで取得（ネットワーク往復削減）
- ソート処理をuseMemoでメモ化し、不要な再計算を防止

## Test plan
- [ ] 施設レビューページの表示確認
- [ ] ソート機能が正常に動作すること
- [ ] ページ遷移後のキャッシュ動作確認
- [ ] AI分析ボタンが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)