### PR TITLE
fix: 求人詳細ページの募集人数表示を修正 (ID-78)

### DIFF
--- a/src/lib/actions/job-worker.ts
+++ b/src/lib/actions/job-worker.ts
@@ -1232,9 +1232,10 @@ export async function getJobById(id: string, options?: { currentTime?: Date }) {
 
     // 一番近い勤務日を取得
     const nearestWorkDate = job.workDates.length > 0 ? job.workDates[0] : null;
-    // 総応募数を計算
+    // 総数を計算（各勤務日の値を合計）
     const totalAppliedCount = job.workDates.reduce((sum: number, wd) => sum + wd.applied_count, 0);
     const totalMatchedCount = job.workDates.reduce((sum: number, wd) => sum + wd.matched_count, 0);
+    const totalRecruitmentCount = job.workDates.reduce((sum: number, wd) => sum + wd.recruitment_count, 0);
 
     // 今日以降の勤務日をカウント（JST基準で比較）
     const today = todayStart;
@@ -1254,6 +1255,7 @@ export async function getJobById(id: string, options?: { currentTime?: Date }) {
         deadline: nearestWorkDate ? nearestWorkDate.deadline.toISOString() : null,
         applied_count: totalAppliedCount,
         matched_count: totalMatchedCount,
+        recruitment_count: totalRecruitmentCount,
         workDates: job.workDates.map((wd) => ({
             ...wd,
             work_date: wd.work_date.toISOString(),


### PR DESCRIPTION
## Summary

- 求人詳細ページの「募集人数 X/Y人」表示が正しく計算されていなかった問題を修正
- `getJobById` 関数で `recruitment_count` を各勤務日の合計として計算するように変更

## 問題

Playwrightテストで確認:
- 表示: 「募集人数 3/1人」「募集人数 2/1人」
- 期待: 「募集人数 X/Y人」（応募数/募集枠）

原因:
- `applied_count` は各勤務日の合計を計算していた
- `recruitment_count` は Job テーブルの単一値をそのまま使っていた
- 結果として、複数勤務日の求人で数値が正しく表示されなかった

## 修正内容

`src/lib/actions/job-worker.ts` の `getJobById` 関数:
```typescript
// 追加
const totalRecruitmentCount = job.workDates.reduce((sum, wd) => sum + wd.recruitment_count, 0);

// 戻り値に追加
recruitment_count: totalRecruitmentCount,
```

## Test plan

- [x] TypeScriptコンパイルエラーなし
- [ ] ステージング環境にデプロイ後、Playwrightテストで確認
- [ ] 求人詳細ページで募集人数が「応募数/募集枠」の形式で正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)