### PR TITLE
fix: 労働条件通知書URLを正しいページに修正

### DIFF
--- a/prisma/seed-notifications.ts
+++ b/prisma/seed-notifications.ts
@@ -18,11 +18,10 @@ const notificationSettings = [
 日時: {{work_date}} {{start_time}}〜{{end_time}}
 報酬: {{wage}}円
 
-▼ 労働条件通知書はこちら
-{{job_url}}
+▼ 勤務詳細・労働条件通知書はこちら
+{{my_job_url}}
 
-上記ページの「労働条件通知書」ボタンからご確認ください。
-※本書は労働基準法第15条に基づき、労働条件を明示するものです。
+※労働条件通知書は労働基準法第15条に基づき、労働条件を明示するものです。
 
 当日はよろしくお願いいたします。`,
         email_subject: '【+TASTAS】マッチング成立のお知らせ',
@@ -37,8 +36,8 @@ const notificationSettings = [
 日時: {{work_date}} {{start_time}}〜{{end_time}}
 報酬: {{wage}}円
 
-詳細はマイページよりご確認ください。
-{{job_url}}
+▼ 勤務詳細・労働条件通知書はこちら
+{{my_job_url}}
 
 ──────────────────────────
 +TASTAS 運営
@@ -59,11 +58,10 @@ const notificationSettings = [
 勤務先: {{facility_name}}
 日時: {{work_date}} {{start_time}}〜{{end_time}}
 
-▼ 労働条件通知書はこちら
-{{job_url}}
+▼ 勤務詳細・労働条件通知書はこちら
+{{my_job_url}}
 
-上記ページの「労働条件通知書」ボタンからご確認ください。
-※本書は労働基準法第15条に基づき、労働条件を明示するものです。
+※労働条件通知書は労働基準法第15条に基づき、労働条件を明示するものです。
 
 当日はよろしくお願いいたします。`,
         email_subject: '【+TASTAS】採用決定のお知らせ',
@@ -78,8 +76,8 @@ const notificationSettings = [
 日時: {{work_date}} {{start_time}}〜{{end_time}}
 報酬: {{wage}}円
 
-詳細はマイページよりご確認ください。
-{{job_url}}
+▼ 勤務詳細・労働条件通知書はこちら
+{{my_job_url}}
 
 ──────────────────────────
 +TASTAS 運営

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -162,11 +162,10 @@ const notificationSettings = [
 日時: {{work_date}} {{start_time}}〜{{end_time}}
 報酬: {{wage}}円
 
-▼ 労働条件通知書はこちら
-{{job_url}}
+▼ 勤務詳細・労働条件通知書はこちら
+{{my_job_url}}
 
-上記ページの「労働条件通知書」ボタンからご確認ください。
-※本書は労働基準法第15条に基づき、労働条件を明示するものです。
+※労働条件通知書は労働基準法第15条に基づき、労働条件を明示するものです。
 
 当日はよろしくお願いいたします。`,
     email_subject: '【+TASTAS】マッチング成立のお知らせ',
@@ -181,8 +180,8 @@ const notificationSettings = [
 日時: {{work_date}} {{start_time}}〜{{end_time}}
 報酬: {{wage}}円
 
-詳細はマイページよりご確認ください。
-{{job_url}}
+▼ 勤務詳細・労働条件通知書はこちら
+{{my_job_url}}
 
 ──────────────────────────
 +TASTAS 運営
@@ -203,6 +202,11 @@ const notificationSettings = [
 勤務先: {{facility_name}}
 日時: {{work_date}} {{start_time}}〜{{end_time}}
 
+▼ 勤務詳細・労働条件通知書はこちら
+{{my_job_url}}
+
+※労働条件通知書は労働基準法第15条に基づき、労働条件を明示するものです。
+
 当日はよろしくお願いいたします。`,
     email_subject: '【+TASTAS】採用決定のお知らせ',
     email_body: `{{worker_name}}様
@@ -216,8 +220,8 @@ const notificationSettings = [
 日時: {{work_date}} {{start_time}}〜{{end_time}}
 報酬: {{wage}}円
 
-詳細はマイページよりご確認ください。
-{{job_url}}
+▼ 勤務詳細・労働条件通知書はこちら
+{{my_job_url}}
 
 ──────────────────────────
 +TASTAS 運営

--- a/src/lib/actions/notification.ts
+++ b/src/lib/actions/notification.ts
@@ -261,6 +261,7 @@ export async function sendMatchingNotification(
         // 審査あり求人の場合はWORKER_INTERVIEW_ACCEPTED、それ以外はWORKER_MATCHED
         const notificationKey = isInterviewJob ? 'WORKER_INTERVIEW_ACCEPTED' : 'WORKER_MATCHED';
 
+        const baseUrl = process.env.NEXT_PUBLIC_APP_URL || process.env.NEXTAUTH_URL || 'https://tastas.jp';
         await sendNotification({
             notificationKey,
             targetType: 'WORKER',
@@ -275,7 +276,9 @@ export async function sendMatchingNotification(
                 job_title: jobTitle,
                 wage: job?.hourly_wage?.toLocaleString() || '',
                 hourly_wage: job?.hourly_wage?.toString() || '',
-                job_url: `${process.env.NEXT_PUBLIC_APP_URL || process.env.NEXTAUTH_URL || 'https://tastas.jp'}/jobs/${jobId}`,
+                job_url: `${baseUrl}/jobs/${jobId}`,
+                my_job_url: `${baseUrl}/my-jobs/${applicationId}`,
+                labor_document_url: `${baseUrl}/my-jobs/${applicationId}/labor-document`,
                 work_date: formattedWorkDate,
                 start_time: workDateInfo?.startTime?.substring(0, 5) || '',
                 end_time: workDateInfo?.endTime?.substring(0, 5) || '',


### PR DESCRIPTION
## Summary
- マッチング成立時の通知メッセージで送られる労働条件通知書のURLを修正
- `{{job_url}}` (求人詳細ページ) から `{{my_job_url}}` (応募詳細ページ) に変更
- WORKER_MATCHED と WORKER_INTERVIEW_ACCEPTED の両テンプレートを修正

## 問題の詳細
通知メッセージに含まれるURLが `/jobs/{jobId}` を指していたため、ワーカーが「労働条件通知書はこちら」のリンクをクリックしても労働条件通知書にアクセスできなかった。

労働条件通知書は `/my-jobs/{applicationId}/labor-document` でアクセスする必要があるが、通知では `/jobs/{jobId}` が送られていた。

## 修正内容
1. **notification.ts**: `sendMatchingNotification` 関数に `my_job_url` と `labor_document_url` 変数を追加
2. **seed.ts / seed-notifications.ts**: 通知テンプレートを `{{my_job_url}}` に変更

## Test plan
- [ ] マッチング成立時にワーカーへ送信される通知メッセージのURLが `/my-jobs/{applicationId}` になっていることを確認
- [ ] リンクをクリックして応募詳細ページが表示されることを確認
- [ ] 応募詳細ページから労働条件通知書ボタンをクリックして正しく表示されることを確認

## Note
**本番環境への反映には DB へのseed実行が必要です。**
既存の通知設定テンプレートはDBに保存されているため、以下のいずれかで対応してください：
1. System Admin管理画面から通知テンプレートを手動更新
2. `npx prisma db seed` でseedを再実行（※他の設定もリセットされる可能性あり）

🤖 Generated with [Claude Code](https://claude.ai/code)