### PR TITLE
fix: メッセージ一覧にAPPLIED/CANCELLED状態の会話も表示 (ID-82/86)

### DIFF
--- a/src/lib/actions/message.ts
+++ b/src/lib/actions/message.ts
@@ -666,10 +666,14 @@ export async function getGroupedConversations() {
   const user = await getAuthenticatedUser();
 
   // ユーザーの全応募を取得（施設情報付き）
+  // ID-82/86対応: APPLIED（審査待ち）やCANCELLED（不採用）でもメッセージがある場合は表示
   const applications = await prisma.application.findMany({
     where: {
       user_id: user.id,
-      status: { in: ['SCHEDULED', 'WORKING', 'COMPLETED_PENDING', 'COMPLETED_RATED'] },
+      OR: [
+        { status: { in: ['SCHEDULED', 'WORKING', 'COMPLETED_PENDING', 'COMPLETED_RATED'] } },
+        { messages: { some: {} } }, // メッセージがある応募は全て表示
+      ],
     },
     include: {
       workDate: {


### PR DESCRIPTION
## Summary

- 審査あり求人への応募（APPLIED）でもメッセージがあれば会話一覧に表示
- 不採用（CANCELLED）後もメッセージ通知が一覧に表示される
- ID-82/86の同時修正

## 問題

| 症状 | 原因 |
|------|------|
| 審査待ちの応募がメッセージ一覧に表示されない | `APPLIED`がフィルターに含まれていない |
| 不採用通知が一覧に出ない | `CANCELLED`がフィルターに含まれていない |
| 未読カウントは増えるが場所がわからない | 上記の結果 |

## 変更内容

`src/lib/actions/message.ts:670-677`

```typescript
// Before
status: { in: ['SCHEDULED', 'WORKING', 'COMPLETED_PENDING', 'COMPLETED_RATED'] }

// After
OR: [
  { status: { in: ['SCHEDULED', 'WORKING', 'COMPLETED_PENDING', 'COMPLETED_RATED'] } },
  { messages: { some: {} } }, // メッセージがある応募は全て表示
]
```

## Test plan

- [ ] 審査あり求人に応募後、メッセージ一覧に会話が表示される
- [ ] 不採用通知を受け取った後、メッセージ一覧で確認できる
- [ ] 既存の正常なフローに影響がない

🤖 Generated with [Claude Code](https://claude.com/claude-code)