### PR TITLE
feat: メッセージ・プロフィール更新にupdated_by追跡を追加 (ID-82/86/92)

### DIFF
--- a/src/lib/actions/message.ts
+++ b/src/lib/actions/message.ts
@@ -212,13 +212,15 @@ export async function sendMessage(applicationId: number, content: string) {
         from_user_id: user.id,
         to_facility_id: application.workDate.job.facility_id,
         content,
+        updated_by_type: 'WORKER',
+        updated_by_id: user.id,
       },
     });
 
     // 応募の更新日時を更新
     await prisma.application.update({
       where: { id: applicationId },
-      data: { updated_at: new Date() },
+      data: { updated_at: new Date(), updated_by_type: 'WORKER', updated_by_id: user.id },
     });
 
     // 施設への通知を送信
@@ -470,7 +472,8 @@ export async function sendFacilityMessage(
   applicationId: number,
   facilityId: number,
   content: string,
-  attachments: string[] = []
+  attachments: string[] = [],
+  adminId?: number
 ) {
   try {
     console.log('[sendFacilityMessage] Sending message for application:', applicationId);
@@ -514,13 +517,17 @@ export async function sendFacilityMessage(
         to_user_id: application.user_id,
         content,
         attachments,
+        ...(adminId && { updated_by_type: 'FACILITY_ADMIN', updated_by_id: adminId }),
       },
     });
 
     // 応募の更新日時を更新
     await prisma.application.update({
       where: { id: applicationId },
-      data: { updated_at: new Date() },
+      data: {
+        updated_at: new Date(),
+        ...(adminId && { updated_by_type: 'FACILITY_ADMIN', updated_by_id: adminId }),
+      },
     });
 
     // ワーカーへの通知を送信
@@ -1436,6 +1443,8 @@ export async function sendMessageToFacility(facilityId: number, content: string,
         to_facility_id: facilityId,
         application_id: latestApplication.id,
         job_id: latestApplication.workDate.job_id,
+        updated_by_type: 'WORKER',
+        updated_by_id: user.id,
       },
     });
 

--- a/src/lib/actions/user-profile.ts
+++ b/src/lib/actions/user-profile.ts
@@ -173,7 +173,7 @@ export async function updateUserSelfPR(selfPR: string): Promise<{ success: boole
 
         await prisma.user.update({
             where: { id: user.id },
-            data: { self_pr: selfPR.trim() || null },
+            data: { self_pr: selfPR.trim() || null, updated_by_type: 'WORKER', updated_by_id: user.id },
         });
 
         return { success: true };
@@ -453,6 +453,9 @@ export async function updateUserProfile(formData: FormData) {
                 id_document: idDocumentPath,
                 bank_book_image: bankBookImagePath,
                 qualification_certificates: Object.keys(newCertificates).length > 0 ? newCertificates : undefined,
+                // 更新者追跡
+                updated_by_type: 'WORKER',
+                updated_by_id: user.id,
             },
         });
 


### PR DESCRIPTION
## Summary
- メッセージ一覧にAPPLIED/CANCELLED状態の会話も表示するよう修正 (ID-82/86)
- Server Actionsにupdated_by_type/updated_by_id追跡を追加 (ID-92)

## 変更内容

### ID-82/86: メッセージ一覧表示の修正
- 既存のメッセージがある場合、応募ステータスに関わらず会話を表示

### ID-92: updated_by追跡の実装
対象Server Actions:
- `sendMessage` - ワーカーからのメッセージ送信
- `sendFacilityMessage` - 施設からのメッセージ送信
- `sendMessageToFacility` - 施設へのメッセージ送信
- `updateUserSelfPR` - 自己PR更新
- `updateUserProfile` - プロフィール更新

## Test plan
- [x] 統合テスト: 5/5成功
- [x] E2Eテスト: 成功
- [x] ビルド: 成功

🤖 Generated with [Claude Code](https://claude.ai/code)