### PR TITLE
fix: デプロイエラーの修正（themeColor + Prisma pgbouncer対応）

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -8,20 +8,20 @@ import { ErrorToastProvider } from '@/components/ui/PersistentErrorToast';
 import { DebugErrorProvider } from '@/components/debug/DebugErrorBanner';
 import { WorkerLayout } from '@/components/layout/WorkerLayout';
 
-// Viewport設定（iOS safe-area対応）
+// Viewport設定（iOS safe-area対応 + themeColor）
 export const viewport: Viewport = {
   width: 'device-width',
   initialScale: 1,
   maximumScale: 1,
   userScalable: false,
   viewportFit: 'cover', // iPhoneのノッチ/Dynamic Island対応
+  themeColor: '#6366f1', // Next.js 14+ではviewport exportに移動が必要
 };
 
 export const metadata: Metadata = {
   title: "+TASTAS - 看護師・介護士のための求人マッチング",
   description: "看護師・介護士のための求人マッチングWebサービス",
   manifest: '/manifest.json',
-  themeColor: '#6366f1',
   appleWebApp: {
     capable: true,
     statusBarStyle: 'default',

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,7 +1,9 @@
 import { PrismaClient } from '@prisma/client';
 
 // PrismaClient設定
-// prepared statementの問題を回避するため、datasources経由で接続設定を行う
+// Vercel Postgres (PgBouncer) 環境でのprepared statementエラー対策:
+// DATABASE_URLに ?pgbouncer=true&connection_limit=1 を追加する必要あり
+// または DIRECT_URL を使用（マイグレーション用）
 const prismaClientSingleton = () => {
   return new PrismaClient({
     log: process.env.NODE_ENV === 'development' ? ['error', 'warn'] : ['error'],


### PR DESCRIPTION
## Summary
- Next.js 14の警告修正: `metadata.themeColor` を `viewport` exportに移動
- Prisma接続設定のコメント更新: `pgbouncer=true` パラメータ必須を明記

## 必要な追加作業（Vercel側）
**DATABASE_URLの末尾に `?pgbouncer=true` を追加してください**

```
現在: postgres://...@aws-1-ap-northeast-1.pooler.supabase.com:6543/postgres
修正: postgres://...@aws-1-ap-northeast-1.pooler.supabase.com:6543/postgres?pgbouncer=true
```

## 変更ファイル
- `app/layout.tsx` - themeColorをviewportに移動
- `lib/prisma.ts` - コメント更新

## Test plan
- [ ] Vercel環境変数DATABASE_URLに`?pgbouncer=true`を追加
- [ ] ステージング環境で動作確認
- [ ] prepared statementエラーが解消されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)