### PR TITLE
docs: 本番URLをtastas.workに修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 | 環境 | URL | ブランチ | 用途 |
 |------|-----|----------|------|
-| 本番 | https://share-worker-app.vercel.app | main | 本番環境 |
+| 本番 | https://tastas.work | main | 本番環境 |
 | ステージング | https://stg-share-worker.vercel.app | develop | 検証環境 |
 | 開発 | http://localhost:3000 | - | ローカル開発 |
 


### PR DESCRIPTION
## Summary
- CLAUDE.mdの本番URLを修正
- `https://share-worker-app.vercel.app` → `https://tastas.work`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)