### PR TITLE
fix: 全サーバーサイドの日付処理をJST対応に統一

### DIFF
--- a/app/api/admin/workers/[id]/schedules/route.ts
+++ b/app/api/admin/workers/[id]/schedules/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 import { prisma } from '@/lib/prisma';
 import { WorkerStatus } from '@prisma/client';
-import { DEBUG_TIME_COOKIE_NAME, parseDebugTimeCookie, getCurrentTimeFromSettings } from '@/utils/debugTime.server';
+import { DEBUG_TIME_COOKIE_NAME, parseDebugTimeCookie, getCurrentTimeFromSettings, getJSTTodayStart } from '@/utils/debugTime.server';
 
 export async function GET(
   request: NextRequest,
@@ -45,12 +45,12 @@ export async function GET(
       );
     }
 
-    // デバッグ時刻をCookieから取得
+    // デバッグ時刻をCookieから取得（JST対応）
     const debugTimeCookie = request.cookies.get(DEBUG_TIME_COOKIE_NAME);
     const debugTimeSettings = parseDebugTimeCookie(debugTimeCookie?.value);
     const currentTime = getCurrentTimeFromSettings(debugTimeSettings);
-    const today = new Date(currentTime);
-    today.setHours(0, 0, 0, 0);
+    // サーバーがUTCでもJSTの今日を正しく計算
+    const today = getJSTTodayStart(currentTime);
 
     // 今後の勤務予定を取得（SCHEDULED, WORKING状態）
     const upcomingApplications = await prisma.application.findMany({

--- a/src/lib/actions/application-admin.ts
+++ b/src/lib/actions/application-admin.ts
@@ -15,6 +15,7 @@ import { sendNotification } from '../notification-service';
 import { getAuthenticatedUser } from './helpers';
 import { updateApplicationStatuses } from '../status-updater';
 import { logActivity, getErrorMessage, getErrorStack } from '@/lib/logger';
+import { normalizeToJSTDayStart } from '@/utils/debugTime.server';
 
 /**
  * 施設管理用: 施設に届いた応募一覧を取得
@@ -501,11 +502,10 @@ export async function getJobsWithApplications(
             const current = workerCancelStats.get(app.user_id) || { totalScheduled: 0, lastMinuteCancels: 0 };
             current.totalScheduled += 1;
             if (app.status === 'CANCELLED' && app.cancelled_by === 'WORKER') {
-                const workDate = new Date(app.workDate.work_date);
+                const workDateNormalized = normalizeToJSTDayStart(new Date(app.workDate.work_date));
                 const updatedAt = new Date(app.updated_at);
-                const dayBefore = new Date(workDate);
-                dayBefore.setDate(dayBefore.getDate() - 1);
-                dayBefore.setHours(0, 0, 0, 0);
+                // 前日 = workDate - 24時間（JST基準）
+                const dayBefore = new Date(workDateNormalized.getTime() - 24 * 60 * 60 * 1000);
                 if (updatedAt >= dayBefore) current.lastMinuteCancels += 1;
             }
             workerCancelStats.set(app.user_id, current);
@@ -714,11 +714,10 @@ export async function getApplicationsByWorker(
             const current = workerCancelStats.get(app.user_id) || { totalScheduled: 0, lastMinuteCancels: 0 };
             current.totalScheduled += 1;
             if (app.status === 'CANCELLED' && app.cancelled_by === 'WORKER') {
-                const workDate = new Date(app.workDate.work_date);
+                const workDateNormalized = normalizeToJSTDayStart(new Date(app.workDate.work_date));
                 const updatedAt = new Date(app.updated_at);
-                const dayBefore = new Date(workDate);
-                dayBefore.setDate(dayBefore.getDate() - 1);
-                dayBefore.setHours(0, 0, 0, 0);
+                // 前日 = workDate - 24時間（JST基準）
+                const dayBefore = new Date(workDateNormalized.getTime() - 24 * 60 * 60 * 1000);
                 if (updatedAt >= dayBefore) current.lastMinuteCancels += 1;
             }
             workerCancelStats.set(app.user_id, current);
@@ -987,11 +986,10 @@ export async function getFacilityApplicationsByWorker(facilityId: number) {
       // 直前キャンセルの判定：ワーカー自身のキャンセルかつ勤務日の前日以降に更新された
       // 施設からのキャンセルはカウントしない
       if (app.status === 'CANCELLED' && app.cancelled_by === 'WORKER') {
-        const workDate = new Date(app.workDate.work_date);
+        const workDateNormalized = normalizeToJSTDayStart(new Date(app.workDate.work_date));
         const updatedAt = new Date(app.updated_at);
-        const dayBefore = new Date(workDate);
-        dayBefore.setDate(dayBefore.getDate() - 1);
-        dayBefore.setHours(0, 0, 0, 0);
+        // 前日 = workDate - 24時間（JST基準）
+        const dayBefore = new Date(workDateNormalized.getTime() - 24 * 60 * 60 * 1000);
 
         if (updatedAt >= dayBefore) {
           current.lastMinuteCancels += 1;

--- a/src/lib/actions/job-worker.ts
+++ b/src/lib/actions/job-worker.ts
@@ -5,7 +5,7 @@ import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
 import { revalidatePath, unstable_cache, unstable_noStore as noStore } from 'next/cache';
 import { getCurrentTime, getTodayStart } from '@/utils/debugTime';
-import { getJSTTodayStart } from '@/utils/debugTime.server';
+import { getJSTTodayStart, normalizeToJSTDayStart } from '@/utils/debugTime.server';
 import {
     getAuthenticatedUser,
     isTimeOverlapping,
@@ -1236,11 +1236,10 @@ export async function getJobById(id: string, options?: { currentTime?: Date }) {
     const totalAppliedCount = job.workDates.reduce((sum: number, wd) => sum + wd.applied_count, 0);
     const totalMatchedCount = job.workDates.reduce((sum: number, wd) => sum + wd.matched_count, 0);
 
-    // 今日以降の勤務日をカウント
+    // 今日以降の勤務日をカウント（JST基準で比較）
     const today = todayStart;
     const futureWorkDateCount = job.workDates.filter(wd => {
-        const workDate = new Date(wd.work_date);
-        workDate.setHours(0, 0, 0, 0);
+        const workDate = normalizeToJSTDayStart(new Date(wd.work_date));
         return workDate >= today;
     }).length;
 

--- a/src/lib/review-helpers.ts
+++ b/src/lib/review-helpers.ts
@@ -1,5 +1,6 @@
 import { prisma } from '@/lib/prisma';
 import { getCurrentTime } from '@/utils/debugTime';
+import { normalizeToJSTDayStart } from '@/utils/debugTime.server';
 
 /**
  * 求人の勤務期間を取得する（最初の勤務日と最後の勤務日）
@@ -48,9 +49,8 @@ export async function canReview(jobId: number, userId: number): Promise<boolean>
     if (!period) return false;
 
     const today = getCurrentTime();
-    // 勤務初日の0:00以降ならレビュー可能
-    const startDate = new Date(period.start);
-    startDate.setHours(0, 0, 0, 0);
+    // 勤務初日の0:00以降ならレビュー可能（JST基準で比較）
+    const startDate = normalizeToJSTDayStart(new Date(period.start));
 
     return today >= startDate;
 }
@@ -74,10 +74,10 @@ export async function isReviewPending(jobId: number, userId: number, reviewerTyp
     if (!period) return false;
 
     const today = getCurrentTime();
-    const endDate = new Date(period.end);
-    // 最終勤務日の翌日以降なら督促対象
-    endDate.setDate(endDate.getDate() + 1);
-    endDate.setHours(0, 0, 0, 0);
+    // 最終勤務日の翌日以降なら督促対象（JST基準で比較）
+    const endDateNormalized = normalizeToJSTDayStart(new Date(period.end));
+    // 翌日 = +24時間
+    const nextDay = new Date(endDateNormalized.getTime() + 24 * 60 * 60 * 1000);
 
-    return today >= endDate;
+    return today >= nextDay;
 }

--- a/utils/debugTime.server.ts
+++ b/utils/debugTime.server.ts
@@ -67,6 +67,28 @@ export function getJSTTodayStart(baseTime?: Date): Date {
 }
 
 /**
+ * 任意の日付をJST基準の日の開始時刻（00:00:00 JST）に正規化
+ * DBから取得した日付を比較用に正規化する際に使用
+ */
+export function normalizeToJSTDayStart(date: Date): Date {
+  const JST_OFFSET = 9 * 60;
+
+  // 日付をJSTに変換
+  const jstTime = new Date(date.getTime() + JST_OFFSET * 60 * 1000);
+
+  // JSTでの日の00:00:00を計算
+  const jstDayStart = new Date(Date.UTC(
+    jstTime.getUTCFullYear(),
+    jstTime.getUTCMonth(),
+    jstTime.getUTCDate(),
+    0, 0, 0, 0
+  ));
+
+  // JSTの00:00をUTCに戻す（-9時間）
+  return new Date(jstDayStart.getTime() - JST_OFFSET * 60 * 1000);
+}
+
+/**
  * 日本時間（JST）での今日の日付文字列を取得（YYYY-MM-DD形式）
  */
 export function getJSTTodayString(baseTime?: Date): string {


### PR DESCRIPTION
## Summary
- サーバーサイドの全ての日付比較処理をJST対応に統一
- `normalizeToJSTDayStart()`ユーティリティ関数を追加

## 修正箇所

| ファイル | 修正内容 |
|---------|---------|
| `utils/debugTime.server.ts` | `normalizeToJSTDayStart()`追加 |
| `schedules/route.ts` | ワーカー予定取得の今日判定 |
| `review-admin.ts` | ワーカー一覧の今日以降判定、直前キャンセル判定 |
| `job-worker.ts` | `getJobById()`の将来勤務日カウント |
| `review-helpers.ts` | レビュー可否判定の日付比較 |
| `application-admin.ts` | 直前キャンセル判定（3箇所） |

## 問題の詳細
`setHours(0, 0, 0, 0)`はサーバーのタイムゾーン（Vercel=UTC）で動作するため、JST 00:00〜09:00の間に日付境界がずれる問題があった。

## Test plan
- [ ] ワーカー予定一覧が正しく表示される
- [ ] ワーカー一覧の「勤務予定あり」が正しく判定される
- [ ] 直前キャンセル率が正しく計算される
- [ ] レビュー可否が正しく判定される

🤖 Generated with [Claude Code](https://claude.com/claude-code)