### PR TITLE
perf: プロフィール更新後のリダイレクトを高速化

### DIFF
--- a/app/mypage/profile/ProfileEditClient.tsx
+++ b/app/mypage/profile/ProfileEditClient.tsx
@@ -571,14 +571,8 @@ export default function ProfileEditClient({ userProfile }: ProfileEditClientProp
       const result = await updateUserProfile(form);
 
       if (result.success) {
-        toast.success(result.message || 'プロフィールを更新しました');
-        // 画像アップロード後はファイル状態をリセット
-        setProfileImageFile(null);
-        setIdDocumentFile(null);
-        setBankBookImageFile(null);
-        setQualificationCertificateFiles({});
         // フルページリロードでリダイレクト（キャッシュを確実に無効化）
-        // router.push()ではクライアントキャッシュが効いてしまうため
+        // 状態リセットは不要（リダイレクト後にページがリロードされるため）
         const redirectUrl = returnUrl || '/mypage';
         window.location.replace(redirectUrl);
         return;


### PR DESCRIPTION
## Summary
- プロフィール更新後のリダイレクトが遅い問題を改善

## 変更内容
- 不要なtoast表示と状態リセット処理を削除
- リダイレクト後にページがリロードされるため、これらの処理は不要

🤖 Generated with [Claude Code](https://claude.ai/code)