### PR TITLE
fix: TypeScriptビルドエラーを修正

### DIFF
--- a/lib/logger.ts
+++ b/lib/logger.ts
@@ -7,6 +7,7 @@
  */
 
 import { prisma } from '@/lib/prisma'
+import { Prisma } from '@prisma/client'
 
 // ========== 型定義 ==========
 
@@ -191,8 +192,8 @@ export async function logActivity(params: ActivityLogParams): Promise<void> {
         action: params.action,
         target_type: params.targetType,
         target_id: params.targetId,
-        request_data: sanitizedRequestData,
-        response_data: params.responseData,
+        request_data: sanitizedRequestData as Prisma.InputJsonValue | undefined,
+        response_data: params.responseData as Prisma.InputJsonValue | undefined,
         result: params.result || 'SUCCESS',
         error_message: params.errorMessage,
         error_stack: params.errorStack,

--- a/src/lib/actions/facility-account.ts
+++ b/src/lib/actions/facility-account.ts
@@ -99,7 +99,7 @@ export async function addFacilityAccount(
                 facilityId,
                 email: data.email,
             },
-            result: 'FAILURE',
+            result: 'ERROR',
             errorMessage: getErrorMessage(error),
             errorStack: getErrorStack(error),
         }).catch(() => {});
@@ -176,7 +176,7 @@ export async function updateFacilityAccount(
             requestData: {
                 facilityId,
             },
-            result: 'FAILURE',
+            result: 'ERROR',
             errorMessage: getErrorMessage(error),
             errorStack: getErrorStack(error),
         }).catch(() => {});
@@ -236,7 +236,7 @@ export async function updateFacilityAccountPassword(
                 facilityId,
                 field: 'password',
             },
-            result: 'FAILURE',
+            result: 'ERROR',
             errorMessage: getErrorMessage(error),
             errorStack: getErrorStack(error),
         }).catch(() => {});
@@ -292,7 +292,7 @@ export async function deleteFacilityAccount(accountId: number, facilityId: numbe
             requestData: {
                 facilityId,
             },
-            result: 'FAILURE',
+            result: 'ERROR',
             errorMessage: getErrorMessage(error),
             errorStack: getErrorStack(error),
         }).catch(() => {});

--- a/src/lib/actions/facility-info.ts
+++ b/src/lib/actions/facility-info.ts
@@ -131,7 +131,7 @@ export async function toggleFacilityFavorite(facilityId: string) {
                 facilityId,
                 bookmarkType: 'FAVORITE',
             },
-            result: 'FAILURE',
+            result: 'ERROR',
             errorMessage: getErrorMessage(error),
             errorStack: getErrorStack(error),
         }).catch(() => {});
@@ -298,7 +298,7 @@ export async function updateFacilityInitialMessage(facilityId: number, initialMe
             requestData: {
                 field: 'initial_message',
             },
-            result: 'FAILURE',
+            result: 'ERROR',
             errorMessage: getErrorMessage(error),
             errorStack: getErrorStack(error),
         }).catch(() => {});
@@ -405,7 +405,7 @@ export async function updateFacilityBasicInfo(facilityId: number, data: any) {
             requestData: {
                 facilityName: data.facilityName,
             },
-            result: 'FAILURE',
+            result: 'ERROR',
             errorMessage: getErrorMessage(error),
             errorStack: getErrorStack(error),
         }).catch(() => {});
@@ -478,7 +478,7 @@ export async function updateFacilityLatLng(facilityId: number, lat: number, lng:
             requestData: {
                 field: 'lat_lng',
             },
-            result: 'FAILURE',
+            result: 'ERROR',
             errorMessage: getErrorMessage(error),
             errorStack: getErrorStack(error),
         }).catch(() => {});
@@ -540,7 +540,7 @@ export async function updateFacilityMapImageByLatLng(facilityId: number, lat: nu
             requestData: {
                 field: 'map_image_lat_lng',
             },
-            result: 'FAILURE',
+            result: 'ERROR',
             errorMessage: getErrorMessage(error),
             errorStack: getErrorStack(error),
         }).catch(() => {});

--- a/src/lib/actions/job-template.ts
+++ b/src/lib/actions/job-template.ts
@@ -167,7 +167,7 @@ export async function createJobTemplate(
                 facilityId,
                 name: data.name,
             },
-            result: 'FAILURE',
+            result: 'ERROR',
             errorMessage: getErrorMessage(error),
             errorStack: getErrorStack(error),
         }).catch(() => {});
@@ -282,7 +282,7 @@ export async function updateJobTemplate(
                 facilityId,
                 name: data.name,
             },
-            result: 'FAILURE',
+            result: 'ERROR',
             errorMessage: getErrorMessage(error),
             errorStack: getErrorStack(error),
         }).catch(() => {});

--- a/src/lib/actions/labor-document-shift.ts
+++ b/src/lib/actions/labor-document-shift.ts
@@ -432,7 +432,7 @@ export async function cancelShift(applicationId: number): Promise<{ success: boo
             action: 'FACILITY_CANCEL',
             targetType: 'Application',
             targetId: applicationId,
-            result: 'FAILURE',
+            result: 'ERROR',
             errorMessage: getErrorMessage(error),
             errorStack: getErrorStack(error),
         }).catch(() => {});

