### PR TITLE
feat: 銀行口座検索機能の実装（バックエンド + フロントエンド）

### DIFF
--- a/components/ui/BankSelector.tsx
+++ b/components/ui/BankSelector.tsx
@@ -1,0 +1,211 @@
+'use client';
+
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { X, Loader2, Search, Building2 } from 'lucide-react';
+
+// 銀行データ型
+interface Bank {
+  code: string;
+  name: string;
+  nameKana: string;
+  isMajor: boolean;
+}
+
+interface BankSelectorProps {
+  value: { code: string; name: string } | null;
+  onChange: (bank: { code: string; name: string } | null) => void;
+  required?: boolean;
+  showErrors?: boolean;
+  disabled?: boolean;
+}
+
+export default function BankSelector({
+  value,
+  onChange,
+  required = false,
+  showErrors = false,
+  disabled = false,
+}: BankSelectorProps) {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<Bank[]>([]);
+  const [majorBanks, setMajorBanks] = useState<Bank[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [isLoadingMajor, setIsLoadingMajor] = useState(true);
+  const [error, setError] = useState('');
+
+  // 主要銀行を取得
+  useEffect(() => {
+    const fetchMajorBanks = async () => {
+      try {
+        const response = await fetch('/api/bank/major');
+        if (response.ok) {
+          const data = await response.json();
+          setMajorBanks(data.banks || []);
+        }
+      } catch (err) {
+        console.error('主要銀行の取得に失敗:', err);
+      } finally {
+        setIsLoadingMajor(false);
+      }
+    };
+    fetchMajorBanks();
+  }, []);
+
+  // 銀行検索API呼び出し
+  const searchBanks = useCallback(async (query: string) => {
+    if (!query || query.length < 2) {
+      setSearchResults([]);
+      return;
+    }
+
+    setIsSearching(true);
+    setError('');
+
+    try {
+      const response = await fetch(`/api/bank/search?q=${encodeURIComponent(query)}`);
+      if (response.ok) {
+        const data = await response.json();
+        setSearchResults(data.banks || []);
+        if (data.banks?.length === 0) {
+          setError('該当する銀行が見つかりませんでした');
+        }
+      } else {
+        setError('検索に失敗しました');
+      }
+    } catch (err) {
+      console.error('銀行検索エラー:', err);
+      setError('検索に失敗しました');
+    } finally {
+      setIsSearching(false);
+    }
+  }, []);
+
+  // デバウンス検索（useEffect + setTimeout）
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      searchBanks(searchQuery);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [searchQuery, searchBanks]);
+
+  // 銀行選択
+  const handleSelectBank = (bank: Bank) => {
+    onChange({ code: bank.code, name: bank.name });
+    setSearchQuery('');
+    setSearchResults([]);
+    setError('');
+  };
+
+  // 選択解除
+  const handleClear = () => {
+    onChange(null);
+  };
+
+  // 表示する銀行リスト（検索結果または主要銀行）
+  const displayBanks = searchQuery.length >= 2 ? searchResults : majorBanks;
+
+  return (
+    <div className="space-y-2">
+      {/* 選択済み表示 */}
+      {value && (
+        <div className="flex items-center gap-2 mb-2">
+          <span className="inline-flex items-center gap-2 px-3 py-1.5 bg-indigo-100 text-indigo-700 text-sm rounded-lg">
+            <Building2 className="w-4 h-4" />
+            {value.name}
+            <span className="text-xs text-indigo-500">({value.code})</span>
+            {!disabled && (
+              <button
+                type="button"
+                onClick={handleClear}
+                className="hover:text-indigo-900 ml-1"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            )}
+          </span>
+        </div>
+      )}
+
+      {/* 検索入力 */}
+      {!value && !disabled && (
+        <>
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-slate-400" />
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className={`w-full pl-9 pr-4 py-2 text-sm border rounded-lg ${
+                showErrors && required && !value
+                  ? 'border-red-500 bg-red-50'
+                  : 'border-slate-300'
+              }`}
+              placeholder="銀行名で検索（2文字以上）..."
+            />
+            {isSearching && (
+              <Loader2 className="absolute right-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-primary animate-spin" />
+            )}
+          </div>
+
+          {/* エラー表示 */}
+          {error && (
+            <p className="text-xs text-red-500">{error}</p>
+          )}
+
+          {/* 銀行リスト */}
+          <div className={`border rounded-lg max-h-48 overflow-y-auto ${
+            showErrors && required && !value ? 'border-red-500' : 'border-slate-300'
+          }`}>
+            {isLoadingMajor && !searchQuery ? (
+              <div className="flex items-center justify-center p-4">
+                <Loader2 className="w-5 h-5 text-slate-400 animate-spin" />
+              </div>
+            ) : displayBanks.length === 0 ? (
+              <div className="p-4 text-center text-sm text-slate-500">
+                {searchQuery.length >= 2
+                  ? '検索結果がありません'
+                  : searchQuery.length > 0
+                  ? '2文字以上入力してください'
+                  : '主要銀行を読み込み中...'}
+              </div>
+            ) : (
+              <div className="divide-y divide-slate-100">
+                {!searchQuery && (
+                  <div className="px-3 py-2 bg-slate-50 text-xs font-medium text-slate-600">
+                    主要銀行
+                  </div>
+                )}
+                {displayBanks.map((bank) => (
+                  <button
+                    key={bank.code}
+                    type="button"
+                    onClick={() => handleSelectBank(bank)}
+                    className="w-full px-3 py-2 text-left text-sm hover:bg-slate-50 flex items-center justify-between"
+                  >
+                    <span className="font-medium text-slate-700">{bank.name}</span>
+                    <span className="text-xs text-slate-400">{bank.code}</span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* バリデーションエラー */}
+          {showErrors && required && !value && (
+            <p className="text-red-500 text-xs">銀行を選択してください</p>
+          )}
+        </>
+      )}
+
+      {/* disabled状態で未選択 */}
+      {!value && disabled && (
+        <input
+          type="text"
+          disabled
+          className="w-full px-3 py-2 text-sm border border-slate-200 rounded-lg bg-slate-50 text-slate-400"
+          placeholder="銀行を選択してください"
+        />
+      )}
+    </div>
+  );
+}

--- a/components/ui/BranchSelector.tsx
+++ b/components/ui/BranchSelector.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { X, Loader2, Search, MapPin } from 'lucide-react';
+
+// 支店データ型
+interface Branch {
+  code: string;
+  name: string;
+  nameKana: string;
+}
+
+interface BranchSelectorProps {
+  bankCode: string | null; // 選択された銀行コード
+  value: { code: string; name: string } | null;
+  onChange: (branch: { code: string; name: string } | null) => void;
+  required?: boolean;
+  showErrors?: boolean;
+  disabled?: boolean;
+}
+
+export default function BranchSelector({
+  bankCode,
+  value,
+  onChange,
+  required = false,
+  showErrors = false,
+  disabled = false,
+}: BranchSelectorProps) {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [branches, setBranches] = useState<Branch[]>([]);
+  const [filteredBranches, setFilteredBranches] = useState<Branch[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  // 銀行コードが変更されたら支店リストを取得
+  useEffect(() => {
+    if (!bankCode) {
+      setBranches([]);
+      setFilteredBranches([]);
+      onChange(null);
+      return;
+    }
+
+    const fetchBranches = async () => {
+      setIsLoading(true);
+      setError('');
+
+      try {
+        const response = await fetch(`/api/bank/${bankCode}/branches`);
+        if (response.ok) {
+          const data = await response.json();
+          setBranches(data.branches || []);
+          setFilteredBranches((data.branches || []).slice(0, 50));
+        } else {
+          setError('支店一覧の取得に失敗しました');
+        }
+      } catch (err) {
+        console.error('支店取得エラー:', err);
+        setError('支店一覧の取得に失敗しました');
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchBranches();
+  }, [bankCode, onChange]);
+
+  // 検索フィルタリング
+  const filterBranches = useCallback((query: string) => {
+    if (!query) {
+      setFilteredBranches(branches.slice(0, 50));
+      return;
+    }
+
+    const filtered = branches.filter(
+      (branch) =>
+        branch.name.toLowerCase().includes(query.toLowerCase()) ||
+        branch.nameKana.toLowerCase().includes(query.toLowerCase()) ||
+        branch.code.includes(query)
+    );
+    setFilteredBranches(filtered);
+  }, [branches]);
+
+  // デバウンスフィルタリング（useEffect + setTimeout）
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      filterBranches(searchQuery);
+    }, 200);
+    return () => clearTimeout(timer);
+  }, [searchQuery, filterBranches]);
+
+  // 支店選択
+  const handleSelectBranch = (branch: Branch) => {
+    onChange({ code: branch.code, name: branch.name });
+    setSearchQuery('');
+  };
+
+  // 選択解除
+  const handleClear = () => {
+    onChange(null);
+  };
+
+  // 銀行未選択時
+  if (!bankCode) {
+    return (
+      <div className="space-y-2">
+        <input
+          type="text"
+          disabled
+          className={`w-full px-3 py-2 text-sm border rounded-lg bg-slate-50 text-slate-400 ${
+            showErrors && required ? 'border-red-500' : 'border-slate-200'
+          }`}
+          placeholder="先に銀行を選択してください"
+        />
+        {showErrors && required && (
+          <p className="text-red-500 text-xs">支店を選択してください</p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {/* 選択済み表示 */}
+      {value && (
+        <div className="flex items-center gap-2 mb-2">
+          <span className="inline-flex items-center gap-2 px-3 py-1.5 bg-emerald-100 text-emerald-700 text-sm rounded-lg">
+            <MapPin className="w-4 h-4" />
+            {value.name}
+            <span className="text-xs text-emerald-500">({value.code})</span>
+            {!disabled && (
+              <button
+                type="button"
+                onClick={handleClear}
+                className="hover:text-emerald-900 ml-1"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            )}
+          </span>
+        </div>
+      )}
+
+      {/* 検索入力 */}
+      {!value && !disabled && (
+        <>
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-slate-400" />
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className={`w-full pl-9 pr-4 py-2 text-sm border rounded-lg ${
+                showErrors && required && !value
+                  ? 'border-red-500 bg-red-50'
+                  : 'border-slate-300'
+              }`}
+              placeholder="支店名で検索..."
+              disabled={isLoading}
+            />
+            {isLoading && (
+              <Loader2 className="absolute right-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-primary animate-spin" />
+            )}
+          </div>
+
+          {/* エラー表示 */}
+          {error && (
+            <p className="text-xs text-red-500">{error}</p>
+          )}
+
+          {/* 支店リスト */}
+          <div className={`border rounded-lg max-h-48 overflow-y-auto ${
+            showErrors && required && !value ? 'border-red-500' : 'border-slate-300'
+          }`}>
+            {isLoading ? (
+              <div className="flex items-center justify-center p-4">
+                <Loader2 className="w-5 h-5 text-slate-400 animate-spin" />
+                <span className="ml-2 text-sm text-slate-500">支店一覧を取得中...</span>
+              </div>
+            ) : filteredBranches.length === 0 ? (
+              <div className="p-4 text-center text-sm text-slate-500">
+                {searchQuery
+                  ? '検索結果がありません'
+                  : branches.length === 0
+                  ? '支店情報がありません'
+                  : '支店を検索してください'}
+              </div>
+            ) : (
+              <div className="divide-y divide-slate-100">
+                {!searchQuery && branches.length > 50 && (
+                  <div className="px-3 py-2 bg-slate-50 text-xs font-medium text-slate-600">
+                    {branches.length}件中50件表示（検索で絞り込み可能）
+                  </div>
+                )}
+                {filteredBranches.map((branch) => (
+                  <button
+                    key={branch.code}
+                    type="button"
+                    onClick={() => handleSelectBranch(branch)}
+                    className="w-full px-3 py-2 text-left text-sm hover:bg-slate-50 flex items-center justify-between"
+                  >
+                    <span className="font-medium text-slate-700">{branch.name}</span>
+                    <span className="text-xs text-slate-400">{branch.code}</span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* バリデーションエラー */}
+          {showErrors && required && !value && (
+            <p className="text-red-500 text-xs">支店を選択してください</p>
+          )}
+        </>
+      )}
+
+      {/* disabled状態で未選択 */}
+      {!value && disabled && (
+        <input
+          type="text"
+          disabled
+          className="w-full px-3 py-2 text-sm border border-slate-200 rounded-lg bg-slate-50 text-slate-400"
+          placeholder="支店を選択してください"
+        />
+      )}
+    </div>
+  );
+}

--- a/constants/features.ts
+++ b/constants/features.ts
@@ -1,0 +1,30 @@
+/**
+ * フィーチャーフラグ設定
+ *
+ * 新機能のリリース管理に使用
+ * 環境変数でオーバーライド可能
+ */
+
+export const FEATURE_FLAGS = {
+  /**
+   * 銀行口座検索機能
+   * true: 新しい検索ベースのUIを使用
+   * false: 従来のテキスト入力UIを使用
+   */
+  BANK_SEARCH_ENABLED: process.env.NEXT_PUBLIC_ENABLE_BANK_SEARCH === 'true',
+} as const;
+
+/**
+ * フィーチャーフラグのデフォルト値
+ * 環境変数が未設定の場合に使用
+ */
+export const FEATURE_DEFAULTS = {
+  BANK_SEARCH_ENABLED: false,
+} as const;
+
+/**
+ * フィーチャーフラグを取得するヘルパー関数
+ */
+export function isFeatureEnabled(featureName: keyof typeof FEATURE_FLAGS): boolean {
+  return FEATURE_FLAGS[featureName] ?? FEATURE_DEFAULTS[featureName] ?? false;
+}

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -7,3 +7,4 @@ export * from './time';
 export * from './salary';
 export * from './templates';
 export * from './employment';
+export * from './features';


### PR DESCRIPTION
## Summary
- 銀行・支店マスタデータのDB管理（Bank/Branch/BankAccountモデル）
- 銀行検索API（ローカルDB + BankcodeJP API フォールバック）
- 週次Cronジョブでデータ自動更新
- プロフィール画面に銀行・支店検索UIを実装
- フィーチャーフラグで新旧UI切り替え可能

## 変更内容

### バックエンド
- `prisma/schema.prisma`: Bank, Branch, BankAccountモデル追加
- `app/api/bank/search/route.ts`: 銀行検索API
- `app/api/bank/major/route.ts`: 主要銀行取得API
- `app/api/bank/[bankCode]/branches/route.ts`: 支店取得API
- `app/api/cron/update-bank-data/route.ts`: 週次更新Cron
- `lib/bankcode-jp.ts`: BankcodeJP APIクライアント
- `vercel.json`: Cronジョブ設定追加

### フロントエンド
- `components/ui/BankSelector.tsx`: 銀行検索・選択コンポーネント
- `components/ui/BranchSelector.tsx`: 支店検索・選択コンポーネント
- `constants/features.ts`: フィーチャーフラグ設定
- `app/mypage/profile/ProfileEditClient.tsx`: 条件分岐UI実装

## フィーチャーフラグ
新機能を有効にするには環境変数を設定:
```
NEXT_PUBLIC_ENABLE_BANK_SEARCH=true
```

## Test plan
- [ ] 開発環境でフィーチャーフラグOFFの状態で従来UIが表示されることを確認
- [ ] フィーチャーフラグONで新しい検索UIが表示されることを確認
- [ ] 銀行検索が動作することを確認
- [ ] 支店検索が動作することを確認
- [ ] プロフィール保存が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)