### PR TITLE
fix: 求人詳細の労働条件通知書ボタンを案内文に変更

### DIFF
--- a/components/job/JobDetailClient.tsx
+++ b/components/job/JobDetailClient.tsx
@@ -1159,14 +1159,12 @@ export function JobDetailClient({ job, facility, relatedJobs: _relatedJobs, faci
         </div>
       </div>
 
-      {/* 労働条件通知書ボタン */}
+      {/* 労働条件通知書の案内 */}
       <div className="mb-4 px-4">
-        <button
-          onClick={() => toast('労働条件通知書のダミーデータです', { icon: '📄' })}
-          className="px-3 py-1.5 text-xs text-white bg-primary rounded hover:bg-primary/90 transition-colors"
-        >
-          労働条件通知書を確認
-        </button>
+        <div className="flex items-center gap-2 text-xs text-gray-500 bg-gray-50 rounded-lg px-3 py-2">
+          <span>📄</span>
+          <span>労働条件通知書はマッチング成立後、仕事管理画面から確認できます</span>
+        </div>
       </div>
 
       {/* レビュー */}


### PR DESCRIPTION
## Summary
- 求人詳細ページの労働条件通知書ボタンがダミートースト表示のみで機能していなかった問題を修正
- ボタンを削除し、適切な案内文に変更

## Changes
- `components/job/JobDetailClient.tsx`
  - ダミートースト表示ボタンを削除
  - 「労働条件通知書はマッチング成立後、仕事管理画面から確認できます」という案内文に変更

## Background
労働条件通知書は`/my-jobs/[id]/labor-document`で正しく実装されており、マッチング成立後に仕事管理画面からアクセスする仕様です。求人詳細ページ（マッチング前）でボタンを表示する必要はないため、案内文に変更しました。

## Test plan
- [ ] 求人詳細ページで「労働条件通知書はマッチング成立後...」の案内文が表示されることを確認
- [ ] マッチング済みの仕事詳細ページ（/my-jobs/[id]）から労働条件通知書へアクセスできることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)