--- a/src/lib/actions/notification.ts
+++ b/src/lib/actions/notification.ts
@@ -127,7 +127,7 @@ export async function markNotificationAsRead(notificationId: number) {
             action: 'NOTIFICATION_READ',
             targetType: 'Notification',
             targetId: notificationId,
-            result: 'FAILURE',
+            result: 'ERROR',
             errorMessage: getErrorMessage(error),
             errorStack: getErrorStack(error),
         }).catch(() => {});
@@ -179,7 +179,7 @@ export async function markAllNotificationsAsRead() {
             requestData: {
                 action: 'mark_all_read',
             },
-            result: 'FAILURE',
+            result: 'ERROR',
             errorMessage: getErrorMessage(error),
             errorStack: getErrorStack(error),
         }).catch(() => {});

--- a/src/lib/actions/offer-template.ts
+++ b/src/lib/actions/offer-template.ts
@@ -87,7 +87,7 @@ export async function createOfferTemplate(
         facilityId,
         name,
       },
-      result: 'FAILURE',
+      result: 'ERROR',
       errorMessage: getErrorMessage(error),
       errorStack: getErrorStack(error),
     }).catch(() => {});
@@ -151,7 +151,7 @@ export async function updateOfferTemplate(
         facilityId,
         name,
       },
-      result: 'FAILURE',
+      result: 'ERROR',
       errorMessage: getErrorMessage(error),
       errorStack: getErrorStack(error),
     }).catch(() => {});
@@ -210,7 +210,7 @@ export async function deleteOfferTemplate(
       requestData: {
         facilityId,
       },
-      result: 'FAILURE',
+      result: 'ERROR',
       errorMessage: getErrorMessage(error),
       errorStack: getErrorStack(error),
     }).catch(() => {});

--- a/src/lib/actions/review-admin.ts
+++ b/src/lib/actions/review-admin.ts
@@ -462,7 +462,7 @@ export async function submitWorkerReview(data: {
         facilityId: data.facilityId,
         applicationId: data.applicationId,
       },
-      result: 'FAILURE',
+      result: 'ERROR',
       errorMessage: getErrorMessage(error),
       errorStack: getErrorStack(error),
     }).catch(() => {});
@@ -640,7 +640,7 @@ export async function submitWorkerReviewByJob(data: {
         jobId: data.jobId,
         workerId: data.userId,
       },
-      result: 'FAILURE',
+      result: 'ERROR',
       errorMessage: getErrorMessage(error),
       errorStack: getErrorStack(error),
     }).catch(() => {});
@@ -736,7 +736,7 @@ export async function createReviewTemplate(facilityId: number, name: string, con
         facilityId,
         name,
       },
-      result: 'FAILURE',
+      result: 'ERROR',
       errorMessage: getErrorMessage(error),
       errorStack: getErrorStack(error),
     }).catch(() => {});
@@ -790,7 +790,7 @@ export async function updateReviewTemplate(templateId: number, name: string, con
         facilityId,
         name,
       },
-      result: 'FAILURE',
+      result: 'ERROR',
       errorMessage: getErrorMessage(error),
       errorStack: getErrorStack(error),
     }).catch(() => {});
@@ -841,7 +841,7 @@ export async function deleteReviewTemplate(templateId: number, facilityId: numbe
       requestData: {
         facilityId,
       },
-      result: 'FAILURE',
+      result: 'ERROR',
       errorMessage: getErrorMessage(error),
       errorStack: getErrorStack(error),
     }).catch(() => {});
@@ -920,7 +920,7 @@ export async function toggleWorkerFavorite(workerId: number, facilityId: number)
         workerId,
         type: 'FAVORITE',
       },
-      result: 'FAILURE',
+      result: 'ERROR',
       errorMessage: getErrorMessage(error),
       errorStack: getErrorStack(error),
     }).catch(() => {});
@@ -999,7 +999,7 @@ export async function toggleWorkerBlock(workerId: number, facilityId: number): P
         workerId,
         type: 'BLOCK',
       },
-      result: 'FAILURE',
+      result: 'ERROR',
       errorMessage: getErrorMessage(error),
       errorStack: getErrorStack(error),
     }).catch(() => {});
@@ -1306,7 +1306,7 @@ export async function submitFacilityReviewForWorker(
         facilityId,
         applicationId,
       },
-      result: 'FAILURE',
+      result: 'ERROR',
       errorMessage: getErrorMessage(error),
       errorStack: getErrorStack(error),
     }).catch(() => {});


### PR DESCRIPTION
## Summary
- `lib/logger.ts`: Prisma JSON型エラーを修正（`Prisma.InputJsonValue`型アサーション追加）
- 各actionsファイル: LogResult型エラーを修正（`'FAILURE'`を`'ERROR'`に変更）

## Background
1月5日以降、Vercelのデプロイが全て失敗していた原因を修正。
これにより、`{{my_job_url}}`の変数置換が正常に動作するようになる。

## Test plan
- [x] `npx tsc --noEmit` で型エラーなし
- [ ] Vercelでのデプロイ成功確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)