### PR TITLE
fix: SEO公開パスをmiddlewareに追加＆動的URL生成

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,12 +1,17 @@
 import { MetadataRoute } from 'next';
+import { headers } from 'next/headers';
 
 /**
  * robots.txt を動的に生成
  * - /public/ 配下は許可（SEO用公開ページ）
  * - その他の認証必要ページは禁止
  */
-export default function robots(): MetadataRoute.Robots {
-    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://share-worker-app.vercel.app';
+export default async function robots(): Promise<MetadataRoute.Robots> {
+    // リクエストのホストからベースURLを取得
+    const headersList = await headers();
+    const host = headersList.get('host') || '';
+    const protocol = host.includes('localhost') ? 'http' : 'https';
+    const baseUrl = host ? `${protocol}://${host}` : (process.env.NEXT_PUBLIC_BASE_URL || 'https://share-worker-app.vercel.app');
 
     return {
         rules: [

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,4 +1,5 @@
 import { MetadataRoute } from 'next';
+import { headers } from 'next/headers';
 import { getPublicJobsForSitemap } from '@/src/lib/actions/job-public';
 
 /**
@@ -7,7 +8,11 @@ import { getPublicJobsForSitemap } from '@/src/lib/actions/job-public';
  * - 求人の更新日時を lastModified に設定
  */
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://share-worker-app.vercel.app';
+    // リクエストのホストからベースURLを取得（環境変数のフォールバック付き）
+    const headersList = await headers();
+    const host = headersList.get('host') || '';
+    const protocol = host.includes('localhost') ? 'http' : 'https';
+    const baseUrl = host ? `${protocol}://${host}` : (process.env.NEXT_PUBLIC_BASE_URL || 'https://share-worker-app.vercel.app');
 
     // 静的ページ
     const staticPages: MetadataRoute.Sitemap = [

--- a/middleware.ts
+++ b/middleware.ts
@@ -15,6 +15,9 @@ const publicPaths = [
   '/terms',
   '/privacy',
   '/contact',
+  '/public', // SEO用公開ページ
+  '/robots.txt', // SEO: robots.txt
+  '/sitemap.xml', // SEO: サイトマップ
 ];
 
 // 静的ファイルとAPI認証エンドポイント


### PR DESCRIPTION
## Summary
- `/public`, `/robots.txt`, `/sitemap.xml` を認証不要パスに追加
- sitemap.ts, robots.ts でリクエストホストから動的にURLを生成（ステージング/本番で正しいURLになる）

## 問題
PR #112 で追加したSEOページが、middlewareで認証必須になっていたためログインにリダイレクトされていた。

## 修正内容
1. `middleware.ts`: publicPathsに `/public`, `/robots.txt`, `/sitemap.xml` を追加
2. `app/sitemap.ts`: `headers()` でホストを取得し動的にbaseURLを生成
3. `app/robots.ts`: 同上

## Test plan
- [ ] `/robots.txt` にアクセスして内容が表示されること
- [ ] `/sitemap.xml` にアクセスしてXMLが表示されること
- [ ] `/public/jobs/[id]` にアクセスして求人詳細が表示されること
- [ ] sitemap.xmlのURLがアクセス先のホスト名になっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)