### PR TITLE
fix: IME入力問題を全フォームで修正

### DIFF
--- a/app/admin/facility/page.tsx
+++ b/app/admin/facility/page.tsx
@@ -18,9 +18,9 @@ import {
 import { getSystemTemplates } from '@/src/lib/content-actions';
 import { MapPin } from 'lucide-react';
 import { validateFile } from '@/utils/fileValidation';
-import { formatPhoneNumber } from '@/utils/inputValidation';
 import { directUpload, MAX_FILE_SIZE, formatFileSize } from '@/utils/directUpload';
 import AddressSelector from '@/components/ui/AddressSelector';
+import { PhoneNumberInput } from '@/components/ui/PhoneNumberInput';
 import { SERVICE_TYPES } from '@/constants/serviceTypes';
 import { useDebugError, extractDebugInfo } from '@/components/debug/DebugErrorBanner';
 
@@ -1231,10 +1231,9 @@ export default function FacilityPage() {
                   <label className="block text-sm font-medium text-gray-700 mb-1">
                     代表電話番号 <span className="text-red-500">*</span>
                   </label>
-                  <input
-                    type="tel"
+                  <PhoneNumberInput
                     value={corporateInfo.phone}
-                    onChange={(e) => setCorporateInfo({ ...corporateInfo, phone: formatPhoneNumber(e.target.value) })}
+                    onChange={(value) => setCorporateInfo({ ...corporateInfo, phone: value })}
                     placeholder="03-1234-5678"
                     className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-admin-primary focus:border-transparent"
                   />
@@ -1446,10 +1445,9 @@ export default function FacilityPage() {
                     <label className="block text-sm font-medium text-gray-700 mb-1">
                       電話番号 <span className="text-red-500">*</span>
                     </label>
-                    <input
-                      type="tel"
+                    <PhoneNumberInput
                       value={managerInfo.phone}
-                      onChange={(e) => setManagerInfo({ ...managerInfo, phone: formatPhoneNumber(e.target.value) })}
+                      onChange={(value) => setManagerInfo({ ...managerInfo, phone: value })}
                       placeholder="090-1234-5678"
                       className={`w-full max-w-xs px-2 py-1.5 text-sm border rounded-lg focus:ring-2 focus:ring-admin-primary focus:border-transparent ${showErrors && !managerInfo.phone ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
                     />
@@ -1605,10 +1603,9 @@ export default function FacilityPage() {
                     <label className="block text-sm font-medium text-gray-700 mb-1">
                       連絡先電話番号 <span className="text-red-500">*</span>
                     </label>
-                    <input
-                      type="tel"
+                    <PhoneNumberInput
                       value={staffInfo.phone}
-                      onChange={(e) => setStaffInfo({ ...staffInfo, phone: formatPhoneNumber(e.target.value) })}
+                      onChange={(value) => setStaffInfo({ ...staffInfo, phone: value })}
                       placeholder="090-1234-5678"
                       className={`w-full max-w-xs px-2 py-1.5 text-sm border rounded-lg focus:ring-2 focus:ring-admin-primary focus:border-transparent ${showErrors && !staffInfo.phone ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
                     />

--- a/app/mypage/profile/ProfileEditClient.tsx
+++ b/app/mypage/profile/ProfileEditClient.tsx
@@ -6,10 +6,11 @@ import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { updateUserProfile } from '@/src/lib/actions';
 import { validateFile, getSafeImageUrl, isValidImageUrl } from '@/utils/fileValidation';
-import { formatPhoneNumber, isKatakanaOnly, isKatakanaWithSpaceOnly } from '@/utils/inputValidation';
+import { isKatakanaOnly, isKatakanaWithSpaceOnly } from '@/utils/inputValidation';
 import toast from 'react-hot-toast';
 import AddressSelector from '@/components/ui/AddressSelector';
 import { KatakanaInput, KatakanaWithSpaceInput } from '@/components/ui/KatakanaInput';
+import { PhoneNumberInput } from '@/components/ui/PhoneNumberInput';
 import { QUALIFICATION_GROUPS } from '@/constants/qualifications';
 import { useDebugError, extractDebugInfo } from '@/components/debug/DebugErrorBanner';
 
@@ -929,13 +930,9 @@ export default function ProfileEditClient({ userProfile }: ProfileEditClientProp
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
             <div>
               <label className="block text-sm font-medium mb-2">電話番号 <span className="text-red-500">*</span></label>
-              <input
-                type="tel"
+              <PhoneNumberInput
                 value={formData.phone}
-                onChange={(e) => {
-                  const value = formatPhoneNumber(e.target.value);
-                  setFormData({ ...formData, phone: value });
-                }}
+                onChange={(value) => setFormData({ ...formData, phone: value })}
                 placeholder="090-1234-5678"
                 className={`w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent ${showErrors && !formData.phone ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
               />
@@ -1025,13 +1022,9 @@ export default function ProfileEditClient({ userProfile }: ProfileEditClientProp
             </div>
             <div>
               <label className="block text-sm font-medium mb-2">電話番号</label>
-              <input
-                type="tel"
+              <PhoneNumberInput
                 value={formData.emergencyContactPhone}
-                onChange={(e) => {
-                  const value = formatPhoneNumber(e.target.value);
-                  setFormData({ ...formData, emergencyContactPhone: value });
-                }}
+                onChange={(value) => setFormData({ ...formData, emergencyContactPhone: value })}
                 placeholder="090-1234-5678"
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent"
               />

--- a/app/register/worker/page.tsx
+++ b/app/register/worker/page.tsx
@@ -7,9 +7,10 @@ import Link from 'next/link';
 import toast from 'react-hot-toast';
 import { useAuth } from '@/contexts/AuthContext';
 import { compressImage, MAX_FILE_SIZE, formatFileSize } from '@/utils/fileValidation';
-import { formatPhoneNumber, isValidEmail, isValidPhoneNumber, isKatakanaOnly } from '@/utils/inputValidation';
+import { isValidEmail, isValidPhoneNumber, isKatakanaOnly } from '@/utils/inputValidation';
 import AddressSelector from '@/components/ui/AddressSelector';
 import { KatakanaInput } from '@/components/ui/KatakanaInput';
+import { PhoneNumberInput } from '@/components/ui/PhoneNumberInput';
 import { QUALIFICATION_GROUPS } from '@/constants/qualifications';
 import { useDebugError, extractDebugInfo } from '@/components/debug/DebugErrorBanner';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
@@ -526,11 +527,10 @@ export default function WorkerRegisterPage() {
                   <label className="block text-sm font-medium text-gray-700 mb-1">
                     電話番号 <span className="text-red-500">*</span>
                   </label>
-                  <input
-                    type="tel"
+                  <PhoneNumberInput
                     required
                     value={formData.phoneNumber}
-                    onChange={(e) => setFormData({ ...formData, phoneNumber: formatPhoneNumber(e.target.value) })}
+                    onChange={(value) => setFormData({ ...formData, phoneNumber: value })}
                     placeholder="090-1234-5678"
                     className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary ${showErrors && !formData.phoneNumber ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
                   />

--- a/app/system-admin/facilities/new/page.tsx
+++ b/app/system-admin/facilities/new/page.tsx
@@ -7,7 +7,7 @@ import { createFacilityWithAdmin } from '@/src/lib/system-actions';
 import { SERVICE_TYPES } from '@/constants/serviceTypes';
 import { ChevronLeft, Building2, User, Lock, Mail, Phone, MapPin } from 'lucide-react';
 import toast from 'react-hot-toast';
-import { formatPhoneNumber } from '@/utils/inputValidation';
+import { PhoneNumberInput } from '@/components/ui/PhoneNumberInput';
 import { useDebugError, extractDebugInfo } from '@/components/debug/DebugErrorBanner';
 
 export default function SystemAdminNewFacilityPage() {
@@ -181,11 +181,10 @@ export default function SystemAdminNewFacilityPage() {
 
                         <div>
                             <label className="block text-sm font-medium text-slate-700 mb-1">電話番号</label>
-                            <input
-                                type="tel"
+                            <PhoneNumberInput
                                 name="phoneNumber"
                                 value={formData.phoneNumber}
-                                onChange={(e) => setFormData(prev => ({ ...prev, phoneNumber: formatPhoneNumber(e.target.value) }))}
+                                onChange={(value) => setFormData(prev => ({ ...prev, phoneNumber: value }))}
                                 placeholder="例: 03-1234-5678"
                                 className="w-full px-4 py-2 border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500"
                             />
@@ -296,11 +295,10 @@ export default function SystemAdminNewFacilityPage() {
 
                         <div>
                             <label className="block text-sm font-medium text-slate-700 mb-1">電話番号</label>
-                            <input
-                                type="tel"
+                            <PhoneNumberInput
                                 name="adminPhone"
                                 value={formData.adminPhone}
-                                onChange={(e) => setFormData(prev => ({ ...prev, adminPhone: formatPhoneNumber(e.target.value) }))}
+                                onChange={(value) => setFormData(prev => ({ ...prev, adminPhone: value }))}
                                 placeholder="例: 090-1234-5678"
                                 className="w-full px-4 py-2 border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500"
                             />

--- a/components/ui/AddressSelector.tsx
+++ b/components/ui/AddressSelector.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo, useCallback } from 'react';
 import { PREFECTURES } from '@/src/lib/analytics-constants';
 import { CITIES_BY_PREFECTURE } from '@/constants/japan-cities';
 import { X, Loader2 } from 'lucide-react';
+import { PostalCodeInput } from './PostalCodeInput';
 
 interface AddressSelectorProps {
     prefecture: string;
@@ -91,18 +92,16 @@ export default function AddressSelector({
     }, [addressLine, building, onChange]);
 
     // 郵便番号変更時のハンドラー
-    const handlePostalCodeChange = (value: string) => {
+    const handlePostalCodeChange = useCallback((value: string) => {
         // 郵便番号を更新
         onChange({ prefecture, city, addressLine, building, postalCode: value });
+        setPostalCodeError('');
+    }, [prefecture, city, addressLine, building, onChange]);
 
-        // 自動検索（7桁入力時）
-        const cleanValue = value.replace(/[-\s]/g, '');
-        if (cleanValue.length === 7) {
-            searchAddressByPostalCode(value);
-        } else {
-            setPostalCodeError('');
-        }
-    };
+    // 郵便番号入力完了時のハンドラー（7桁入力時に住所検索）
+    const handlePostalCodeComplete = useCallback((value: string) => {
+        searchAddressByPostalCode(value);
+    }, [searchAddressByPostalCode]);
 
     // 選択された都道府県の市区町村リスト
     const availableCities = useMemo(() => {
@@ -151,13 +150,12 @@ export default function AddressSelector({
                         </span>
                     </label>
                     <div className="flex items-center gap-2">
-                        <input
-                            type="text"
+                        <PostalCodeInput
                             value={postalCode}
-                            onChange={e => handlePostalCodeChange(e.target.value)}
+                            onChange={handlePostalCodeChange}
+                            onComplete={handlePostalCodeComplete}
                             className="w-full max-w-[200px] px-2 py-1.5 text-sm border border-slate-300 rounded-lg"
                             placeholder="123-4567"
-                            maxLength={8}
                         />
                         {isSearchingPostalCode && (
                             <Loader2 className="w-5 h-5 text-primary animate-spin" />

--- a/components/ui/KatakanaInput.tsx
+++ b/components/ui/KatakanaInput.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useRef, useCallback, InputHTMLAttributes } from 'react';
+import { useState, useRef, useCallback, useEffect, InputHTMLAttributes } from 'react';
 import { formatKatakana, formatKatakanaWithSpace } from '@/utils/inputValidation';
 
 interface KatakanaInputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'value'> {
@@ -11,23 +11,31 @@ interface KatakanaInputProps extends Omit<InputHTMLAttributes<HTMLInputElement>,
 /**
  * iOSのIME入力問題に対応したカタカナ入力コンポーネント
  *
- * 問題: iOSではIME入力中（変換確定前）にonChangeが発火し、
+ * 問題: iOSやMacのライブ変換ではIME入力中（変換確定前）にonChangeが発火し、
  * formatKatakanaによる変換がIMEのcomposition状態と干渉して
  * 「勝手に文字が入力される」問題が発生する。
  *
- * 解決策: onCompositionStart/Endを使用してIME入力中は
- * 変換処理をスキップし、入力確定後にのみ変換を行う。
+ * 解決策:
+ * 1. onCompositionStart/Endを使用してIME入力中は変換処理をスキップ
+ * 2. onBlur時にも変換を適用（ライブ変換の取りこぼし対策）
+ * 3. useEffectで外部値との同期（レンダリング中の状態更新を回避）
+ * 4. 変換後の値が同じ場合はonChangeを呼ばない（無限ループ防止）
  */
-export function KatakanaInput({ value, onChange, ...props }: KatakanaInputProps) {
+export function KatakanaInput({ value, onChange, onBlur, ...props }: KatakanaInputProps) {
   // IME入力中かどうかを追跡
   const isComposingRef = useRef(false);
   // ローカルの入力値（IME入力中は変換せずに保持）
   const [localValue, setLocalValue] = useState(value);
+  // 最後にonChangeに渡した値（重複呼び出し防止）
+  const lastNotifiedValueRef = useRef(value);
 
-  // 外部からの値変更に追従
-  if (value !== localValue && !isComposingRef.current) {
-    setLocalValue(value);
-  }
+  // 外部からの値変更に追従（useEffectで安全に同期）
+  useEffect(() => {
+    if (!isComposingRef.current && value !== localValue) {
+      setLocalValue(value);
+      lastNotifiedValueRef.current = value;
+    }
+  }, [value, localValue]);
 
   const handleCompositionStart = useCallback(() => {
     isComposingRef.current = true;
@@ -36,9 +44,15 @@ export function KatakanaInput({ value, onChange, ...props }: KatakanaInputProps)
   const handleCompositionEnd = useCallback((e: React.CompositionEvent<HTMLInputElement>) => {
     isComposingRef.current = false;
     // IME入力確定時にカタカナ変換を適用
-    const convertedValue = formatKatakana(e.currentTarget.value);
+    const rawValue = e.currentTarget.value;
+    const convertedValue = formatKatakana(rawValue);
     setLocalValue(convertedValue);
-    onChange(convertedValue);
+
+    // 値が変わった場合のみonChangeを呼ぶ
+    if (convertedValue !== lastNotifiedValueRef.current) {
+      lastNotifiedValueRef.current = convertedValue;
+      onChange(convertedValue);
+    }
   }, [onChange]);
 
   const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
@@ -51,9 +65,34 @@ export function KatakanaInput({ value, onChange, ...props }: KatakanaInputProps)
       // 通常入力時（英数字直接入力など）は即座に変換
       const convertedValue = formatKatakana(newValue);
       setLocalValue(convertedValue);
-      onChange(convertedValue);
+
+      // 値が変わった場合のみonChangeを呼ぶ
+      if (convertedValue !== lastNotifiedValueRef.current) {
+        lastNotifiedValueRef.current = convertedValue;
+        onChange(convertedValue);
+      }
     }
   }, [onChange]);
+
+  // blurイベントで最終的な変換を保証（ライブ変換対策）
+  const handleBlur = useCallback((e: React.FocusEvent<HTMLInputElement>) => {
+    isComposingRef.current = false;
+    const rawValue = e.currentTarget.value;
+    const convertedValue = formatKatakana(rawValue);
+
+    if (convertedValue !== localValue) {
+      setLocalValue(convertedValue);
+    }
+
+    // 値が変わった場合のみonChangeを呼ぶ
+    if (convertedValue !== lastNotifiedValueRef.current) {
+      lastNotifiedValueRef.current = convertedValue;
+      onChange(convertedValue);
+    }
+
+    // 元のonBlurハンドラも呼ぶ
+    onBlur?.(e);
+  }, [localValue, onChange, onBlur]);
 
   return (
     <input
@@ -63,6 +102,7 @@ export function KatakanaInput({ value, onChange, ...props }: KatakanaInputProps)
       onChange={handleChange}
       onCompositionStart={handleCompositionStart}
       onCompositionEnd={handleCompositionEnd}
+      onBlur={handleBlur}
     />
   );
 }
@@ -71,13 +111,18 @@ export function KatakanaInput({ value, onChange, ...props }: KatakanaInputProps)
  * スペース付きカタカナ入力コンポーネント（口座名義用）
  * KatakanaInputと同様のIME対応を行い、スペースを許容する
  */
-export function KatakanaWithSpaceInput({ value, onChange, ...props }: KatakanaInputProps) {
+export function KatakanaWithSpaceInput({ value, onChange, onBlur, ...props }: KatakanaInputProps) {
   const isComposingRef = useRef(false);
   const [localValue, setLocalValue] = useState(value);
+  const lastNotifiedValueRef = useRef(value);
 
-  if (value !== localValue && !isComposingRef.current) {
-    setLocalValue(value);
-  }
+  // 外部からの値変更に追従
+  useEffect(() => {
+    if (!isComposingRef.current && value !== localValue) {
+      setLocalValue(value);
+      lastNotifiedValueRef.current = value;
+    }
+  }, [value, localValue]);
 
   const handleCompositionStart = useCallback(() => {
     isComposingRef.current = true;
@@ -85,9 +130,14 @@ export function KatakanaWithSpaceInput({ value, onChange, ...props }: KatakanaIn
 
   const handleCompositionEnd = useCallback((e: React.CompositionEvent<HTMLInputElement>) => {
     isComposingRef.current = false;
-    const convertedValue = formatKatakanaWithSpace(e.currentTarget.value);
+    const rawValue = e.currentTarget.value;
+    const convertedValue = formatKatakanaWithSpace(rawValue);
     setLocalValue(convertedValue);
-    onChange(convertedValue);
+
+    if (convertedValue !== lastNotifiedValueRef.current) {
+      lastNotifiedValueRef.current = convertedValue;
+      onChange(convertedValue);
+    }
   }, [onChange]);
 
   const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
@@ -98,9 +148,31 @@ export function KatakanaWithSpaceInput({ value, onChange, ...props }: KatakanaIn
     } else {
       const convertedValue = formatKatakanaWithSpace(newValue);
       setLocalValue(convertedValue);
-      onChange(convertedValue);
+
+      if (convertedValue !== lastNotifiedValueRef.current) {
+        lastNotifiedValueRef.current = convertedValue;
+        onChange(convertedValue);
+      }
     }
   }, [onChange]);
+
+  // blurイベントで最終的な変換を保証（ライブ変換対策）
+  const handleBlur = useCallback((e: React.FocusEvent<HTMLInputElement>) => {
+    isComposingRef.current = false;
+    const rawValue = e.currentTarget.value;
+    const convertedValue = formatKatakanaWithSpace(rawValue);
+
+    if (convertedValue !== localValue) {
+      setLocalValue(convertedValue);
+    }
+
+    if (convertedValue !== lastNotifiedValueRef.current) {
+      lastNotifiedValueRef.current = convertedValue;
+      onChange(convertedValue);
+    }
+
+    onBlur?.(e);
+  }, [localValue, onChange, onBlur]);
 
   return (
     <input
@@ -110,6 +182,7 @@ export function KatakanaWithSpaceInput({ value, onChange, ...props }: KatakanaIn
       onChange={handleChange}
       onCompositionStart={handleCompositionStart}
       onCompositionEnd={handleCompositionEnd}
+      onBlur={handleBlur}
     />
   );
 }

--- a/components/ui/PhoneNumberInput.tsx
+++ b/components/ui/PhoneNumberInput.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useState, useRef, useCallback, useEffect, InputHTMLAttributes } from 'react';
+import { formatPhoneNumber } from '@/utils/inputValidation';
+
+interface PhoneNumberInputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'value'> {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+/**
+ * IME入力問題に対応した電話番号入力コンポーネント
+ *
+ * 問題: 電話番号入力でformatPhoneNumber（ハイフン自動挿入）を
+ * リアルタイムで適用すると、IME入力中に干渉して
+ * 「勝手に文字が入力される」「カーソルが飛ぶ」問題が発生する。
+ *
+ * 解決策:
+ * 1. onCompositionStart/Endを使用してIME入力中はフォーマット処理をスキップ
+ * 2. onBlur時にもフォーマットを適用（ライブ変換の取りこぼし対策）
+ * 3. 変換後の値が同じ場合はonChangeを呼ばない（無限ループ防止）
+ */
+export function PhoneNumberInput({ value, onChange, onBlur, ...props }: PhoneNumberInputProps) {
+  // IME入力中かどうかを追跡
+  const isComposingRef = useRef(false);
+  // ローカルの入力値
+  const [localValue, setLocalValue] = useState(value);
+  // 最後にonChangeに渡した値（重複呼び出し防止）
+  const lastNotifiedValueRef = useRef(value);
+
+  // 外部からの値変更に追従
+  useEffect(() => {
+    if (!isComposingRef.current && value !== localValue) {
+      setLocalValue(value);
+      lastNotifiedValueRef.current = value;
+    }
+  }, [value, localValue]);
+
+  const handleCompositionStart = useCallback(() => {
+    isComposingRef.current = true;
+  }, []);
+
+  const handleCompositionEnd = useCallback((e: React.CompositionEvent<HTMLInputElement>) => {
+    isComposingRef.current = false;
+    const rawValue = e.currentTarget.value;
+    const formattedValue = formatPhoneNumber(rawValue);
+    setLocalValue(formattedValue);
+
+    if (formattedValue !== lastNotifiedValueRef.current) {
+      lastNotifiedValueRef.current = formattedValue;
+      onChange(formattedValue);
+    }
+  }, [onChange]);
+
+  const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value;
+
+    if (isComposingRef.current) {
+      // IME入力中はフォーマットせずにそのまま表示
+      setLocalValue(newValue);
+    } else {
+      // 通常入力時は即座にフォーマット
+      const formattedValue = formatPhoneNumber(newValue);
+      setLocalValue(formattedValue);
+
+      if (formattedValue !== lastNotifiedValueRef.current) {
+        lastNotifiedValueRef.current = formattedValue;
+        onChange(formattedValue);
+      }
+    }
+  }, [onChange]);
+
+  // blurイベントで最終的なフォーマットを保証
+  const handleBlur = useCallback((e: React.FocusEvent<HTMLInputElement>) => {
+    isComposingRef.current = false;
+    const rawValue = e.currentTarget.value;
+    const formattedValue = formatPhoneNumber(rawValue);
+
+    if (formattedValue !== localValue) {
+      setLocalValue(formattedValue);
+    }
+
+    if (formattedValue !== lastNotifiedValueRef.current) {
+      lastNotifiedValueRef.current = formattedValue;
+      onChange(formattedValue);
+    }
+
+    onBlur?.(e);
+  }, [localValue, onChange, onBlur]);
+
+  return (
+    <input
+      {...props}
+      type="tel"
+      inputMode="tel"
+      value={localValue}
+      onChange={handleChange}
+      onCompositionStart={handleCompositionStart}
+      onCompositionEnd={handleCompositionEnd}
+      onBlur={handleBlur}
+    />
+  );
+}

--- a/components/ui/PostalCodeInput.tsx
+++ b/components/ui/PostalCodeInput.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useState, useRef, useCallback, useEffect, InputHTMLAttributes } from 'react';
+import { formatPostalCode } from '@/utils/inputValidation';
+
+interface PostalCodeInputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'value'> {
+  value: string;
+  onChange: (value: string) => void;
+  /** 7桁入力完了時のコールバック（住所自動入力などに使用） */
+  onComplete?: (value: string) => void;
+}
+
+/**
+ * IME入力問題に対応した郵便番号入力コンポーネント
+ *
+ * 問題: 郵便番号入力でformatPostalCode（ハイフン自動挿入）を
+ * リアルタイムで適用すると、IME入力中に干渉して
+ * 「勝手に文字が入力される」「カーソルが飛ぶ」問題が発生する。
+ *
+ * 解決策:
+ * 1. onCompositionStart/Endを使用してIME入力中はフォーマット処理をスキップ
+ * 2. onBlur時にもフォーマットを適用（ライブ変換の取りこぼし対策）
+ * 3. 7桁入力完了時にonCompleteコールバックを呼ぶ
+ */
+export function PostalCodeInput({ value, onChange, onComplete, onBlur, ...props }: PostalCodeInputProps) {
+  // IME入力中かどうかを追跡
+  const isComposingRef = useRef(false);
+  // ローカルの入力値
+  const [localValue, setLocalValue] = useState(value);
+  // 最後にonChangeに渡した値（重複呼び出し防止）
+  const lastNotifiedValueRef = useRef(value);
+  // onCompleteが呼ばれた値を記録（重複防止）
+  const lastCompletedValueRef = useRef('');
+
+  // 7桁かどうかをチェックしてonCompleteを呼ぶ
+  const checkComplete = useCallback((formattedValue: string) => {
+    const digitsOnly = formattedValue.replace(/\D/g, '');
+    if (digitsOnly.length === 7 && digitsOnly !== lastCompletedValueRef.current) {
+      lastCompletedValueRef.current = digitsOnly;
+      onComplete?.(formattedValue);
+    }
+  }, [onComplete]);
+
+  // 外部からの値変更に追従
+  useEffect(() => {
+    if (!isComposingRef.current && value !== localValue) {
+      setLocalValue(value);
+      lastNotifiedValueRef.current = value;
+    }
+  }, [value, localValue]);
+
+  const handleCompositionStart = useCallback(() => {
+    isComposingRef.current = true;
+  }, []);
+
+  const handleCompositionEnd = useCallback((e: React.CompositionEvent<HTMLInputElement>) => {
+    isComposingRef.current = false;
+    const rawValue = e.currentTarget.value;
+    const formattedValue = formatPostalCode(rawValue);
+    setLocalValue(formattedValue);
+
+    if (formattedValue !== lastNotifiedValueRef.current) {
+      lastNotifiedValueRef.current = formattedValue;
+      onChange(formattedValue);
+    }
+
+    checkComplete(formattedValue);
+  }, [onChange, checkComplete]);
+
+  const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value;
+
+    if (isComposingRef.current) {
+      // IME入力中はフォーマットせずにそのまま表示
+      setLocalValue(newValue);
+    } else {
+      // 通常入力時は即座にフォーマット
+      const formattedValue = formatPostalCode(newValue);
+      setLocalValue(formattedValue);
+
+      if (formattedValue !== lastNotifiedValueRef.current) {
+        lastNotifiedValueRef.current = formattedValue;
+        onChange(formattedValue);
+      }
+
+      checkComplete(formattedValue);
+    }
+  }, [onChange, checkComplete]);
+
+  // blurイベントで最終的なフォーマットを保証
+  const handleBlur = useCallback((e: React.FocusEvent<HTMLInputElement>) => {
+    isComposingRef.current = false;
+    const rawValue = e.currentTarget.value;
+    const formattedValue = formatPostalCode(rawValue);
+
+    if (formattedValue !== localValue) {
+      setLocalValue(formattedValue);
+    }
+
+    if (formattedValue !== lastNotifiedValueRef.current) {
+      lastNotifiedValueRef.current = formattedValue;
+      onChange(formattedValue);
+    }
+
+    checkComplete(formattedValue);
+    onBlur?.(e);
+  }, [localValue, onChange, onBlur, checkComplete]);
+
+  return (
+    <input
+      {...props}
+      type="text"
+      inputMode="numeric"
+      value={localValue}
+      onChange={handleChange}
+      onCompositionStart={handleCompositionStart}
+      onCompositionEnd={handleCompositionEnd}
+      onBlur={handleBlur}
+      maxLength={8}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- Mac/iOSのライブ変換でカタカナ・電話番号・郵便番号の入力が正しく反映されない問題を修正
- IME対応の専用入力コンポーネント（PhoneNumberInput、PostalCodeInput）を新規作成
- KatakanaInputにonBlurハンドラと外部値同期のuseEffectを追加

## 修正対象フォーム
- ワーカー登録（電話番号）
- プロフィール編集（電話番号、緊急連絡先）
- 施設管理（電話番号3箇所）
- 施設新規登録（電話番号2箇所）
- 住所入力（郵便番号）

## 技術的な修正内容
1. `compositionstart/end`イベントでIME入力中を検知
2. `onBlur`でライブ変換の取りこぼしを補完
3. `useEffect`で外部からの値変更に追従
4. `lastNotifiedValueRef`で重複onChange呼び出しを防止

## Test plan
- [ ] Vercel Previewで確認
- [ ] Mac Safari/Chromeでカタカナ入力（口座名義）テスト
- [ ] Mac Safari/Chromeで電話番号入力テスト
- [ ] 郵便番号入力で住所自動入力テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)