### PR TITLE
fix(ID-2): 距離検索で無効な座標を除外

### DIFF
--- a/src/lib/actions/job-worker.ts
+++ b/src/lib/actions/job-worker.ts
@@ -1137,7 +1137,8 @@ export async function getJobsListWithPagination(
             .map((job) => {
                 const facilityLat = job.facility.lat;
                 const facilityLng = job.facility.lng;
-                if (facilityLat === null || facilityLng === null) {
+                // null または デフォルト値(0,0) の場合は無効な座標として扱う
+                if (facilityLat === null || facilityLng === null || (facilityLat === 0 && facilityLng === 0)) {
                     return { ...job, _distance: Infinity };
                 }
                 const distance = calculateDistanceKm(
@@ -1158,7 +1159,8 @@ export async function getJobsListWithPagination(
             filteredJobsWithDistance = filteredJobsWithDistance.map((job) => {
                 const facilityLat = job.facility.lat;
                 const facilityLng = job.facility.lng;
-                if (facilityLat === null || facilityLng === null) {
+                // null または デフォルト値(0,0) の場合は無効な座標として扱う
+                if (facilityLat === null || facilityLng === null || (facilityLat === 0 && facilityLng === 0)) {
                     return { ...job, _distance: Infinity };
                 }
                 const distance = calculateDistanceKm(


### PR DESCRIPTION
## Summary
- 施設の座標が(0, 0)（デフォルト値）の場合、距離検索結果から除外するよう修正
- これにより、正しい座標を持つ施設のみが距離検索で表示される

## 問題
施設のlat/lngはデフォルトで0に設定されている。座標が設定されていない施設が距離検索に含まれてしまう可能性があった。

## 変更内容
- `src/lib/actions/job-worker.ts`
  - 距離フィルター適用時: (0, 0)座標の施設をInfinityとして扱う
  - 距離ソート時: 同様に(0, 0)座標の施設をInfinityとして扱う

## Test plan
- [ ] 距離検索で「1km以内」を選択したとき、1km以上の施設が表示されない
- [ ] 座標が設定されていない施設は検索結果に含まれない
- [ ] システム設定の距離検索機能が正常に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)