### PR TITLE
fix: 審査あり求人でも募集枠超過採用を防止

### DIFF
--- a/src/lib/actions/application-admin.ts
+++ b/src/lib/actions/application-admin.ts
@@ -150,7 +150,8 @@ export async function updateApplicationStatus(
                     include: { job: true },
                 });
 
-                if (workDate && !workDate.job.requires_interview && workDate.matched_count >= workDate.recruitment_count) {
+                // 審査あり・なしに関わらず、募集枠を超えた採用を防止
+                if (workDate && workDate.matched_count >= workDate.recruitment_count) {
                     throw new Error('この勤務日は既に募集人数に達しています');
                 }
 


### PR DESCRIPTION
## Summary
- 審査あり求人（requires_interview = true）で、募集枠を超えた採用決定が可能になっていた問題を修正
- 募集枠チェックの条件から`!requires_interview`を削除し、全求人タイプで同一のバリデーションを適用

## Changes
- `src/lib/actions/application-admin.ts:153` - 募集枠チェック条件の修正

## Test plan
- [ ] 審査あり求人で募集枠（例：1名）に達した後、追加の採用決定を試みる
- [ ] エラーメッセージ「この勤務日は既に募集人数に達しています」が表示されることを確認
- [ ] 通常求人（審査なし）の動作が変更されていないことを確認

## Related Issues
Closes #81（デバッグシート ID-81）

🤖 Generated with [Claude Code](https://claude.ai/code)