### PR TITLE
refactor: 公開版求人詳細ページでJobDetailClientを共有利用

### DIFF
--- a/app/public/jobs/[id]/page.tsx
+++ b/app/public/jobs/[id]/page.tsx
@@ -1,23 +1,12 @@
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
-import Image from 'next/image';
 import Script from 'next/script';
 import { headers } from 'next/headers';
 import { getPublicJobById } from '@/src/lib/actions/job-public';
-import Link from 'next/link';
-import { MapPin, Clock, JapaneseYen, Calendar, Users, Building2, FileText } from 'lucide-react';
+import { JobDetailClient } from '@/components/job/JobDetailClient';
 
 interface PageProps {
     params: Promise<{ id: string }>;
-}
-
-interface WorkDateItem {
-    id: number;
-    work_date: string;
-    deadline: string;
-    recruitment_count: number;
-    matched_count: number;
-    remaining: number;
 }
 
 // OGP/メタデータを動的に生成
@@ -109,7 +98,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
 export default async function PublicJobDetailPage({ params }: PageProps) {
     const { id } = await params;
-    const job = await getPublicJobById(id);
+    const jobData = await getPublicJobById(id);
 
     // ベースURL取得
     const headersList = await headers();
@@ -117,86 +106,49 @@ export default async function PublicJobDetailPage({ params }: PageProps) {
     const protocol = host.includes('localhost') ? 'http' : 'https';
     const baseUrl = host ? `${protocol}://${host}` : 'https://share-worker-app.vercel.app';
 
-    if (!job) {
+    if (!jobData) {
         notFound();
     }
 
-    // 勤務時間計算
-    const calculateWorkHours = () => {
-        if (!job.start_time || !job.end_time) return null;
-        const [startH, startM] = job.start_time.split(':').map(Number);
-        const [endH, endM] = job.end_time.split(':').map(Number);
-        let totalMinutes = (endH * 60 + endM) - (startH * 60 + startM);
-        if (totalMinutes < 0) totalMinutes += 24 * 60; // 日跨ぎ対応
-        const breakMinutes = Number(job.break_time) || 0;
-        const workMinutes = totalMinutes - breakMinutes;
-        const hours = Math.floor(workMinutes / 60);
-        const minutes = workMinutes % 60;
-        return minutes > 0 ? `${hours}時間${minutes}分` : `${hours}時間`;
-    };
-
-    // 日給計算
-    const calculateDailyWage = () => {
-        if (!job.start_time || !job.end_time || !job.hourly_wage) return null;
-        const [startH, startM] = job.start_time.split(':').map(Number);
-        const [endH, endM] = job.end_time.split(':').map(Number);
-        let totalMinutes = (endH * 60 + endM) - (startH * 60 + startM);
-        if (totalMinutes < 0) totalMinutes += 24 * 60;
-        const breakMinutes = Number(job.break_time) || 0;
-        const workMinutes = totalMinutes - breakMinutes;
-        const workHours = workMinutes / 60;
-        return Math.floor(job.hourly_wage * workHours);
-    };
-
-    const workHours = calculateWorkHours();
-    const dailyWage = calculateDailyWage();
-
-    // 勤務日のフォーマット
-    const formatWorkDate = (dateStr: string) => {
-        const date = new Date(dateStr);
-        const weekdays = ['日', '月', '火', '水', '木', '金', '土'];
-        return `${date.getMonth() + 1}/${date.getDate()}(${weekdays[date.getDay()]})`;
-    };
-
     // 職種名（資格から推定）
-    const jobType = job.qualifications?.length > 0
-        ? job.qualifications[0]
+    const jobType = jobData.qualifications?.length > 0
+        ? jobData.qualifications[0]
         : '介護・看護スタッフ';
 
     // Google for Jobs 構造化データ (JSON-LD)
     const jobPostingJsonLd = {
         '@context': 'https://schema.org/',
         '@type': 'JobPosting',
-        title: job.title,
-        description: job.description || `${job.facility.name}での${jobType}のお仕事です。`,
+        title: jobData.title,
+        description: jobData.description || `${jobData.facility.name}での${jobType}のお仕事です。`,
         identifier: {
             '@type': 'PropertyValue',
             name: '+TASTAS',
-            value: `tastas-job-${job.id}`,
+            value: `tastas-job-${jobData.id}`,
         },
-        datePosted: job.created_at,
-        validThrough: job.workDates[job.workDates.length - 1]?.work_date || job.work_date,
+        datePosted: jobData.created_at,
+        validThrough: jobData.workDates[jobData.workDates.length - 1]?.work_date || jobData.work_date,
         employmentType: 'TEMPORARY',
         hiringOrganization: {
             '@type': 'Organization',
-            name: job.facility.name,
-            sameAs: `${baseUrl}/public/facilities/${job.facility.id}`,
-            logo: job.facility.images?.[0] || `${baseUrl}/images/logo.png`,
+            name: jobData.facility.name,
+            sameAs: `${baseUrl}/public/facilities/${jobData.facility.id}`,
+            logo: jobData.facility.images?.[0] || `${baseUrl}/images/logo.png`,
         },
         jobLocation: {
             '@type': 'Place',
             address: {
                 '@type': 'PostalAddress',
-                streetAddress: `${job.facility.address || ''}${job.facility.address_line || ''}`,
-                addressLocality: job.facility.city || '',
-                addressRegion: job.facility.prefecture || '',
+                streetAddress: `${jobData.facility.address || ''}${jobData.facility.address_line || ''}`,
+                addressLocality: jobData.facility.city || '',
+                addressRegion: jobData.facility.prefecture || '',
                 addressCountry: 'JP',
             },
-            ...(job.facility.lat && job.facility.lng ? {
+            ...(jobData.facility.lat && jobData.facility.lng ? {
                 geo: {
                     '@type': 'GeoCoordinates',
-                    latitude: job.facility.lat,
-                    longitude: job.facility.lng,
+                    latitude: jobData.facility.lat,
+                    longitude: jobData.facility.lng,
                 },
             } : {}),
         },
@@ -205,16 +157,104 @@ export default async function PublicJobDetailPage({ params }: PageProps) {
             currency: 'JPY',
             value: {
                 '@type': 'QuantitativeValue',
-                value: job.hourly_wage,
+                value: jobData.hourly_wage,
                 unitText: 'HOUR',
             },
         },
-        workHours: `${job.start_time}-${job.end_time}`,
-        jobBenefits: job.transportation_fee && job.transportation_fee > 0
-            ? `交通費支給（${job.transportation_fee.toLocaleString()}円）`
+        workHours: `${jobData.start_time}-${jobData.end_time}`,
+        jobBenefits: jobData.transportation_fee && jobData.transportation_fee > 0
+            ? `交通費支給（${jobData.transportation_fee.toLocaleString()}円）`
             : undefined,
-        qualifications: job.qualifications?.join('、') || '資格不問',
+        qualifications: jobData.qualifications?.join('、') || '資格不問',
         directApply: true,
+    };
+
+    // DBのBooleanから移動手段配列を生成
+    const transportMethods = [
+        { name: '車', available: jobData.allow_car },
+    ];
+
+    // DBのデータをフロントエンドの型に変換
+    const job = {
+        id: jobData.id,
+        status: jobData.status as 'published' | 'draft' | 'stopped' | 'working' | 'completed' | 'cancelled',
+        facilityId: jobData.facility.id,
+        title: jobData.title,
+        workDate: jobData.work_date ? jobData.work_date.split('T')[0] : '',
+        workDates: jobData.workDates?.map((wd: any) => ({
+            id: wd.id,
+            workDate: wd.work_date ? wd.work_date.split('T')[0] : '',
+            deadline: wd.deadline,
+            appliedCount: 0, // 公開版では非表示
+            matchedCount: wd.matched_count,
+            recruitmentCount: wd.recruitment_count,
+        })) || [],
+        startTime: jobData.start_time,
+        endTime: jobData.end_time,
+        breakTime: jobData.break_time,
+        wage: jobData.wage,
+        hourlyWage: jobData.hourly_wage,
+        deadline: jobData.deadline,
+        tags: jobData.tags,
+        address: jobData.address,
+        prefecture: jobData.prefecture,
+        city: jobData.city,
+        addressLine: jobData.address_line,
+        access: jobData.access,
+        recruitmentCount: jobData.recruitment_count,
+        appliedCount: 0, // 公開版では非表示
+        matchedCount: jobData.matched_count,
+        transportationFee: jobData.transportation_fee,
+        overview: jobData.overview,
+        workContent: jobData.work_content,
+        requiredQualifications: jobData.required_qualifications,
+        requiredExperience: jobData.required_experience,
+        dresscode: jobData.dresscode,
+        dresscodeImages: jobData.dresscode_images || [],
+        belongings: jobData.belongings,
+        // 施設の責任者情報を優先、なければ求人の担当者情報を使用
+        managerName: jobData.facility.staff_same_as_manager
+            ? (jobData.facility.manager_last_name && jobData.facility.manager_first_name
+                ? `${jobData.facility.manager_last_name} ${jobData.facility.manager_first_name}`
+                : jobData.manager_name)
+            : (jobData.facility.staff_last_name && jobData.facility.staff_first_name
+                ? `${jobData.facility.staff_last_name} ${jobData.facility.staff_first_name}`
+                : jobData.manager_name),
+        managerMessage: jobData.facility.staff_greeting || jobData.manager_message || '',
+        managerAvatar: jobData.facility.staff_photo || jobData.manager_avatar || '',
+        images: jobData.images,
+        badges: [],
+        mapImage: jobData.facility.map_image || null,
+        transportMethods,
+        accessDescription: jobData.access,
+        featureTags: jobData.feature_tags || [],
+        attachments: jobData.attachments || [],
+        weeklyFrequency: jobData.weekly_frequency,
+        requiresInterview: jobData.requires_interview,
+        jobType: jobData.job_type as 'NORMAL' | 'LIMITED_WORKED' | 'LIMITED_FAVORITE' | 'OFFER' | 'ORIENTATION',
+    };
+
+    const facility = {
+        id: jobData.facility.id,
+        name: jobData.facility.facility_name,
+        corporationName: jobData.facility.corporation_name,
+        type: jobData.facility.facility_type,
+        address: jobData.facility.address,
+        prefecture: jobData.facility.prefecture,
+        city: jobData.facility.city,
+        addressLine: jobData.facility.address_line,
+        lat: jobData.facility.lat,
+        lng: jobData.facility.lng,
+        phoneNumber: jobData.facility.phone_number,
+        description: jobData.facility.description || '',
+        images: jobData.facility.images,
+        rating: jobData.facility.rating,
+        reviewCount: jobData.facility.review_count,
+        stations: jobData.facility.stations || [],
+        accessDescription: jobData.facility.access_description || '',
+        transportation: jobData.facility.transportation || [],
+        parking: jobData.facility.parking || '',
+        transportationNote: jobData.facility.transportation_note || '',
     };
 
     return (
@@ -225,162 +265,15 @@ export default async function PublicJobDetailPage({ params }: PageProps) {
                 type="application/ld+json"
                 dangerouslySetInnerHTML={{ __html: JSON.stringify(jobPostingJsonLd) }}
             />
-        <div className="bg-background">
-            {/* 画像カルーセル */}
-            <div className="relative aspect-video bg-gray-100">
-                {job.images && job.images.length > 0 ? (
-                    <Image
-                        src={job.images[0]}
-                        alt={job.title}
-                        fill
-                        className="object-cover"
-                        priority
-                    />
-                ) : (
-                    <div className="flex items-center justify-center h-full">
-                        <Building2 className="w-16 h-16 text-gray-300" />
-                    </div>
-                )}
-            </div>
-
-            {/* メインコンテンツ */}
-            <div className="p-4 space-y-6">
-                {/* タイトル・施設名 */}
-                <div>
-                    <h1 className="text-xl font-bold text-gray-900 mb-2">{job.title}</h1>
-                    <p className="text-gray-600">{job.facility.name}</p>
-                </div>
-
-                {/* 給与情報 */}
-                <div className="bg-primary/5 rounded-lg p-4">
-                    <div className="flex items-center gap-2 mb-2">
-                        <JapaneseYen className="w-5 h-5 text-primary" />
-                        <span className="text-2xl font-bold text-primary">
-                            {job.hourly_wage.toLocaleString()}円
-                        </span>
-                        <span className="text-gray-500">/時</span>
-                    </div>
-                    {dailyWage && (
-                        <p className="text-sm text-gray-600">
-                            日給目安: <span className="font-semibold">{dailyWage.toLocaleString()}円</span>
-                            {job.transportation_fee && job.transportation_fee > 0 && (
-                                <span className="ml-2">+ 交通費 {job.transportation_fee.toLocaleString()}円</span>
-                            )}
-                        </p>
-                    )}
-                </div>
-
-                {/* 勤務日程 */}
-                <div className="space-y-3">
-                    <h2 className="font-semibold text-gray-900 flex items-center gap-2">
-                        <Calendar className="w-5 h-5 text-gray-500" />
-                        勤務日程
-                    </h2>
-                    <div className="grid grid-cols-3 gap-2">
-                        {job.workDates.slice(0, 6).map((wd: WorkDateItem) => (
-                            <div
-                                key={wd.id}
-                                className={`p-2 rounded-lg text-center text-sm ${
-                                    wd.remaining > 0
-                                        ? 'bg-green-50 border border-green-200'
-                                        : 'bg-gray-100 text-gray-400'
-                                }`}
-                            >
-                                <div className="font-medium">{formatWorkDate(wd.work_date)}</div>
-                                <div className="text-xs">
-                                    {wd.remaining > 0 ? `残${wd.remaining}枠` : '満員'}
-                                </div>
-                            </div>
-                        ))}
-                    </div>
-                    {job.workDates.length > 6 && (
-                        <p className="text-sm text-gray-500 text-center">
-                            他 {job.workDates.length - 6} 日程あり
-                        </p>
-                    )}
-                </div>
-
-                {/* 勤務時間 */}
-                <div className="space-y-2">
-                    <h2 className="font-semibold text-gray-900 flex items-center gap-2">
-                        <Clock className="w-5 h-5 text-gray-500" />
-                        勤務時間
-                    </h2>
-                    <div className="bg-gray-50 rounded-lg p-3">
-                        <p className="text-lg font-medium">
-                            {job.start_time} 〜 {job.end_time}
-                        </p>
-                        <p className="text-sm text-gray-600">
-                            実働 {workHours}
-                            {job.break_time && Number(job.break_time) > 0 && `（休憩${job.break_time}分）`}
-                        </p>
-                    </div>
-                </div>
-
-                {/* 勤務地 */}
-                <div className="space-y-2">
-                    <h2 className="font-semibold text-gray-900 flex items-center gap-2">
-                        <MapPin className="w-5 h-5 text-gray-500" />
-                        勤務地
-                    </h2>
-                    <div className="bg-gray-50 rounded-lg p-3 space-y-1">
-                        <p className="font-medium">{job.facility.name}</p>
-                        <p className="text-sm text-gray-600">
-                            {job.facility.prefecture}{job.facility.city}{job.facility.address}
-                            {job.facility.address_line && ` ${job.facility.address_line}`}
-                        </p>
-                    </div>
-                </div>
-
-                {/* 応募資格 */}
-                {job.qualifications && job.qualifications.length > 0 && (
-                    <div className="space-y-2">
-                        <h2 className="font-semibold text-gray-900 flex items-center gap-2">
-                            <Users className="w-5 h-5 text-gray-500" />
-                            応募資格
-                        </h2>
-                        <div className="flex flex-wrap gap-2">
-                            {job.qualifications.map((qual: string, idx: number) => (
-                                <span
-                                    key={idx}
-                                    className="px-3 py-1 bg-blue-50 text-blue-700 rounded-full text-sm"
-                                >
-                                    {qual}
-                                </span>
-                            ))}
-                        </div>
-                    </div>
-                )}
-
-                {/* 仕事内容 */}
-                {job.description && (
-                    <div className="space-y-2">
-                        <h2 className="font-semibold text-gray-900">仕事内容</h2>
-                        <p className="text-gray-700 whitespace-pre-wrap">{job.description}</p>
-                    </div>
-                )}
-
-                {/* 労働条件通知書プレビュー */}
-                <div>
-                    <Link
-                        href={`/public/jobs/${job.id}/labor-document`}
-                        className="flex items-center gap-2 px-3 py-2 text-sm text-primary border border-primary rounded-lg hover:bg-primary/5 transition-colors"
-                    >
-                        <FileText className="w-4 h-4" />
-                        労働条件通知書を確認
-                    </Link>
-                </div>
-
-                {/* 審査について */}
-                {job.requires_interview && (
-                    <div className="bg-amber-50 border border-amber-200 rounded-lg p-3">
-                        <p className="text-sm text-amber-800">
-                            ※ この求人は審査があります。応募後、施設からの承認が必要です。
-                        </p>
-                    </div>
-                )}
-            </div>
-        </div>
+            <JobDetailClient
+                job={job}
+                facility={facility}
+                relatedJobs={[]}
+                facilityReviews={[]}
+                initialHasApplied={false}
+                initialAppliedWorkDateIds={[]}
+                isPublic={true}
+            />
         </>
     );
 }

--- a/src/lib/actions/job-public.ts
+++ b/src/lib/actions/job-public.ts
@@ -32,6 +32,8 @@ export async function getPublicJobById(id: string) {
                 select: {
                     id: true,
                     facility_name: true,
+                    corporation_name: true,
+                    facility_type: true,
                     prefecture: true,
                     city: true,
                     address: true,
@@ -40,6 +42,23 @@ export async function getPublicJobById(id: string) {
                     images: true,
                     lat: true,
                     lng: true,
+                    phone_number: true,
+                    rating: true,
+                    review_count: true,
+                    stations: true,
+                    access_description: true,
+                    transportation: true,
+                    parking: true,
+                    transportation_note: true,
+                    map_image: true,
+                    // 担当者情報
+                    staff_same_as_manager: true,
+                    manager_last_name: true,
+                    manager_first_name: true,
+                    staff_last_name: true,
+                    staff_first_name: true,
+                    staff_greeting: true,
+                    staff_photo: true,
                 },
             },
             workDates: {
@@ -89,24 +108,70 @@ export async function getPublicJobById(id: string) {
     const totalMatchedCount = futureWorkDates.reduce((sum, wd) => sum + wd.matched_count, 0);
     const remainingSlots = totalRecruitmentCount - totalMatchedCount;
 
+    // DBのBooleanから特徴タグ配列を生成
+    const featureTags = [
+        job.inexperienced_ok && '未経験者歓迎',
+        job.blank_ok && 'ブランク歓迎',
+        job.hair_style_free && '髪型・髪色自由',
+        job.nail_ok && 'ネイルOK',
+        job.uniform_provided && '制服貸与',
+        job.allow_car && '車通勤OK',
+        job.meal_support && '食事補助',
+    ].filter(Boolean) as string[];
+
     return {
         id: job.id,
+        status: job.status.toLowerCase(),
         title: job.title,
         description: job.overview,
-        qualifications: job.required_qualifications,
+        overview: job.overview,
         work_content: job.work_content,
+        qualifications: job.required_qualifications,
+        required_qualifications: job.required_qualifications,
+        required_experience: job.required_experience,
         hourly_wage: job.hourly_wage,
+        wage: job.wage,
         transportation_fee: job.transportation_fee,
         start_time: job.start_time,
         end_time: job.end_time,
         break_time: job.break_time,
         images: job.images,
         requires_interview: job.requires_interview,
+        job_type: job.job_type,
+
+        // アドレス情報
+        address: job.address,
+        prefecture: job.prefecture,
+        city: job.city,
+        address_line: job.address_line,
+        access: job.access,
+
+        // ドレスコード
+        dresscode: job.dresscode,
+        dresscode_images: job.dresscode_images,
+        belongings: job.belongings,
+
+        // 担当者情報
+        manager_name: job.manager_name,
+        manager_message: job.manager_message,
+        manager_avatar: job.manager_avatar,
+
+        // 特徴タグ
+        feature_tags: featureTags,
+        tags: job.tags,
+
+        // 添付ファイル
+        attachments: job.attachments,
+
+        // 募集条件
+        weekly_frequency: job.weekly_frequency,
+        allow_car: job.allow_car,
 
         // 日程関連
         work_date: nearestWorkDate.work_date.toISOString(),
         deadline: nearestWorkDate.deadline.toISOString(),
         recruitment_count: totalRecruitmentCount,
+        matched_count: totalMatchedCount,
         remaining_slots: remainingSlots > 0 ? remainingSlots : 0,
 
         // 勤務日一覧
@@ -123,6 +188,9 @@ export async function getPublicJobById(id: string) {
         facility: {
             id: job.facility.id,
             name: job.facility.facility_name,
+            facility_name: job.facility.facility_name,
+            corporation_name: job.facility.corporation_name,
+            facility_type: job.facility.facility_type,
             prefecture: job.facility.prefecture,
             city: job.facility.city,
             address: job.facility.address,
@@ -131,6 +199,23 @@ export async function getPublicJobById(id: string) {
             images: job.facility.images,
             lat: job.facility.lat,
             lng: job.facility.lng,
+            phone_number: job.facility.phone_number,
+            rating: job.facility.rating,
+            review_count: job.facility.review_count,
+            stations: job.facility.stations,
+            access_description: job.facility.access_description,
+            transportation: job.facility.transportation,
+            parking: job.facility.parking,
+            transportation_note: job.facility.transportation_note,
+            map_image: job.facility.map_image,
+            // 担当者情報
+            staff_same_as_manager: job.facility.staff_same_as_manager,
+            manager_last_name: job.facility.manager_last_name,
+            manager_first_name: job.facility.manager_first_name,
+            staff_last_name: job.facility.staff_last_name,
+            staff_first_name: job.facility.staff_first_name,
+            staff_greeting: job.facility.staff_greeting,
+            staff_photo: job.facility.staff_photo,
         },
 
         created_at: job.created_at.toISOString(),


### PR DESCRIPTION
## Summary
- `JobDetailClient`に`isPublic`プロップを追加し、公開版（未ログイン）と通常版でコンポーネントを共有
- 公開版では認証が必要な機能（チェックボックス、ブックマーク等）を非表示/無効化
- SEOメタデータとGoogle for Jobs用JSON-LD構造化データを維持
- コード重複を大幅に削減し、メンテナンス性を向上

## Changes
### JobDetailClient.tsx
- `isPublic?: boolean`プロップを追加（デフォルト: false）
- 公開版では以下を非表示/無効化:
  - 勤務日選択のチェックボックス
  - 「あとで見る」ボタン
  - ブックマーク/お気に入り/ミュートボタン
  - 応募不可オーバーレイ
- 公開版のフッターにCTAボタン（「ログインして応募する」）を表示

### job-public.ts
- `getPublicJobById`を拡張して`JobDetailClient`が必要とする全フィールドを返すように変更
- 施設情報、特徴タグ、ドレスコード等のフィールドを追加

### app/public/jobs/[id]/page.tsx
- インライン実装から`JobDetailClient`の利用に変更
- `isPublic={true}`を渡して公開版モードで表示
- 既存のSEOメタデータ（generateMetadata）とJSON-LD構造化データを維持

## Test plan
- [ ] 公開版求人詳細ページ（/public/jobs/[id]）が正常に表示される
- [ ] チェックボックスが非表示になっている
- [ ] 「あとで見る」「ブックマーク」等のボタンが非表示になっている
- [ ] フッターにCTAボタン（ログインして応募する）が表示される
- [ ] ログイン版求人詳細ページ（/jobs/[id]）が引き続き正常に動作する
- [ ] SEOメタデータが正しく設定されている

🤖 Generated with [Claude Code](https://claude.ai/code)