### PR TITLE
fix: 銀行再選択時に支店入力フォームが表示されない問題を修正

### DIFF
--- a/components/ui/BranchSelector.tsx
+++ b/components/ui/BranchSelector.tsx
@@ -228,7 +228,7 @@ export default function BranchSelector({
       )}
 
       {/* 検索入力 */}
-      {!value && !showLegacy && !disabled && (
+      {!value && (!showLegacy || !legacyName) && !disabled && (
         <>
           <div className="relative">
             <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-slate-400" />


### PR DESCRIPTION
## Summary
- 銀行を再選択した際、支店名がリセットされても検索フォームが表示されなくなる問題を修正

## 原因
- `showLegacy`がuseStateで初期化されるため、`legacyName`が空になっても`true`のまま残る
- 結果、検索フォームの表示条件`!showLegacy`がfalseになり、何も表示されない

## 修正内容
```tsx
// Before
{!value && !showLegacy && !disabled && (

// After
{!value && (!showLegacy || !legacyName) && !disabled && (
```

## Test plan
- [ ] 既存の銀行名データがある状態でプロフィール編集を開く
- [ ] 銀行を再選択する
- [ ] 支店名の入力フォームが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)