### PR TITLE
fix: プロフィール更新後にフルページリロードを使用

### DIFF
--- a/app/mypage/profile/ProfileEditClient.tsx
+++ b/app/mypage/profile/ProfileEditClient.tsx
@@ -577,13 +577,12 @@ export default function ProfileEditClient({ userProfile }: ProfileEditClientProp
         setIdDocumentFile(null);
         setBankBookImageFile(null);
         setQualificationCertificateFiles({});
-        // キャッシュを無効化してからリダイレクト
-        router.refresh();
-        // リダイレクト: returnUrlがあれば戻り先へ、なければマイページへ
+        // フルページリロードでリダイレクト（キャッシュを確実に無効化）
+        // router.push()ではクライアントキャッシュが効いてしまうため
         if (returnUrl) {
-          router.push(returnUrl);
+          window.location.href = returnUrl;
         } else {
-          router.push('/mypage');
+          window.location.href = '/mypage';
         }
       } else {
         // デバッグ用エラー通知を表示


### PR DESCRIPTION
## Summary
- プロフィール画像更新後、マイページで古い画像が表示される問題を修正
- `router.push()`を`window.location.href`に変更してフルページリロード

## 背景
- PR #76: サーバー側の`revalidatePath`追加 → 効果なし
- PR #78: `router.refresh()`追加 → 効果なし
- 今回: `window.location.href`でフルリロード → 確実にキャッシュ無効化

## Test plan
- [ ] プロフィール画像をアップロード
- [ ] マイページに戻った際、リロードなしで新しい画像が表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)