### PR TITLE
fix: プロフィール更新後のリダイレクトを修正

### DIFF
--- a/app/mypage/profile/ProfileEditClient.tsx
+++ b/app/mypage/profile/ProfileEditClient.tsx
@@ -579,11 +579,9 @@ export default function ProfileEditClient({ userProfile }: ProfileEditClientProp
         setQualificationCertificateFiles({});
         // フルページリロードでリダイレクト（キャッシュを確実に無効化）
         // router.push()ではクライアントキャッシュが効いてしまうため
-        if (returnUrl) {
-          window.location.href = returnUrl;
-        } else {
-          window.location.href = '/mypage';
-        }
+        const redirectUrl = returnUrl || '/mypage';
+        window.location.replace(redirectUrl);
+        return;
       } else {
         // デバッグ用エラー通知を表示
         showDebugError({


### PR DESCRIPTION
## Summary
- プロフィール更新後にマイページへリダイレクトされない問題を修正

## 変更内容
- `window.location.href`を`window.location.replace()`に変更
- `return`文を追加して確実にリダイレクト

## Test plan
- [ ] プロフィールを更新
- [ ] マイページにリダイレクトされることを確認
- [ ] 新しいプロフィール画像が表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)