### PR TITLE
fix: 求人作成時の日時計算をJST対応に修正

### DIFF
--- a/utils/debugTime.server.ts
+++ b/utils/debugTime.server.ts
@@ -106,3 +106,44 @@ export function getJSTTodayString(baseTime?: Date): string {
 
   return `${year}-${month}-${day}`;
 }
+
+/**
+ * 日付の時刻をJST基準で設定する
+ * 入力日付のJSTでの日付部分を維持したまま、指定した時刻（JST）を設定
+ *
+ * 例: 2026-01-20 (どのタイムゾーンでも) に 9:00 JST を設定
+ *     → 2026-01-20 00:00:00 UTC (= 2026-01-20 09:00:00 JST)
+ *
+ * @param date 基準となる日付
+ * @param hours JST時刻の時（0-23）
+ * @param minutes JST時刻の分（0-59）、デフォルト0
+ * @param seconds JST時刻の秒（0-59）、デフォルト0
+ * @param milliseconds JST時刻のミリ秒（0-999）、デフォルト0
+ * @returns 指定したJST時刻に対応するUTC Date
+ */
+export function setJSTHours(
+  date: Date,
+  hours: number,
+  minutes: number = 0,
+  seconds: number = 0,
+  milliseconds: number = 0
+): Date {
+  const JST_OFFSET = 9 * 60;
+
+  // 入力日付をJSTに変換して日付部分を取得
+  const jstTime = new Date(date.getTime() + JST_OFFSET * 60 * 1000);
+
+  // JSTでの指定時刻を計算
+  const jstTarget = new Date(Date.UTC(
+    jstTime.getUTCFullYear(),
+    jstTime.getUTCMonth(),
+    jstTime.getUTCDate(),
+    hours,
+    minutes,
+    seconds,
+    milliseconds
+  ));
+
+  // JSTの時刻をUTCに戻す（-9時間）
+  return new Date(jstTarget.getTime() - JST_OFFSET * 60 * 1000);
+}


### PR DESCRIPTION
## Summary
- 求人作成時の日時計算（visible_from, visible_until, deadline）がUTC基準になっていた問題を修正
- `setJSTHours()` 関数を追加し、全ての時刻設定をJST対応に統一

## 背景
ID-99（今日の求人が表示されない問題）の調査で、主要な表示ロジックは既にJST対応済みだが、求人作成時の `job-management.ts` に残存していた `setHours()` がJSTではなくUTC基準で動作していた。

## 変更内容
- `utils/debugTime.server.ts` に `setJSTHours()` 関数を追加
- `src/lib/actions/job-management.ts` の6箇所の `setHours()` を `setJSTHours()` に置換

## 影響範囲
- 求人新規作成時のworkDate設定
- 求人編集時の勤務日追加
- 既存勤務日の可視性設定更新

## Test plan
- [ ] 求人を新規作成し、設定した募集開始時刻が正しく保存されることを確認
- [ ] 求人編集で勤務日を追加し、締切時刻が正しく設定されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)