### PR TITLE
fix: 日付フィルターのsetHours()をJST対応に修正

### DIFF
--- a/src/lib/actions/job-worker.ts
+++ b/src/lib/actions/job-worker.ts
@@ -896,11 +896,11 @@ export async function getJobsListWithPagination(
     }
 
     // 日付フィルター
+    // targetDateは既にgenerateDatesFromBase()でJST基準の日付になっている
+    // setHours()はサーバーのタイムゾーン(UTC)で動作するため使用しない
     if (targetDate) {
-        const startOfDay = new Date(targetDate);
-        startOfDay.setHours(0, 0, 0, 0);
-        const endOfDay = new Date(targetDate);
-        endOfDay.setHours(23, 59, 59, 999);
+        const startOfDay = targetDate;
+        const endOfDay = new Date(targetDate.getTime() + 24 * 60 * 60 * 1000 - 1);
 
         whereConditions.workDates = {
             some: {
@@ -954,10 +954,9 @@ export async function getJobsListWithPagination(
     };
 
     if (targetDate) {
-        const startOfDayForInclude = new Date(targetDate);
-        startOfDayForInclude.setHours(0, 0, 0, 0);
-        const endOfDayForInclude = new Date(targetDate);
-        endOfDayForInclude.setHours(23, 59, 59, 999);
+        // targetDateは既にJST基準なのでそのまま使用
+        const startOfDayForInclude = targetDate;
+        const endOfDayForInclude = new Date(targetDate.getTime() + 24 * 60 * 60 * 1000 - 1);
 
         workDatesWhereCondition.AND[0] = {
             work_date: {


### PR DESCRIPTION
## Summary
- 日付フィルターで`setHours()`を使用していた問題を修正
- `targetDate`は既にJST基準で生成されているため、`setHours()`は不要

## 問題の詳細
前回のPR (#95) で`generateDatesFromBase()`と`getJSTTodayStart()`をJST対応にしたが、日付フィルター部分で`setHours(0, 0, 0, 0)`を使用していたため、再びUTC基準に戻っていた。

```typescript
// 問題のコード
const startOfDay = new Date(targetDate);
startOfDay.setHours(0, 0, 0, 0);  // ← UTCの0時にリセットされる
```

## 修正内容
- `setHours()`の呼び出しを削除
- `endOfDay`は`targetDate + 24時間 - 1ms`で計算
- 2箇所修正: whereConditions用とworkDatesWhereCondition用

## Test plan
- [ ] ステージング環境で「今日」の日付で求人検索
- [ ] JST 00:00〜09:00（UTCでは前日）でも正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)