### PR TITLE
fix: プロフィール更新後のマイページキャッシュを無効化

### DIFF
--- a/src/lib/actions/user-profile.ts
+++ b/src/lib/actions/user-profile.ts
@@ -455,7 +455,9 @@ export async function updateUserProfile(formData: FormData) {
             },
         });
 
+        // プロフィール関連ページのキャッシュを無効化
         revalidatePath('/mypage/profile');
+        revalidatePath('/mypage');
 
         return {
             success: true,


### PR DESCRIPTION
## Summary
- プロフィール画像更新後、マイページで古い画像が表示される問題を修正
- `/mypage`のrevalidatePathを追加してキャッシュを無効化

## Test plan
- [ ] プロフィール画像をアップロード
- [ ] マイページに戻った際、リロードなしで新しい画像が表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)