### PR TITLE
fix: プロフィール更新後のクライアントキャッシュを無効化

### DIFF
--- a/app/mypage/profile/ProfileEditClient.tsx
+++ b/app/mypage/profile/ProfileEditClient.tsx
@@ -576,6 +576,8 @@ export default function ProfileEditClient({ userProfile }: ProfileEditClientProp
         setIdDocumentFile(null);
         setBankBookImageFile(null);
         setQualificationCertificateFiles({});
+        // キャッシュを無効化してからリダイレクト
+        router.refresh();
         // リダイレクト: returnUrlがあれば戻り先へ、なければマイページへ
         if (returnUrl) {
           router.push(returnUrl);


### PR DESCRIPTION
## Summary
- プロフィール画像更新後、マイページで古い画像が表示される問題を修正
- `router.push()`の前に`router.refresh()`を呼び出してクライアントキャッシュを無効化

## 前回の修正（PR #76）
- サーバー側の`revalidatePath('/mypage')`を追加したが不十分だった
- クライアント側のナビゲーションではキャッシュが効いてしまう

## 今回の修正
- `ProfileEditClient.tsx`で`router.refresh()`を追加
- これによりクライアント側のキャッシュも無効化される

## Test plan
- [ ] プロフィール画像をアップロード
- [ ] マイページに戻った際、リロードなしで新しい画像が表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)