### PR TITLE
セキュリティ強化: デバッグAPI保護と認証設定改善

### DIFF
--- a/app/api/debug/db/route.ts
+++ b/app/api/debug/db/route.ts
@@ -3,7 +3,23 @@ import { prisma } from '@/lib/prisma';
 
 export const dynamic = 'force-dynamic';
 
+/**
+ * 本番環境でのアクセスを拒否
+ */
+function rejectInProduction(): NextResponse | null {
+    if (process.env.NODE_ENV === 'production') {
+        return NextResponse.json(
+            { error: 'Debug API is disabled in production' },
+            { status: 403 }
+        );
+    }
+    return null;
+}
+
 export async function GET() {
+    const rejected = rejectInProduction();
+    if (rejected) return rejected;
+
     try {
         // DB接続テスト
         const userCount = await prisma.user.count();

--- a/app/api/debug/system-admin/route.ts
+++ b/app/api/debug/system-admin/route.ts
@@ -4,7 +4,23 @@ import bcrypt from 'bcryptjs';
 
 export const dynamic = 'force-dynamic';
 
+/**
+ * 本番環境でのアクセスを拒否
+ */
+function rejectInProduction(): NextResponse | null {
+    if (process.env.NODE_ENV === 'production') {
+        return NextResponse.json(
+            { error: 'Debug API is disabled in production' },
+            { status: 403 }
+        );
+    }
+    return null;
+}
+
 export async function GET() {
+    const rejected = rejectInProduction();
+    if (rejected) return rejected;
+
     try {
         // システム管理者テーブルの確認
         const admins = await prisma.systemAdmin.findMany({
@@ -34,6 +50,9 @@ export async function GET() {
 }
 
 export async function POST(request: NextRequest) {
+    const rejected = rejectInProduction();
+    if (rejected) return rejected;
+
     try {
         const { email, password } = await request.json();
 

--- a/app/api/debug/time/route.ts
+++ b/app/api/debug/time/route.ts
@@ -3,6 +3,19 @@ import { NextRequest, NextResponse } from 'next/server';
 // 開発環境のみで動作
 export const dynamic = 'force-dynamic';
 
+/**
+ * 本番環境でのアクセスを拒否
+ */
+function rejectInProduction(): NextResponse | null {
+  if (process.env.NODE_ENV === 'production') {
+    return NextResponse.json(
+      { error: 'Debug API is disabled in production' },
+      { status: 403 }
+    );
+  }
+  return null;
+}
+
 const DEBUG_TIME_COOKIE_NAME = 'debugTimeSettings';
 
 interface DebugTimeSettings {
@@ -14,6 +27,9 @@ interface DebugTimeSettings {
  * デバッグ時刻設定を取得
  */
 export async function GET(request: NextRequest) {
+  const rejected = rejectInProduction();
+  if (rejected) return rejected;
+
   try {
     const cookie = request.cookies.get(DEBUG_TIME_COOKIE_NAME);
 
@@ -33,6 +49,9 @@ export async function GET(request: NextRequest) {
  * デバッグ時刻設定を更新
  */
 export async function POST(request: NextRequest) {
+  const rejected = rejectInProduction();
+  if (rejected) return rejected;
+
   try {
     const body = await request.json();
     const { enabled, time } = body;

--- a/app/api/debug/users/route.ts
+++ b/app/api/debug/users/route.ts
@@ -3,7 +3,23 @@ import { prisma } from '@/lib/prisma';
 
 export const dynamic = 'force-dynamic';
 
+/**
+ * 本番環境でのアクセスを拒否
+ */
+function rejectInProduction(): NextResponse | null {
+    if (process.env.NODE_ENV === 'production') {
+        return NextResponse.json(
+            { error: 'Debug API is disabled in production' },
+            { status: 403 }
+        );
+    }
+    return null;
+}
+
 export async function GET() {
+    const rejected = rejectInProduction();
+    if (rejected) return rejected;
+
     try {
         const users = await prisma.user.findMany({
             select: {


### PR DESCRIPTION
## Summary

- デバッグAPI（/api/debug/*）を本番環境で無効化し、セキュリティリスクを軽減
- iron-sessionのセッションシークレット設定を強化
- テスト用マジックパスワードの条件を厳格化

## 変更内容

### 🔒 デバッグAPIの本番環境無効化

| エンドポイント | 変更前 | 変更後 |
|---------------|--------|--------|
| `/api/debug/db` | 認証なしでDB情報取得可能 | 本番で403 |
| `/api/debug/users` | 認証なしでユーザー一覧取得可能 | 本番で403 |
| `/api/debug/system-admin` | 認証なしでパスワード検証可能 | 本番で403 |
| `/api/debug/time` | 認証なしでデバッグ時刻設定可能 | 本番で403 |

### 🔐 iron-session設定の強化

- 本番環境で`SYSTEM_ADMIN_SESSION_SECRET`未設定時にエラーをスロー
- 32文字未満のシークレットを拒否
- 開発環境では警告付きでデフォルト値を許容（後方互換性維持）

### 🔑 マジックパスワード条件の強化

- 本番環境では完全に無効化（NODE_ENV=productionで動作しない）
- 開発環境でも`ENABLE_TEST_LOGIN=true`環境変数が必要

## 影響範囲

| 環境 | 影響 |
|------|------|
| 本番 | デバッグAPIアクセス不可（意図した動作） |
| 開発 | 変更なし（引き続き利用可能） |
| 既存の認証フロー | 影響なし |

## Test plan

- [ ] 開発環境で`/api/debug/*`にアクセスできることを確認
- [ ] ステージング環境（NODE_ENV=production）で`/api/debug/*`が403を返すことを確認
- [ ] システム管理者ログインが正常に動作することを確認
- [ ] 通常ユーザーログインが正常に動作することを確認

## 環境変数の確認（本番デプロイ前）

以下の環境変数が設定されていることを確認してください：

```
SYSTEM_ADMIN_SESSION_SECRET=（32文字以上のランダム文字列）
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)