### PR TITLE
fix: /api/jobs をミドルウェアの認証除外リストに追加

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -29,6 +29,7 @@ const ignoredPaths = [
   '/api/debug', // デバッグ用API
   '/api/dev', // 開発用API（テストメール送信など）
   '/api/error-messages', // エラーメッセージ設定（認証不要）
+  '/api/jobs', // 求人一覧API（ログイン前でも表示が必要）
   '/rogo', // ロゴ画像
   '/images', // 画像ファイル
   '/icons', // アイコン


### PR DESCRIPTION
## Summary
- 求人一覧API (`/api/jobs`) が認証でブロックされ、307リダイレクトで `/login` に転送される問題を修正
- `/api/jobs` を `ignoredPaths` に追加して認証チェックをスキップ

## 原因
`middleware.ts` の `ignoredPaths` に `/api/jobs` が含まれていなかったため、未認証リクエストがログインページにリダイレクトされていた。

## Test plan
- [ ] ステージング環境で求人一覧が表示されることを確認
- [ ] `/api/jobs` エンドポイントが認証なしで200を返すことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)