### PR TITLE
fix: 距離ソートAPIのパラメータ検証とデフォルト値を追加

### DIFF
--- a/app/api/jobs/route.ts
+++ b/app/api/jobs/route.ts
@@ -40,6 +40,22 @@ export async function GET(request: NextRequest) {
     const distanceLat = searchParams.get('distanceLat') ? parseFloat(searchParams.get('distanceLat')!) : undefined;
     const distanceLng = searchParams.get('distanceLng') ? parseFloat(searchParams.get('distanceLng')!) : undefined;
 
+    // 距離ソート時のパラメータ検証とデフォルト値設定
+    let effectiveDistanceKm = distanceKm;
+    if (sort === 'distance') {
+      if (distanceLat === undefined || distanceLng === undefined) {
+        return NextResponse.json(
+          { error: '距離ソートには distanceLat と distanceLng パラメータが必要です' },
+          { status: 400 }
+        );
+      }
+      // distanceKm が未指定の場合はデフォルト50kmを使用
+      if (effectiveDistanceKm === undefined) {
+        effectiveDistanceKm = 50;
+        console.info('[API /api/jobs] distanceKm not specified for distance sort, using default 50km');
+      }
+    }
+
     // 求人リストタイプ（限定求人・オファー対応）
     const listType = (searchParams.get('listType') as 'all' | 'limited' | 'offer') || 'all';
 
@@ -59,7 +75,7 @@ export async function GET(request: NextRequest) {
       workTimeTypes: workTimeTypes.length > 0 ? workTimeTypes : undefined,
       timeRangeFrom,
       timeRangeTo,
-      distanceKm,
+      distanceKm: effectiveDistanceKm,
       distanceLat,
       distanceLng,
       listType,

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,13 +20,15 @@ export default async function JobListPage() {
     const targetDate = dates[0]; // 今日
 
     // サーバーサイドで求人データを事前取得
+    // 注意: SSRでは位置情報が取得できないため、距離ソートは使用しない
+    // クライアント側で位置情報取得後に距離ソートが適用される
     const { jobs: jobsData, pagination } = await getJobsListWithPagination(
       { listType: 'all' },
       {
         page: 1,
         limit: 20,
         targetDate,
-        sort: 'distance',
+        sort: undefined, // SSRでは距離ソート不可（位置情報なし）
         currentTime,
       }
     );


### PR DESCRIPTION
## Summary
- `/api/jobs?sort=distance` 呼び出し時の500エラーを修正
- 距離ソートに必要なパラメータの検証を追加
- SSRでの距離ソート問題を修正

## 問題
本番環境（`tastas.work`）で `/api/jobs?sort=distance&distanceLat=...&distanceLng=...` のリクエストが500エラーを返していた。

**原因:**
1. `distanceKm` パラメータが未指定のまま距離ソートが実行されていた
2. SSR初期化で `sort: 'distance'` が指定されていたが、位置情報がなかった

## 修正内容

### 1. API Route (`app/api/jobs/route.ts`)
- `sort=distance` 時に `distanceLat`, `distanceLng` の必須検証を追加
  - 欠落時は 400 Bad Request を返す
- `distanceKm` 未指定時はデフォルト 50km を使用
  - これにより距離フィルタリングが有効になり、パフォーマンス問題も解消

### 2. SSR初期化 (`app/page.tsx`)
- `sort: 'distance'` を `sort: undefined` に変更
- SSRでは位置情報が取得できないため、クライアント側で位置情報取得後に距離ソートが適用される

## Test plan
- [ ] 本番環境で `/api/jobs?sort=distance&distanceLat=35.1&distanceLng=138.8` が正常に動作すること
- [ ] `distanceLat` または `distanceLng` が欠落時に 400 エラーが返ること
- [ ] トップページが正常に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)