### PR TITLE
fix: システム設定のサイドバーリンク先を修正

### DIFF
--- a/components/system-admin/SystemAdminLayout.tsx
+++ b/components/system-admin/SystemAdminLayout.tsx
@@ -107,7 +107,7 @@ export default function SystemAdminLayout({ children }: SystemAdminLayoutProps) 
         {
             title: 'システム設定',
             icon: <Settings className="w-5 h-5" />,
-            href: '/system-admin/settings',
+            href: '/system-admin/settings/system',
             active: pathname?.startsWith('/system-admin/settings'),
             divider: true,
         },


### PR DESCRIPTION
## Summary
- サイドバーの「システム設定」リンク先を修正
- `/system-admin/settings` → `/system-admin/settings/system`

## Test plan
- [ ] サイドバーの「システム設定」をクリックして正しいページに遷移する

🤖 Generated with [Claude Code](https://claude.ai/claude-code)