### PR TITLE
feat: SEO対応公開求人詳細ページを追加

### DIFF
--- a/app/public/jobs/[id]/page.tsx
+++ b/app/public/jobs/[id]/page.tsx
@@ -1,0 +1,246 @@
+import { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import Image from 'next/image';
+import { getPublicJobById } from '@/src/lib/actions/job-public';
+import { MapPin, Clock, JapaneseYen, Calendar, Users, Building2 } from 'lucide-react';
+
+interface PageProps {
+    params: Promise<{ id: string }>;
+}
+
+interface WorkDateItem {
+    id: number;
+    work_date: string;
+    deadline: string;
+    recruitment_count: number;
+    matched_count: number;
+    remaining: number;
+}
+
+// OGP/メタデータを動的に生成
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+    const { id } = await params;
+    const job = await getPublicJobById(id);
+
+    if (!job) {
+        return {
+            title: '求人が見つかりません | +TASTAS',
+        };
+    }
+
+    const description = `時給${job.hourly_wage.toLocaleString()}円 | ${job.facility.prefecture}${job.facility.city} | ${job.qualifications?.join('・') || '資格不問'}`;
+
+    return {
+        title: `${job.title} | +TASTAS`,
+        description,
+        openGraph: {
+            title: `${job.title} | +TASTAS`,
+            description,
+            type: 'website',
+            images: job.images?.[0] ? [{ url: job.images[0] }] : [{ url: '/images/og-default.png' }],
+            siteName: '+TASTAS',
+        },
+        twitter: {
+            card: 'summary_large_image',
+            title: `${job.title} | +TASTAS`,
+            description,
+        },
+        alternates: {
+            canonical: `/public/jobs/${id}`,
+        },
+    };
+}
+
+export default async function PublicJobDetailPage({ params }: PageProps) {
+    const { id } = await params;
+    const job = await getPublicJobById(id);
+
+    if (!job) {
+        notFound();
+    }
+
+    // 勤務時間計算
+    const calculateWorkHours = () => {
+        if (!job.start_time || !job.end_time) return null;
+        const [startH, startM] = job.start_time.split(':').map(Number);
+        const [endH, endM] = job.end_time.split(':').map(Number);
+        let totalMinutes = (endH * 60 + endM) - (startH * 60 + startM);
+        if (totalMinutes < 0) totalMinutes += 24 * 60; // 日跨ぎ対応
+        const breakMinutes = Number(job.break_time) || 0;
+        const workMinutes = totalMinutes - breakMinutes;
+        const hours = Math.floor(workMinutes / 60);
+        const minutes = workMinutes % 60;
+        return minutes > 0 ? `${hours}時間${minutes}分` : `${hours}時間`;
+    };
+
+    // 日給計算
+    const calculateDailyWage = () => {
+        if (!job.start_time || !job.end_time || !job.hourly_wage) return null;
+        const [startH, startM] = job.start_time.split(':').map(Number);
+        const [endH, endM] = job.end_time.split(':').map(Number);
+        let totalMinutes = (endH * 60 + endM) - (startH * 60 + startM);
+        if (totalMinutes < 0) totalMinutes += 24 * 60;
+        const breakMinutes = Number(job.break_time) || 0;
+        const workMinutes = totalMinutes - breakMinutes;
+        const workHours = workMinutes / 60;
+        return Math.floor(job.hourly_wage * workHours);
+    };
+
+    const workHours = calculateWorkHours();
+    const dailyWage = calculateDailyWage();
+
+    // 勤務日のフォーマット
+    const formatWorkDate = (dateStr: string) => {
+        const date = new Date(dateStr);
+        const weekdays = ['日', '月', '火', '水', '木', '金', '土'];
+        return `${date.getMonth() + 1}/${date.getDate()}(${weekdays[date.getDay()]})`;
+    };
+
+    return (
+        <div className="bg-background">
+            {/* 画像カルーセル */}
+            <div className="relative aspect-video bg-gray-100">
+                {job.images && job.images.length > 0 ? (
+                    <Image
+                        src={job.images[0]}
+                        alt={job.title}
+                        fill
+                        className="object-cover"
+                        priority
+                    />
+                ) : (
+                    <div className="flex items-center justify-center h-full">
+                        <Building2 className="w-16 h-16 text-gray-300" />
+                    </div>
+                )}
+            </div>
+
+            {/* メインコンテンツ */}
+            <div className="p-4 space-y-6">
+                {/* タイトル・施設名 */}
+                <div>
+                    <h1 className="text-xl font-bold text-gray-900 mb-2">{job.title}</h1>
+                    <p className="text-gray-600">{job.facility.name}</p>
+                </div>
+
+                {/* 給与情報 */}
+                <div className="bg-primary/5 rounded-lg p-4">
+                    <div className="flex items-center gap-2 mb-2">
+                        <JapaneseYen className="w-5 h-5 text-primary" />
+                        <span className="text-2xl font-bold text-primary">
+                            {job.hourly_wage.toLocaleString()}円
+                        </span>
+                        <span className="text-gray-500">/時</span>
+                    </div>
+                    {dailyWage && (
+                        <p className="text-sm text-gray-600">
+                            日給目安: <span className="font-semibold">{dailyWage.toLocaleString()}円</span>
+                            {job.transportation_fee && job.transportation_fee > 0 && (
+                                <span className="ml-2">+ 交通費 {job.transportation_fee.toLocaleString()}円</span>
+                            )}
+                        </p>
+                    )}
+                </div>
+
+                {/* 勤務日程 */}
+                <div className="space-y-3">
+                    <h2 className="font-semibold text-gray-900 flex items-center gap-2">
+                        <Calendar className="w-5 h-5 text-gray-500" />
+                        勤務日程
+                    </h2>
+                    <div className="grid grid-cols-3 gap-2">
+                        {job.workDates.slice(0, 6).map((wd: WorkDateItem) => (
+                            <div
+                                key={wd.id}
+                                className={`p-2 rounded-lg text-center text-sm ${
+                                    wd.remaining > 0
+                                        ? 'bg-green-50 border border-green-200'
+                                        : 'bg-gray-100 text-gray-400'
+                                }`}
+                            >
+                                <div className="font-medium">{formatWorkDate(wd.work_date)}</div>
+                                <div className="text-xs">
+                                    {wd.remaining > 0 ? `残${wd.remaining}枠` : '満員'}
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                    {job.workDates.length > 6 && (
+                        <p className="text-sm text-gray-500 text-center">
+                            他 {job.workDates.length - 6} 日程あり
+                        </p>
+                    )}
+                </div>
+
+                {/* 勤務時間 */}
+                <div className="space-y-2">
+                    <h2 className="font-semibold text-gray-900 flex items-center gap-2">
+                        <Clock className="w-5 h-5 text-gray-500" />
+                        勤務時間
+                    </h2>
+                    <div className="bg-gray-50 rounded-lg p-3">
+                        <p className="text-lg font-medium">
+                            {job.start_time} 〜 {job.end_time}
+                        </p>
+                        <p className="text-sm text-gray-600">
+                            実働 {workHours}
+                            {job.break_time && Number(job.break_time) > 0 && `（休憩${job.break_time}分）`}
+                        </p>
+                    </div>
+                </div>
+
+                {/* 勤務地 */}
+                <div className="space-y-2">
+                    <h2 className="font-semibold text-gray-900 flex items-center gap-2">
+                        <MapPin className="w-5 h-5 text-gray-500" />
+                        勤務地
+                    </h2>
+                    <div className="bg-gray-50 rounded-lg p-3 space-y-1">
+                        <p className="font-medium">{job.facility.name}</p>
+                        <p className="text-sm text-gray-600">
+                            {job.facility.prefecture}{job.facility.city}{job.facility.address}
+                            {job.facility.address_line && ` ${job.facility.address_line}`}
+                        </p>
+                    </div>
+                </div>
+
+                {/* 応募資格 */}
+                {job.qualifications && job.qualifications.length > 0 && (
+                    <div className="space-y-2">
+                        <h2 className="font-semibold text-gray-900 flex items-center gap-2">
+                            <Users className="w-5 h-5 text-gray-500" />
+                            応募資格
+                        </h2>
+                        <div className="flex flex-wrap gap-2">
+                            {job.qualifications.map((qual: string, idx: number) => (
+                                <span
+                                    key={idx}
+                                    className="px-3 py-1 bg-blue-50 text-blue-700 rounded-full text-sm"
+                                >
+                                    {qual}
+                                </span>
+                            ))}
+                        </div>
+                    </div>
+                )}
+
+                {/* 仕事内容 */}
+                {job.description && (
+                    <div className="space-y-2">
+                        <h2 className="font-semibold text-gray-900">仕事内容</h2>
+                        <p className="text-gray-700 whitespace-pre-wrap">{job.description}</p>
+                    </div>
+                )}
+
+                {/* 審査について */}
+                {job.requires_interview && (
+                    <div className="bg-amber-50 border border-amber-200 rounded-lg p-3">
+                        <p className="text-sm text-amber-800">
+                            ※ この求人は審査があります。応募後、施設からの承認が必要です。
+                        </p>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/app/public/layout.tsx
+++ b/app/public/layout.tsx
@@ -1,0 +1,58 @@
+import Link from 'next/link';
+import Image from 'next/image';
+import { ReactNode } from 'react';
+
+interface PublicLayoutProps {
+  children: ReactNode;
+}
+
+/**
+ * 公開ページ用レイアウト
+ * - ヘッダー: ロゴのみ
+ * - フッター: 会員登録CTAボタン（固定）
+ * - ナビゲーションメニューなし
+ */
+export default function PublicLayout({ children }: PublicLayoutProps) {
+  return (
+    <div className="min-h-screen bg-background">
+      {/* ヘッダー - ロゴのみ */}
+      <header className="sticky top-0 bg-white border-b border-gray-200 z-10">
+        <div className="max-w-lg mx-auto px-4 py-3">
+          <Link href="/" className="inline-block">
+            <Image
+              src="/images/logo.png"
+              alt="+TASTAS"
+              width={120}
+              height={32}
+              className="h-8 w-auto"
+              priority
+            />
+          </Link>
+        </div>
+      </header>
+
+      {/* メインコンテンツ */}
+      <main
+        className="max-w-lg mx-auto"
+        style={{ paddingBottom: 'calc(5rem + env(safe-area-inset-bottom))' }}
+      >
+        {children}
+      </main>
+
+      {/* フッター - CTA固定 */}
+      <footer
+        className="fixed bottom-0 left-0 right-0 bg-primary z-20"
+        style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+      >
+        <div className="max-w-lg mx-auto p-4">
+          <Link
+            href="/login"
+            className="block w-full bg-white text-primary font-bold py-3 rounded-lg text-center shadow-lg hover:bg-gray-50 transition-colors"
+          >
+            会員登録して応募する
+          </Link>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,33 @@
+import { MetadataRoute } from 'next';
+
+/**
+ * robots.txt を動的に生成
+ * - /public/ 配下は許可（SEO用公開ページ）
+ * - その他の認証必要ページは禁止
+ */
+export default function robots(): MetadataRoute.Robots {
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://share-worker-app.vercel.app';
+
+    return {
+        rules: [
+            {
+                userAgent: '*',
+                allow: ['/public/'],
+                disallow: [
+                    '/admin/',
+                    '/system-admin/',
+                    '/mypage/',
+                    '/messages/',
+                    '/my-jobs/',
+                    '/bookmarks/',
+                    '/application-complete/',
+                    '/login',
+                    '/register/',
+                    '/password-reset/',
+                    '/api/',
+                ],
+            },
+        ],
+        sitemap: `${baseUrl}/sitemap.xml`,
+    };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,38 @@
+import { MetadataRoute } from 'next';
+import { getPublicJobsForSitemap } from '@/src/lib/actions/job-public';
+
+/**
+ * sitemap.xml を動的に生成
+ * - 公開中の通常求人のみを含む
+ * - 求人の更新日時を lastModified に設定
+ */
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://share-worker-app.vercel.app';
+
+    // 静的ページ
+    const staticPages: MetadataRoute.Sitemap = [
+        {
+            url: baseUrl,
+            lastModified: new Date(),
+            changeFrequency: 'daily',
+            priority: 1.0,
+        },
+    ];
+
+    // 公開求人ページ
+    try {
+        const jobs = await getPublicJobsForSitemap();
+
+        const jobPages: MetadataRoute.Sitemap = jobs.map((job) => ({
+            url: `${baseUrl}/public/jobs/${job.id}`,
+            lastModified: job.lastModified,
+            changeFrequency: 'daily' as const,
+            priority: 0.8,
+        }));
+
+        return [...staticPages, ...jobPages];
+    } catch (error) {
+        console.error('Error generating sitemap:', error);
+        return staticPages;
+    }
+}

--- a/components/layout/WorkerLayout.tsx
+++ b/components/layout/WorkerLayout.tsx
@@ -23,6 +23,7 @@ const EXCLUDED_PREFIXES = [
   '/system-admin/',
   '/register/',
   '/password-reset/',
+  '/public/',  // SEO用公開ページ
 ];
 
 export function WorkerLayout({ children }: WorkerLayoutProps) {

--- a/src/lib/actions/job-public.ts
+++ b/src/lib/actions/job-public.ts
@@ -1,0 +1,163 @@
+'use server';
+
+import { prisma } from '@/lib/prisma';
+import { getCurrentTime } from '@/utils/debugTime';
+import { getJSTTodayStart, normalizeToJSTDayStart } from '@/utils/debugTime.server';
+
+/**
+ * 公開用求人詳細を取得
+ * - 認証不要
+ * - NORMAL求人のみ（限定・指名求人は除外）
+ * - 公開中の求人のみ
+ */
+export async function getPublicJobById(id: string) {
+    const jobId = parseInt(id, 10);
+
+    if (isNaN(jobId)) {
+        return null;
+    }
+
+    const now = getCurrentTime();
+    const todayStart = getJSTTodayStart(now);
+
+    const job = await prisma.job.findUnique({
+        where: {
+            id: jobId,
+            // 公開中かつ通常求人のみ
+            status: 'PUBLISHED',
+            job_type: 'NORMAL',
+        },
+        include: {
+            facility: {
+                select: {
+                    id: true,
+                    facility_name: true,
+                    prefecture: true,
+                    city: true,
+                    address: true,
+                    address_line: true,
+                    description: true,
+                    images: true,
+                    lat: true,
+                    lng: true,
+                },
+            },
+            workDates: {
+                orderBy: { work_date: 'asc' },
+                where: {
+                    AND: [
+                        // 募集開始日時を過ぎている
+                        {
+                            OR: [
+                                { visible_from: { lte: now } },
+                                { visible_from: null }
+                            ]
+                        },
+                        // 表示期限内
+                        {
+                            OR: [
+                                { visible_until: { gte: now } },
+                                { visible_until: null }
+                            ]
+                        }
+                    ]
+                }
+            },
+        },
+    });
+
+    if (!job) {
+        return null;
+    }
+
+    // 今日以降の勤務日のみフィルタリング
+    const futureWorkDates = job.workDates.filter(wd => {
+        const workDate = normalizeToJSTDayStart(new Date(wd.work_date));
+        return workDate >= todayStart;
+    });
+
+    // 勤務日がない場合は非公開
+    if (futureWorkDates.length === 0) {
+        return null;
+    }
+
+    // 一番近い勤務日
+    const nearestWorkDate = futureWorkDates[0];
+
+    // 総数を計算
+    const totalRecruitmentCount = futureWorkDates.reduce((sum, wd) => sum + wd.recruitment_count, 0);
+    const totalMatchedCount = futureWorkDates.reduce((sum, wd) => sum + wd.matched_count, 0);
+    const remainingSlots = totalRecruitmentCount - totalMatchedCount;
+
+    return {
+        id: job.id,
+        title: job.title,
+        description: job.overview,
+        qualifications: job.required_qualifications,
+        work_content: job.work_content,
+        hourly_wage: job.hourly_wage,
+        transportation_fee: job.transportation_fee,
+        start_time: job.start_time,
+        end_time: job.end_time,
+        break_time: job.break_time,
+        images: job.images,
+        requires_interview: job.requires_interview,
+
+        // 日程関連
+        work_date: nearestWorkDate.work_date.toISOString(),
+        deadline: nearestWorkDate.deadline.toISOString(),
+        recruitment_count: totalRecruitmentCount,
+        remaining_slots: remainingSlots > 0 ? remainingSlots : 0,
+
+        // 勤務日一覧
+        workDates: futureWorkDates.map((wd) => ({
+            id: wd.id,
+            work_date: wd.work_date.toISOString(),
+            deadline: wd.deadline.toISOString(),
+            recruitment_count: wd.recruitment_count,
+            matched_count: wd.matched_count,
+            remaining: wd.recruitment_count - wd.matched_count,
+        })),
+
+        // 施設情報
+        facility: {
+            id: job.facility.id,
+            name: job.facility.facility_name,
+            prefecture: job.facility.prefecture,
+            city: job.facility.city,
+            address: job.facility.address,
+            address_line: job.facility.address_line,
+            description: job.facility.description,
+            images: job.facility.images,
+            lat: job.facility.lat,
+            lng: job.facility.lng,
+        },
+
+        created_at: job.created_at.toISOString(),
+        updated_at: job.updated_at.toISOString(),
+    };
+}
+
+/**
+ * 公開用求人一覧を取得（サイトマップ用）
+ */
+export async function getPublicJobsForSitemap() {
+    const jobs = await prisma.job.findMany({
+        where: {
+            status: 'PUBLISHED',
+            job_type: 'NORMAL',
+        },
+        select: {
+            id: true,
+            updated_at: true,
+        },
+        orderBy: {
+            updated_at: 'desc',
+        },
+    });
+
+    return jobs.map(job => ({
+        id: job.id,
+        lastModified: job.updated_at,
+    }));
+}


### PR DESCRIPTION
## Summary
- `/public/jobs/[id]` で公開用求人詳細ページを追加（認証不要）
- 動的 `robots.txt`、`sitemap.xml` を追加
- OGP/メタデータを動的生成
- NORMAL求人のみ公開（限定・指名求人は404）

## 変更ファイル
- `app/public/layout.tsx` - 公開ページ用レイアウト（ロゴ+CTA）
- `app/public/jobs/[id]/page.tsx` - 公開求人詳細ページ
- `app/robots.ts` - 動的robots.txt
- `app/sitemap.ts` - 動的サイトマップ
- `src/lib/actions/job-public.ts` - 公開用データ取得関数
- `components/layout/WorkerLayout.tsx` - /public/を除外パスに追加

## Test plan
- [ ] `/public/jobs/[id]` にアクセスして求人詳細が表示されること
- [ ] ヘッダーにロゴのみ、フッターにCTAボタンが表示されること
- [ ] 限定・指名求人のIDでアクセスすると404になること
- [ ] `/robots.txt` の内容を確認
- [ ] `/sitemap.xml` に公開求人が含まれること
- [ ] OGPデバッガーでメタタグが正しいこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)