### PR TITLE
feat: 通知送信を管理画面の設定で一元制御できるように統一

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -626,6 +626,40 @@ const notificationSettings = [
     push_body: '{{worker_name}}さんが勤務をキャンセルしました',
   },
   {
+    notification_key: 'FACILITY_APPLICATION_WITHDRAWN',
+    name: 'ワーカーからの応募取り消し',
+    description: 'ワーカーが審査中の応募を取り消した時に送信',
+    target_type: 'FACILITY',
+    chat_enabled: true,
+    email_enabled: false,
+    push_enabled: false,
+    chat_message: `【システムメッセージ】
+ワーカーが「{{job_title}}」（{{work_date}}）への応募を取り消しました。
+※審査中の応募取消のため、キャンセル率には影響しません。`,
+    email_subject: null,
+    email_body: null,
+    push_title: null,
+    push_body: null,
+  },
+  {
+    notification_key: 'FACILITY_INITIAL_GREETING',
+    name: '施設からの初回挨拶',
+    description: '初めてマッチングしたワーカーに送る施設からの挨拶メッセージ',
+    target_type: 'WORKER',
+    chat_enabled: true,
+    email_enabled: false,
+    push_enabled: false,
+    chat_message: `[ワーカー名字]さん、初めまして！
+[施設名]です。
+
+この度はマッチングありがとうございます。
+当日はよろしくお願いいたします。`,
+    email_subject: null,
+    email_body: null,
+    push_title: null,
+    push_body: null,
+  },
+  {
     notification_key: 'FACILITY_REMINDER_DAY_BEFORE',
     name: '勤務前日リマインド',
     description: '勤務前日に送信するリマインダー',


### PR DESCRIPTION
## Summary
- 全てのチャット/メール/プッシュ通知をNotificationSettingテーブルの設定に基づいて送信するように統一
- 直接の`prisma.message.create`呼び出しを削除し、`sendNotification`経由に変更
- 管理画面（`/system-admin/content/notifications`）で全ての通知の有効/無効とテンプレートを制御可能に

## 主な変更点
- **seed.ts**: 2つの新しい通知設定を追加
  - `FACILITY_INITIAL_GREETING`: 施設からの初回挨拶
  - `FACILITY_APPLICATION_WITHDRAWN`: ワーカーからの応募取り消し
- **notification-service.ts**: チャットメッセージ（Messageテーブル）作成機能を追加
- **notification.ts**: 4つの新しいヘルパー関数を追加
  - `sendApplicationConfirmNotification`: 応募受付確認
  - `sendWorkerCancelNotification`: ワーカーからのキャンセル通知
  - `sendApplicationWithdrawalNotification`: 応募取り消し通知
  - `sendInitialGreetingNotification`: 初回挨拶通知
- **application-admin.ts / application-worker.ts**: 直接message作成を削除、通知関数使用に統一

## Test plan
- [ ] マッチング成立時にチャットメッセージが送信されることを確認
- [ ] 通知設定で`chat_enabled: false`にした場合、チャットメッセージが送信されないことを確認
- [ ] 通知設定のテンプレートが正しく適用されることを確認
- [ ] ワーカーのキャンセル時に施設に通知が送信されることを確認
- [ ] 初回マッチング時に挨拶メッセージが送信されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)