### PR TITLE
fix: 求人検索のタイムゾーン問題を修正（JSTベースに変更）

### DIFF
--- a/app/api/jobs/route.ts
+++ b/app/api/jobs/route.ts
@@ -43,7 +43,7 @@ export async function GET(request: NextRequest) {
     // 求人リストタイプ（限定求人・オファー対応）
     const listType = (searchParams.get('listType') as 'all' | 'limited' | 'offer') || 'all';
 
-    // 日付フィルター用のDateオブジェクト生成（デバッグ時刻対応）
+    // 日付フィルター用のDateオブジェクト生成（デバッグ時刻対応・JST）
     const dates = generateDatesFromBase(currentTime, 90);
     const targetDate = dates[dateIndex];
 

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -70,14 +70,28 @@ export const generateDates = (count: number = 90): Date[] => {
 /**
  * 指定した基準日から日付リストを生成（サーバーサイド用）
  * API Routeなど、Cookieから直接デバッグ時刻を読み取る場合に使用
+ *
+ * 重要: 日本時間（JST）ベースで日付を生成する
+ * サーバーがUTCで動作していても、JSTの日付を基準にする
  */
 export const generateDatesFromBase = (baseDate: Date, count: number = 90): Date[] => {
   const dates: Date[] = [];
 
+  // JSTのオフセット（+9時間 = 540分）
+  const JST_OFFSET = 9 * 60;
+
+  // 基準日をJSTに変換して、その日の00:00:00を取得
+  const jstBase = new Date(baseDate.getTime() + JST_OFFSET * 60 * 1000);
+  const jstYear = jstBase.getUTCFullYear();
+  const jstMonth = jstBase.getUTCMonth();
+  const jstDay = jstBase.getUTCDate();
+
   for (let i = 0; i < count; i++) {
-    const date = new Date(baseDate);
-    date.setDate(baseDate.getDate() + i);
-    dates.push(date);
+    // JSTでの日付を計算（UTCとして格納するが、JSTの日付を表す）
+    const jstDate = new Date(Date.UTC(jstYear, jstMonth, jstDay + i, 0, 0, 0, 0));
+    // JSTの00:00をUTCに戻す（-9時間）= UTC 15:00（前日）
+    const utcDate = new Date(jstDate.getTime() - JST_OFFSET * 60 * 1000);
+    dates.push(utcDate);
   }
 
   return dates;

--- a/utils/debugTime.server.ts
+++ b/utils/debugTime.server.ts
@@ -40,3 +40,47 @@ export function getCurrentTimeFromSettings(settings: DebugTimeSettings): Date {
   }
   return new Date();
 }
+
+/**
+ * 日本時間（JST）での今日の開始時刻を取得
+ * サーバーがUTCで動作していても、JSTの00:00:00を返す
+ */
+export function getJSTTodayStart(baseTime?: Date): Date {
+  const now = baseTime || new Date();
+
+  // JSTのオフセット（+9時間 = 540分）
+  const JST_OFFSET = 9 * 60;
+
+  // UTCでの現在時刻をJSTに変換
+  const jstTime = new Date(now.getTime() + JST_OFFSET * 60 * 1000);
+
+  // JSTでの今日の00:00:00を計算
+  const jstTodayStart = new Date(Date.UTC(
+    jstTime.getUTCFullYear(),
+    jstTime.getUTCMonth(),
+    jstTime.getUTCDate(),
+    0, 0, 0, 0
+  ));
+
+  // JSTの00:00をUTCに戻す（-9時間）
+  return new Date(jstTodayStart.getTime() - JST_OFFSET * 60 * 1000);
+}
+
+/**
+ * 日本時間（JST）での今日の日付文字列を取得（YYYY-MM-DD形式）
+ */
+export function getJSTTodayString(baseTime?: Date): string {
+  const now = baseTime || new Date();
+
+  // JSTのオフセット（+9時間 = 540分）
+  const JST_OFFSET = 9 * 60;
+
+  // UTCでの現在時刻をJSTに変換
+  const jstTime = new Date(now.getTime() + JST_OFFSET * 60 * 1000);
+
+  const year = jstTime.getUTCFullYear();
+  const month = String(jstTime.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(jstTime.getUTCDate()).padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+}


### PR DESCRIPTION
## Summary
- 求人検索で「今日」の求人が表示されない問題を修正
- サーバー（UTC）とクライアント（JST）のタイムゾーンずれを解消
- JST基準での日付計算に統一

## 問題の詳細
Vercelサーバーは UTC で動作するため、`setHours(0, 0, 0, 0)` が UTC の深夜0時を基準に計算されていた。
- JST 08:40 = UTC 23:40（前日）
- サーバーの「今日」= 日本の「昨日」
- そのため、当日に作成した求人が検索結果に表示されなかった

## 修正内容
1. `utils/debugTime.server.ts`: `getJSTTodayStart()` 関数を追加
   - サーバーがUTCでも、JSTの00:00:00を正しく計算
2. `utils/date.ts`: `generateDatesFromBase()` をJST対応に修正
   - 日付リスト生成がJSTベースになるよう変更
3. `src/lib/actions/job-worker.ts`: 3箇所で `getJSTTodayStart()` を使用
   - `getJobsListWithPagination()`
   - `getJobById()`
   - `getJobListTypeCounts()`

## Test plan
- [ ] ステージング環境で「今日」の日付で求人検索
- [ ] 朝の時間帯（JST 00:00〜09:00）でも正常に動作することを確認
- [ ] dateIndex=0（今日）で当日登録した求人が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)