### PR TITLE
機能改善: 勤務時間1分単位化 & 勤怠変更申請ホイールピッカー導入

### DIFF
--- a/components/admin/attendance/ModificationRequestDetail.tsx
+++ b/components/admin/attendance/ModificationRequestDetail.tsx
@@ -178,8 +178,11 @@ export function ModificationRequestDetail({
               <td className="px-4 py-3 text-center text-sm text-blue-700">
                 {requestedEndTime}
               </td>
-              <td className="px-4 py-3 text-center text-sm text-blue-700">
+              <td className="px-4 py-3 text-center text-sm text-gray-400">
                 {request.requestedBreakTime}分
+                {request.requestedBreakTime === scheduledBreakTime && (
+                  <span className="block text-xs">（変更なし）</span>
+                )}
               </td>
             </tr>
           </tbody>

--- a/components/attendance/ModificationForm.tsx
+++ b/components/attendance/ModificationForm.tsx
@@ -2,11 +2,14 @@
 
 /**
  * 勤怠変更申請フォームコンポーネント
+ * - 勤務時間の変更をスクロールホイール型ピッカーで入力
+ * - 休憩時間は元の求人設定値を引き継ぎ（ワーカーからの変更不可）
  */
 
 import { useState, useEffect } from 'react';
-import { AlertCircle, Clock, Coffee } from 'lucide-react';
+import { AlertCircle, Clock } from 'lucide-react';
 import { calculateSalary, formatCurrency, formatMinutesToHoursAndMinutes } from '@/src/lib/salary-calculator';
+import { TimeWheelPicker } from '@/components/ui/TimeWheelPicker';
 
 interface ModificationFormProps {
   attendance: {
@@ -38,13 +41,6 @@ export interface ModificationFormData {
   comment: string;
 }
 
-// 時・分の個別オプション生成（1分単位での時刻指定用）
-const HOUR_OPTIONS = Array.from({ length: 24 }, (_, h) => h.toString().padStart(2, '0'));
-const MINUTE_OPTIONS = Array.from({ length: 60 }, (_, m) => m.toString().padStart(2, '0'));
-
-// 休憩時間オプション
-const BREAK_OPTIONS = [0, 15, 30, 45, 60, 90, 120];
-
 export function ModificationForm({
   attendance,
   scheduledTime,
@@ -57,9 +53,10 @@ export function ModificationForm({
   // フォーム状態
   const [startTime, setStartTime] = useState(scheduledTime.startTime);
   const [endTime, setEndTime] = useState(scheduledTime.endTime);
-  const [hasBreak, setHasBreak] = useState(scheduledTime.breakTime > 0);
-  const [breakTime, setBreakTime] = useState(scheduledTime.breakTime);
   const [comment, setComment] = useState('');
+
+  // 休憩時間は元の求人設定値を固定で使用
+  const breakTime = scheduledTime.breakTime;
 
   // 計算結果
   const [calculatedAmount, setCalculatedAmount] = useState(0);
@@ -83,13 +80,13 @@ export function ModificationForm({
     const result = calculateSalary({
       startTime: start,
       endTime: end,
-      breakMinutes: hasBreak ? breakTime : 0,
+      breakMinutes: breakTime,
       hourlyRate: scheduledTime.hourlyWage,
     });
 
     setCalculatedAmount(result.totalPay + scheduledTime.transportationFee);
     setWorkedMinutes(result.workedMinutes);
-  }, [startTime, endTime, hasBreak, breakTime, scheduledTime, workDate]);
+  }, [startTime, endTime, breakTime, scheduledTime, workDate]);
 
   const handleSubmit = () => {
     if (!comment.trim()) {
@@ -100,8 +97,8 @@ export function ModificationForm({
     onSubmit({
       startTime,
       endTime,
-      breakTime: hasBreak ? breakTime : 0,
-      hasBreak,
+      breakTime,
+      hasBreak: breakTime > 0,
       comment,
     });
   };
@@ -147,105 +144,30 @@ export function ModificationForm({
         </div>
       </div>
 
-      {/* 勤務時間入力 */}
+      {/* 勤務時間入力（スクロールホイール型ピッカー） */}
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-2">
+        <label className="block text-sm font-medium text-gray-700 mb-3">
           勤務時間
         </label>
-        <div className="flex items-center gap-2">
-          {/* 開始時刻: 時 */}
-          <select
-            value={startTime.split(':')[0]}
-            onChange={(e) => setStartTime(`${e.target.value}:${startTime.split(':')[1]}`)}
-            className="w-16 px-2 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#66cc99] text-center"
-          >
-            {HOUR_OPTIONS.map((h) => (
-              <option key={`sh-${h}`} value={h}>{h}</option>
-            ))}
-          </select>
-          <span className="text-gray-500">:</span>
-          {/* 開始時刻: 分 */}
-          <select
-            value={startTime.split(':')[1]}
-            onChange={(e) => setStartTime(`${startTime.split(':')[0]}:${e.target.value}`)}
-            className="w-16 px-2 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#66cc99] text-center"
-          >
-            {MINUTE_OPTIONS.map((m) => (
-              <option key={`sm-${m}`} value={m}>{m}</option>
-            ))}
-          </select>
-          <span className="text-gray-500 mx-1">〜</span>
-          {/* 終了時刻: 時 */}
-          <select
-            value={endTime.split(':')[0]}
-            onChange={(e) => setEndTime(`${e.target.value}:${endTime.split(':')[1]}`)}
-            className="w-16 px-2 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#66cc99] text-center"
-          >
-            {HOUR_OPTIONS.map((h) => (
-              <option key={`eh-${h}`} value={h}>{h}</option>
-            ))}
-          </select>
-          <span className="text-gray-500">:</span>
-          {/* 終了時刻: 分 */}
-          <select
-            value={endTime.split(':')[1]}
-            onChange={(e) => setEndTime(`${endTime.split(':')[0]}:${e.target.value}`)}
-            className="w-16 px-2 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#66cc99] text-center"
-          >
-            {MINUTE_OPTIONS.map((m) => (
-              <option key={`em-${m}`} value={m}>{m}</option>
-            ))}
-          </select>
+        <div className="flex items-center justify-center gap-3">
+          <TimeWheelPicker
+            value={startTime}
+            onChange={setStartTime}
+            label="開始"
+            className="flex-1"
+          />
+          <span className="text-gray-400 text-lg font-medium">〜</span>
+          <TimeWheelPicker
+            value={endTime}
+            onChange={setEndTime}
+            label="終了"
+            className="flex-1"
+          />
         </div>
-        <p className="text-xs text-gray-500 mt-1">
+        <p className="text-xs text-gray-500 mt-2">
           実働時間: {formatMinutesToHoursAndMinutes(workedMinutes)}
+          {breakTime > 0 && `（休憩${breakTime}分を含む）`}
         </p>
-      </div>
-
-      {/* 休憩時間 */}
-      <div>
-        <label className="block text-sm font-medium text-gray-700 mb-2">
-          休憩時間
-        </label>
-        <div className="space-y-2">
-          <div className="flex items-center gap-4">
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="radio"
-                checked={!hasBreak}
-                onChange={() => setHasBreak(false)}
-                className="w-4 h-4 text-[#66cc99]"
-              />
-              <span>なし</span>
-            </label>
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="radio"
-                checked={hasBreak}
-                onChange={() => setHasBreak(true)}
-                className="w-4 h-4 text-[#66cc99]"
-              />
-              <span>あり</span>
-            </label>
-          </div>
-
-          {hasBreak && (
-            <div className="flex items-center gap-2">
-              <Coffee className="w-4 h-4 text-gray-400" />
-              <select
-                value={breakTime}
-                onChange={(e) => setBreakTime(Number(e.target.value))}
-                className="px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#66cc99]"
-              >
-                {BREAK_OPTIONS.map((minutes) => (
-                  <option key={minutes} value={minutes}>
-                    {minutes}分
-                  </option>
-                ))}
-              </select>
-            </div>
-          )}
-        </div>
       </div>
 
       {/* コメント */}

--- a/components/ui/TimeWheelPicker.tsx
+++ b/components/ui/TimeWheelPicker.tsx
@@ -1,0 +1,268 @@
+'use client';
+
+import { useState, useRef, useEffect, useCallback } from 'react';
+
+interface TimeWheelPickerProps {
+  value: string; // "HH:MM" 形式
+  onChange: (value: string) => void;
+  label?: string;
+  className?: string;
+}
+
+interface WheelColumnProps {
+  items: string[];
+  selectedIndex: number;
+  onSelect: (index: number) => void;
+  suffix?: string;
+}
+
+const ITEM_HEIGHT = 44;
+const VISIBLE_ITEMS = 5;
+const WHEEL_HEIGHT = ITEM_HEIGHT * VISIBLE_ITEMS;
+
+function WheelColumn({ items, selectedIndex, onSelect, suffix = '' }: WheelColumnProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isDragging = useRef(false);
+  const startY = useRef(0);
+  const startScrollTop = useRef(0);
+  const lastMoveTime = useRef(0);
+  const lastMoveY = useRef(0);
+  const velocity = useRef(0);
+  const animationRef = useRef<number | null>(null);
+  const isSettling = useRef(false);
+
+  // スクロール位置を選択項目に合わせる
+  const scrollToIndex = useCallback((index: number, smooth = true) => {
+    if (!containerRef.current) return;
+    const targetScroll = index * ITEM_HEIGHT;
+    if (smooth) {
+      containerRef.current.scrollTo({ top: targetScroll, behavior: 'smooth' });
+    } else {
+      containerRef.current.scrollTop = targetScroll;
+    }
+  }, []);
+
+  // 初期位置設定
+  useEffect(() => {
+    scrollToIndex(selectedIndex, false);
+  }, [selectedIndex, scrollToIndex]);
+
+  // スクロール停止後にスナップ
+  const settleToNearest = useCallback(() => {
+    if (!containerRef.current || isSettling.current) return;
+    isSettling.current = true;
+    const scrollTop = containerRef.current.scrollTop;
+    const nearestIndex = Math.round(scrollTop / ITEM_HEIGHT);
+    const clampedIndex = Math.max(0, Math.min(items.length - 1, nearestIndex));
+    scrollToIndex(clampedIndex, true);
+    if (clampedIndex !== selectedIndex) {
+      onSelect(clampedIndex);
+    }
+    setTimeout(() => { isSettling.current = false; }, 200);
+  }, [items.length, selectedIndex, onSelect, scrollToIndex]);
+
+  // タッチ開始
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    if (animationRef.current) {
+      cancelAnimationFrame(animationRef.current);
+      animationRef.current = null;
+    }
+    isDragging.current = true;
+    startY.current = e.touches[0].clientY;
+    startScrollTop.current = containerRef.current?.scrollTop ?? 0;
+    lastMoveTime.current = Date.now();
+    lastMoveY.current = e.touches[0].clientY;
+    velocity.current = 0;
+  }, []);
+
+  // タッチ移動
+  const handleTouchMove = useCallback((e: React.TouchEvent) => {
+    if (!isDragging.current || !containerRef.current) return;
+    e.preventDefault();
+    const currentY = e.touches[0].clientY;
+    const diff = startY.current - currentY;
+    containerRef.current.scrollTop = startScrollTop.current + diff;
+
+    const now = Date.now();
+    const dt = now - lastMoveTime.current;
+    if (dt > 0) {
+      velocity.current = (lastMoveY.current - currentY) / dt;
+    }
+    lastMoveTime.current = now;
+    lastMoveY.current = currentY;
+  }, []);
+
+  // タッチ終了 — 慣性スクロール
+  const handleTouchEnd = useCallback(() => {
+    isDragging.current = false;
+    if (!containerRef.current) return;
+
+    const v = velocity.current;
+    if (Math.abs(v) > 0.3) {
+      // 慣性: 速度に応じて追加スクロール
+      const momentum = v * 150;
+      const target = containerRef.current.scrollTop + momentum;
+      const nearestIndex = Math.round(target / ITEM_HEIGHT);
+      const clampedIndex = Math.max(0, Math.min(items.length - 1, nearestIndex));
+      scrollToIndex(clampedIndex, true);
+      if (clampedIndex !== selectedIndex) {
+        onSelect(clampedIndex);
+      }
+    } else {
+      settleToNearest();
+    }
+  }, [items.length, selectedIndex, onSelect, scrollToIndex, settleToNearest]);
+
+  // マウスホイール対応（PC）
+  const handleWheel = useCallback((e: React.WheelEvent) => {
+    e.preventDefault();
+    const direction = e.deltaY > 0 ? 1 : -1;
+    const newIndex = Math.max(0, Math.min(items.length - 1, selectedIndex + direction));
+    if (newIndex !== selectedIndex) {
+      onSelect(newIndex);
+      scrollToIndex(newIndex, true);
+    }
+  }, [items.length, selectedIndex, onSelect, scrollToIndex]);
+
+  // 項目クリック
+  const handleItemClick = useCallback((index: number) => {
+    if (index !== selectedIndex) {
+      onSelect(index);
+    }
+    scrollToIndex(index, true);
+  }, [selectedIndex, onSelect, scrollToIndex]);
+
+  return (
+    <div className="relative" style={{ height: WHEEL_HEIGHT }}>
+      {/* 選択行のハイライト */}
+      <div
+        className="absolute left-0 right-0 bg-[#66cc99]/10 border-y border-[#66cc99]/30 pointer-events-none z-10"
+        style={{ top: ITEM_HEIGHT * 2, height: ITEM_HEIGHT }}
+      />
+      {/* グラデーションマスク（上下のフェード） */}
+      <div className="absolute inset-0 pointer-events-none z-20 bg-gradient-to-b from-white via-transparent to-white" style={{ backgroundSize: '100% 100%', backgroundImage: 'linear-gradient(to bottom, rgba(255,255,255,0.95) 0%, rgba(255,255,255,0) 30%, rgba(255,255,255,0) 70%, rgba(255,255,255,0.95) 100%)' }} />
+      <div
+        ref={containerRef}
+        className="h-full overflow-hidden touch-none"
+        style={{ scrollbarWidth: 'none', msOverflowStyle: 'none', WebkitOverflowScrolling: 'touch' }}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+        onWheel={handleWheel}
+      >
+        {/* 上下のパディング（2アイテム分） */}
+        <div style={{ height: ITEM_HEIGHT * 2 }} />
+        {items.map((item, index) => {
+          const isSelected = index === selectedIndex;
+          return (
+            <div
+              key={index}
+              className={`flex items-center justify-center cursor-pointer select-none transition-colors ${
+                isSelected ? 'text-gray-900 font-bold text-lg' : 'text-gray-400 text-base'
+              }`}
+              style={{ height: ITEM_HEIGHT }}
+              onClick={() => handleItemClick(index)}
+            >
+              {item}{suffix}
+            </div>
+          );
+        })}
+        <div style={{ height: ITEM_HEIGHT * 2 }} />
+      </div>
+    </div>
+  );
+}
+
+const HOURS = Array.from({ length: 24 }, (_, i) => i.toString().padStart(2, '0'));
+const MINUTES = Array.from({ length: 60 }, (_, i) => i.toString().padStart(2, '0'));
+
+export function TimeWheelPicker({ value, onChange, label, className = '' }: TimeWheelPickerProps) {
+  const [hour, minute] = value.split(':');
+  const hourIndex = HOURS.indexOf(hour) >= 0 ? HOURS.indexOf(hour) : 0;
+  const minuteIndex = MINUTES.indexOf(minute) >= 0 ? MINUTES.indexOf(minute) : 0;
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [tempHour, setTempHour] = useState(hourIndex);
+  const [tempMinute, setTempMinute] = useState(minuteIndex);
+
+  // モーダルを開くときに現在値を同期
+  const handleOpen = () => {
+    setTempHour(hourIndex);
+    setTempMinute(minuteIndex);
+    setIsOpen(true);
+  };
+
+  const handleConfirm = () => {
+    onChange(`${HOURS[tempHour]}:${MINUTES[tempMinute]}`);
+    setIsOpen(false);
+  };
+
+  const handleCancel = () => {
+    setIsOpen(false);
+  };
+
+  return (
+    <>
+      {/* 表示ボタン */}
+      <button
+        type="button"
+        onClick={handleOpen}
+        className={`px-4 py-3 border border-gray-300 rounded-lg bg-white text-center font-medium text-gray-900 focus:outline-none focus:ring-2 focus:ring-[#66cc99] active:bg-gray-50 ${className}`}
+      >
+        {label && <span className="text-xs text-gray-500 block mb-0.5">{label}</span>}
+        <span className="text-xl">{value}</span>
+      </button>
+
+      {/* ピッカーモーダル */}
+      {isOpen && (
+        <div className="fixed inset-0 z-50 flex items-end justify-center">
+          {/* オーバーレイ */}
+          <div className="absolute inset-0 bg-black/40" onClick={handleCancel} />
+          {/* ピッカー本体 */}
+          <div className="relative w-full max-w-md bg-white rounded-t-2xl pb-safe animate-slide-up">
+            {/* ヘッダー */}
+            <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
+              <button
+                type="button"
+                onClick={handleCancel}
+                className="text-gray-500 text-sm px-3 py-1"
+              >
+                キャンセル
+              </button>
+              <span className="text-sm font-medium text-gray-700">
+                {label || '時刻を選択'}
+              </span>
+              <button
+                type="button"
+                onClick={handleConfirm}
+                className="text-[#66cc99] font-bold text-sm px-3 py-1"
+              >
+                決定
+              </button>
+            </div>
+            {/* ホイール */}
+            <div className="flex items-center justify-center px-8 py-4">
+              <div className="flex-1">
+                <WheelColumn
+                  items={HOURS}
+                  selectedIndex={tempHour}
+                  onSelect={setTempHour}
+                />
+              </div>
+              <div className="text-2xl font-bold text-gray-400 mx-2">:</div>
+              <div className="flex-1">
+                <WheelColumn
+                  items={MINUTES}
+                  selectedIndex={tempMinute}
+                  onSelect={setTempMinute}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+export default TimeWheelPicker;

--- a/constants/time.ts
+++ b/constants/time.ts
@@ -23,13 +23,11 @@ export const END_HOUR_OPTIONS = [
   })),
 ];
 
-// 分選択用（00, 15, 30, 45）
-export const MINUTE_OPTIONS = [
-  { value: '00', label: '00分' },
-  { value: '15', label: '15分' },
-  { value: '30', label: '30分' },
-  { value: '45', label: '45分' },
-] as const;
+// 分選択用（00〜59、1分単位）
+export const MINUTE_OPTIONS = Array.from({ length: 60 }, (_, i) => ({
+  value: i.toString().padStart(2, '0'),
+  label: `${i.toString().padStart(2, '0')}分`,
+})) as readonly { value: string; label: string }[];
 
 export const BREAK_TIME_OPTIONS = [
   { value: 0, label: 'なし' },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -50,6 +50,15 @@ export default {
         'primary': '0 2px 8px rgba(255, 51, 51, 0.3)',
         'secondary': '0 2px 8px rgba(56, 149, 255, 0.3)',
       },
+      keyframes: {
+        'slide-up': {
+          '0%': { transform: 'translateY(100%)' },
+          '100%': { transform: 'translateY(0)' },
+        },
+      },
+      animation: {
+        'slide-up': 'slide-up 0.3s ease-out',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- 求人の勤務時間設定を15分単位から1分単位に変更（求人作成・テンプレート）
- ワーカー向け勤怠変更申請にスクロールホイール型時刻ピッカーを導入（スマホ操作最適化）
- 勤怠変更申請から休憩時間の入力項目を削除（元の求人設定値を自動引き継ぎ）
- 施設管理者の承認画面で休憩時間に「（変更なし）」表示を追加

## 変更ファイル
- `constants/time.ts` — MINUTE_OPTIONSを1分単位に変更
- `components/ui/TimeWheelPicker.tsx` — 新規：スクロールホイール型時刻ピッカー
- `components/attendance/ModificationForm.tsx` — ピッカー適用・休憩時間入力削除
- `components/admin/attendance/ModificationRequestDetail.tsx` — 承認画面の表示調整
- `tailwind.config.ts` — スライドアップアニメーション追加

## 影響範囲
- DB変更: なし
- 環境変数変更: なし
- 既存データへの影響: なし（既存の15分単位データはそのまま動作）
- 施設管理画面・システム管理画面のUI: 変更なし

## Test plan
- [ ] 求人作成画面で分の選択肢が00〜59表示されること
- [ ] 求人テンプレート画面でも同様に1分単位で選択可能
- [ ] 勤怠変更申請でホイールピッカーが開閉・選択できること（スマホ実機推奨）
- [ ] 勤怠変更申請に休憩時間の入力欄がないこと
- [ ] 申請送信時に元の休憩時間が正しく引き継がれること
- [ ] 施設管理者の承認画面で休憩時間に「（変更なし）」表示
- [ ] 給与計算が正しく動作すること
- [ ] `npm run build` が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)