### PR TITLE
docs: PRマージ禁止ルールをCLAUDE.mdに追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 3. **developブランチへの直接push禁止（推奨）**
    - 原則としてPR経由でマージ
 
+4. **指示がない限りPRをマージしない**
+   - PRを作成した後、ユーザーから明示的な指示があるまで絶対にマージしないこと
+   - `gh pr merge` は指示があるまで実行禁止
+
 ### ✅ 正しいワークフロー
 
 ```


### PR DESCRIPTION
## Summary
- Git操作の厳格ルールに「指示がない限りPRをマージしない」を追加

## 変更内容
```markdown
4. **指示がない限りPRをマージしない**
   - PRを作成した後、ユーザーから明示的な指示があるまで絶対にマージしないこと
   - `gh pr merge` は指示があるまで実行禁止
```

## Test plan
- [ ] CLAUDE.mdの内容が正しく追加されている

🤖 Generated with [Claude Code](https://claude.ai/code)