### PR TITLE
fix(ID-1): ログインフォームのautocomplete属性を修正

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -144,8 +144,9 @@ export default function WorkerLogin() {
                 <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
                 <input
                   type="email"
+                  id="login-email"
                   name="email"
-                  autoComplete="email"
+                  autoComplete="username"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   className="w-full pl-10 pr-4 py-3 border-0 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 bg-white"
@@ -163,6 +164,7 @@ export default function WorkerLogin() {
                 <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
                 <input
                   type={showPassword ? 'text' : 'password'}
+                  id="login-password"
                   name="password"
                   autoComplete="current-password"
                   value={password}


### PR DESCRIPTION
## Summary
- ログインフォームでブラウザの住所オートフィルが誤動作する問題を修正
- 適切なautocomplete属性とid属性を追加

## 変更内容
- メールフィールド: `autoComplete="username"` + `id="login-email"`
- パスワードフィールド: `id="login-password"`

## Test plan
- [ ] ログインページでブラウザの自動入力が正しく動作する
- [ ] メールフィールドに住所が自動入力されない

🤖 Generated with [Claude Code](https://claude.com/claude-code)