### PR TITLE
feat: 公開求人ページに労働条件通知書プレビューを追加

### DIFF
--- a/app/public/jobs/[id]/labor-document/page.tsx
+++ b/app/public/jobs/[id]/labor-document/page.tsx
@@ -1,0 +1,280 @@
+import { getPublicLaborDocumentPreview } from '@/src/lib/actions/job-public';
+import Link from 'next/link';
+import { ChevronLeft, Info } from 'lucide-react';
+import { notFound } from 'next/navigation';
+import { DEFAULT_DISMISSAL_REASONS } from '@/constants/employment';
+import { Metadata } from 'next';
+
+// 日付フォーマット関数
+function formatDate(dateString: string): string {
+    const date = new Date(dateString);
+    const year = date.getFullYear();
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+    return `${year}年${month}月${day}日`;
+}
+
+// 時刻フォーマット関数
+function formatTime(timeString: string): string {
+    return timeString.substring(0, 5);
+}
+
+interface Props {
+    params: Promise<{ id: string }>;
+}
+
+// メタデータ生成
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+    const { id } = await params;
+    const data = await getPublicLaborDocumentPreview(id);
+
+    if (!data) {
+        return {
+            title: '労働条件通知書が見つかりません | +TASTAS',
+            robots: { index: false, follow: false },
+        };
+    }
+
+    return {
+        title: `労働条件通知書 - ${data.job.title} | +TASTAS`,
+        description: `${data.facility.facility_name}の求人「${data.job.title}」の労働条件通知書プレビュー。時給${data.job.hourly_wage.toLocaleString()}円、勤務時間${data.job.start_time}〜${data.job.end_time}。`,
+        robots: {
+            index: true,
+            follow: true,
+        },
+    };
+}
+
+export default async function PublicLaborDocumentPage({ params }: Props) {
+    const { id } = await params;
+    const data = await getPublicLaborDocumentPreview(id);
+
+    if (!data) {
+        notFound();
+    }
+
+    const { job, facility, sampleWorkDate, dismissalReasons } = data;
+
+    return (
+        <div className="min-h-screen bg-gray-50 pb-24">
+            {/* ヘッダー */}
+            <div className="bg-white sticky top-0 z-10 border-b border-gray-200">
+                <div className="px-4 py-3 flex items-center">
+                    <Link href={`/public/jobs/${id}`} className="mr-4">
+                        <ChevronLeft className="w-6 h-6" />
+                    </Link>
+                    <h1 className="text-lg font-bold">労働条件通知書（プレビュー）</h1>
+                </div>
+            </div>
+
+            {/* プレビュー説明 */}
+            <div className="mx-4 mt-4 p-3 bg-blue-50 border border-blue-200 rounded-lg flex items-start gap-2">
+                <Info className="w-5 h-5 text-blue-500 shrink-0 mt-0.5" />
+                <p className="text-sm text-blue-700">
+                    これは労働条件通知書のプレビューです。会員登録・応募後、マッチング成立時にあなたの氏名が記載された正式な労働条件通知書が発行されます。
+                </p>
+            </div>
+
+            {/* 労働条件通知書本文 */}
+            <div className="p-4">
+                <div className="bg-white rounded-lg shadow-sm p-6 space-y-6 print:shadow-none">
+                    {/* タイトル */}
+                    <div className="text-center border-b pb-4">
+                        <h2 className="text-xl font-bold">労働条件通知書</h2>
+                        <p className="text-sm text-gray-400 mt-2">
+                            （プレビュー）
+                        </p>
+                    </div>
+
+                    {/* 使用者情報 */}
+                    <section className="space-y-3">
+                        <h3 className="font-bold text-lg border-l-4 border-primary pl-3">使用者情報</h3>
+                        <div className="grid grid-cols-1 gap-2 text-sm">
+                            <div className="flex">
+                                <span className="text-gray-600 w-32 shrink-0">使用者法人名</span>
+                                <span className="font-medium">{facility.corporation_name}</span>
+                            </div>
+                            <div className="flex">
+                                <span className="text-gray-600 w-32 shrink-0">法人所在地</span>
+                                <span className="font-medium">
+                                    {facility.prefecture || ''}{facility.city || ''}{facility.address_detail || facility.address}
+                                </span>
+                            </div>
+                            <div className="flex">
+                                <span className="text-gray-600 w-32 shrink-0">事業所名称</span>
+                                <span className="font-medium">{facility.facility_name}</span>
+                            </div>
+                            <div className="flex">
+                                <span className="text-gray-600 w-32 shrink-0">就業場所</span>
+                                <span className="font-medium">{job.address}</span>
+                            </div>
+                        </div>
+                    </section>
+
+                    {/* 労働者情報 - 空欄 */}
+                    <section className="space-y-3">
+                        <h3 className="font-bold text-lg border-l-4 border-primary pl-3">労働者情報</h3>
+                        <div className="grid grid-cols-1 gap-2 text-sm">
+                            <div className="flex">
+                                <span className="text-gray-600 w-32 shrink-0">労働者氏名</span>
+                                <span className="text-gray-400 italic">（マッチング後に表示）</span>
+                            </div>
+                        </div>
+                    </section>
+
+                    {/* 契約情報 */}
+                    <section className="space-y-3">
+                        <h3 className="font-bold text-lg border-l-4 border-primary pl-3">契約情報</h3>
+                        <div className="grid grid-cols-1 gap-2 text-sm">
+                            <div className="flex">
+                                <span className="text-gray-600 w-32 shrink-0">就労日</span>
+                                <span className="font-medium">
+                                    {sampleWorkDate ? formatDate(sampleWorkDate) : '（応募時に選択）'}
+                                </span>
+                            </div>
+                            <div className="flex">
+                                <span className="text-gray-600 w-32 shrink-0">労働契約の期間</span>
+                                <span className="font-medium">1日（単発契約）</span>
+                            </div>
+                            <div className="flex">
+                                <span className="text-gray-600 w-32 shrink-0">契約更新の有無</span>
+                                <span className="font-medium">有（ただし条件あり、都度契約）</span>
+                            </div>
+                        </div>
+                    </section>
+
+                    {/* 業務内容 */}
+                    <section className="space-y-3">
+                        <h3 className="font-bold text-lg border-l-4 border-primary pl-3">業務内容</h3>
+                        <div className="text-sm">
+                            {job.work_content && job.work_content.length > 0 ? (
+                                <ul className="list-disc list-inside space-y-1">
+                                    {job.work_content.map((content: string, index: number) => (
+                                        <li key={index}>{content}</li>
+                                    ))}
+                                </ul>
+                            ) : (
+                                <p>{job.overview || '詳細は施設からの指示に従ってください'}</p>
+                            )}
+                        </div>
+                    </section>
+
+                    {/* 勤務時間 */}
+                    <section className="space-y-3">
+                        <h3 className="font-bold text-lg border-l-4 border-primary pl-3">勤務時間</h3>
+                        <div className="grid grid-cols-1 gap-2 text-sm">
+                            <div className="flex">
+                                <span className="text-gray-600 w-32 shrink-0">始業時刻</span>
+                                <span className="font-medium">{formatTime(job.start_time)}</span>
+                            </div>
+                            <div className="flex">
+                                <span className="text-gray-600 w-32 shrink-0">終業時刻</span>
+                                <span className="font-medium">{formatTime(job.end_time)}</span>
+                            </div>
+                            <div className="flex">
+                                <span className="text-gray-600 w-32 shrink-0">休憩時間</span>
+                                <span className="font-medium">{job.break_time}分</span>
+                            </div>
+                            <div className="flex">
+                                <span className="text-gray-600 w-32 shrink-0">所定時間外労働</span>
+                                <span className="font-medium">原則なし</span>
+                            </div>
+                        </div>
+                    </section>
+
+                    {/* 賃金 */}
+                    <section className="space-y-3">
+                        <h3 className="font-bold text-lg border-l-4 border-primary pl-3">賃金</h3>
+                        <div className="grid grid-cols-1 gap-2 text-sm">
+                            <div className="flex">
+                                <span className="text-gray-600 w-32 shrink-0">基本賃金</span>
+                                <span className="font-medium">時給 {job.hourly_wage.toLocaleString()}円</span>
+                            </div>
+                            <div className="flex">
+                                <span className="text-gray-600 w-32 shrink-0">日給合計</span>
+                                <span className="font-medium text-red-500">{job.wage.toLocaleString()}円</span>
+                            </div>
+                            <div className="flex">
+                                <span className="text-gray-600 w-32 shrink-0">諸手当（交通費）</span>
+                                <span className="font-medium">
+                                    {job.transportation_fee > 0
+                                        ? `${job.transportation_fee.toLocaleString()}円`
+                                        : 'なし'}
+                                </span>
+                            </div>
+                            <div className="flex">
+                                <span className="text-gray-600 w-32 shrink-0">時間外労働割増</span>
+                                <span className="font-medium">法定通り（25%増）</span>
+                            </div>
+                            <div className="flex">
+                                <span className="text-gray-600 w-32 shrink-0">賃金支払日</span>
+                                <span className="font-medium">翌月末日払い</span>
+                            </div>
+                            <div className="flex">
+                                <span className="text-gray-600 w-32 shrink-0">支払方法</span>
+                                <span className="font-medium">銀行振込</span>
+                            </div>
+                        </div>
+                    </section>
+
+                    {/* 社会保険等 */}
+                    <section className="space-y-3">
+                        <h3 className="font-bold text-lg border-l-4 border-primary pl-3">社会保険等</h3>
+                        <div className="text-sm">
+                            <p>単発契約のため、社会保険・雇用保険・労災保険の適用については、法定の要件に基づき判断されます。</p>
+                        </div>
+                    </section>
+
+                    {/* 持ち物・作業用品 */}
+                    {job.belongings && job.belongings.length > 0 && (
+                        <section className="space-y-3">
+                            <h3 className="font-bold text-lg border-l-4 border-primary pl-3">作業用品その他</h3>
+                            <div className="text-sm">
+                                <ul className="list-disc list-inside space-y-1">
+                                    {job.belongings.map((item: string, index: number) => (
+                                        <li key={index}>{item}</li>
+                                    ))}
+                                </ul>
+                            </div>
+                        </section>
+                    )}
+
+                    {/* 受動喫煙防止措置 */}
+                    <section className="space-y-3">
+                        <h3 className="font-bold text-lg border-l-4 border-primary pl-3">受動喫煙防止措置</h3>
+                        <div className="text-sm">
+                            <p>{facility.smoking_measure || '屋内禁煙（喫煙専用室あり）'}</p>
+                        </div>
+                    </section>
+
+                    {/* 解雇の事由 */}
+                    <section className="space-y-3">
+                        <h3 className="font-bold text-lg border-l-4 border-primary pl-3">解雇の事由その他関連する事項</h3>
+                        <div className="text-sm whitespace-pre-wrap bg-gray-50 p-4 rounded-lg">
+                            {dismissalReasons || DEFAULT_DISMISSAL_REASONS}
+                        </div>
+                    </section>
+
+                    {/* 誓約事項 */}
+                    <section className="space-y-3">
+                        <h3 className="font-bold text-lg border-l-4 border-primary pl-3">誓約事項</h3>
+                        <div className="text-sm bg-gray-50 p-4 rounded-lg">
+                            <ul className="list-decimal list-inside space-y-2">
+                                <li>業務上知り得た秘密は、在職中のみならず退職後においても第三者に漏洩いたしません。</li>
+                                <li>利用者様の個人情報は適切に取り扱い、プライバシーを尊重いたします。</li>
+                                <li>施設の規則・指示に従い、誠実に業務を遂行いたします。</li>
+                                <li>遅刻・早退・欠勤の際は、速やかに連絡いたします。</li>
+                            </ul>
+                        </div>
+                    </section>
+
+                    {/* フッター */}
+                    <div className="pt-6 border-t text-center text-sm text-gray-500">
+                        <p>本書は労働基準法第15条に基づき、労働条件を明示するものです。</p>
+                        <p className="mt-2">発行: +TASTAS</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/app/public/jobs/[id]/page.tsx
+++ b/app/public/jobs/[id]/page.tsx
@@ -4,7 +4,8 @@ import Image from 'next/image';
 import Script from 'next/script';
 import { headers } from 'next/headers';
 import { getPublicJobById } from '@/src/lib/actions/job-public';
-import { MapPin, Clock, JapaneseYen, Calendar, Users, Building2 } from 'lucide-react';
+import Link from 'next/link';
+import { MapPin, Clock, JapaneseYen, Calendar, Users, Building2, FileText } from 'lucide-react';
 
 interface PageProps {
     params: Promise<{ id: string }>;
@@ -358,6 +359,17 @@ export default async function PublicJobDetailPage({ params }: PageProps) {
                         <p className="text-gray-700 whitespace-pre-wrap">{job.description}</p>
                     </div>
                 )}
+
+                {/* 労働条件通知書プレビュー */}
+                <div>
+                    <Link
+                        href={`/public/jobs/${job.id}/labor-document`}
+                        className="flex items-center gap-2 px-3 py-2 text-sm text-primary border border-primary rounded-lg hover:bg-primary/5 transition-colors"
+                    >
+                        <FileText className="w-4 h-4" />
+                        労働条件通知書を確認
+                    </Link>
+                </div>
 
                 {/* 審査について */}
                 {job.requires_interview && (


### PR DESCRIPTION
## Summary
- 公開求人ページ `/public/jobs/[id]` から労働条件通知書のプレビューを閲覧可能に
- ログイン不要で閲覧可能（SEO対策の一環）

## 変更内容
- `/public/jobs/[id]/labor-document` ページを新規作成
- `getPublicLaborDocumentPreview` アクションを追加（公開求人のみ対象）
- 公開求人詳細ページに「労働条件通知書を確認」リンクを追加

## 仕様
- **URL**: `/public/jobs/[id]/labor-document`
- **認証**: 不要（ログインなしで閲覧可能）
- **制限**: `status = 'PUBLISHED'` かつ `job_type = 'NORMAL'` の求人のみ
- **労働者氏名**: 「（マッチング後に表示）」と表示（個人情報なし）

## 表示内容
- 使用者情報（法人名、所在地、事業所名、就業場所）
- 契約情報（就労日、契約期間、更新有無）
- 業務内容
- 勤務時間（始業・終業・休憩）
- 賃金（時給、日給、交通費）
- 社会保険等
- 受動喫煙防止措置
- 解雇の事由
- 誓約事項

## Test plan
- [ ] `/public/jobs/[id]` にアクセスし「労働条件通知書を確認」リンクが表示されることを確認
- [ ] リンクをクリックして `/public/jobs/[id]/labor-document` に遷移することを確認
- [ ] 労働者氏名が「（マッチング後に表示）」となっていることを確認
- [ ] 非公開求人・限定求人のIDでアクセスした場合に404になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)