### PR TITLE
fix: ログアウト時にSWRキャッシュをクリア（ID-93）

### DIFF
--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -3,6 +3,7 @@
 import { createContext, useContext, ReactNode, useState, useEffect, useCallback } from 'react';
 import { SessionProvider, useSession, signIn, signOut } from 'next-auth/react';
 import { Session } from 'next-auth';
+import { mutate } from 'swr';
 import { FacilityAdmin } from '@/types/admin';
 import { authenticateFacilityAdmin, logoutFacilityAdmin } from '@/src/lib/actions';
 import {
@@ -197,6 +198,14 @@ function AuthContextProvider({ children }: { children: ReactNode }) {
     // クライアント側の状態をクリア
     setAdmin(null);
     clearAdminSession();
+
+    // SWRキャッシュをすべてクリア（施設切り替え時の古いデータ残存を防止）
+    // ID-93: 新規施設登録後にメッセージが残る問題の修正
+    await mutate(
+      () => true, // すべてのキーにマッチ
+      undefined,  // データをundefinedに設定
+      { revalidate: false } // 再取得しない
+    );
 
     // サーバー側のセッションもクリア（エラーは無視）
     try {


### PR DESCRIPTION
## Summary
- 施設管理画面で新規クライアント登録後にメッセージが残る問題を修正
- ログアウト時にSWRキャッシュをグローバルクリアするよう変更
- `mutate(() => true, undefined, { revalidate: false })` を使用

## 原因
施設切り替え時（ログアウト後の再ログイン）に、SWRキャッシュが残存し、別施設のデータが表示されていた。

## 変更内容
- `contexts/AuthContext.tsx`: `adminLogout`関数にSWRキャッシュクリア処理を追加

## Test plan
- [ ] 施設Aでログイン→メッセージ確認
- [ ] ログアウト
- [ ] 施設Bでログイン
- [ ] 施設Aのメッセージが表示されていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)