### PR TITLE
表記変更: ワーカー画面「審査あり」→「選考あり」

### DIFF
--- a/components/job/JobCard.tsx
+++ b/components/job/JobCard.tsx
@@ -161,7 +161,7 @@ const JobCardComponent: React.FC<JobCardProps> = ({ job, facility, selectedDate,
               )}
               {job.requiresInterview && (
                 <span className="bg-red-500 text-white text-[10px] font-bold px-2 py-1 rounded shadow-sm">
-                  審査あり
+                  選考あり
                 </span>
               )}
             </div>
@@ -283,7 +283,7 @@ const JobCardComponent: React.FC<JobCardProps> = ({ job, facility, selectedDate,
               )}
               {job.requiresInterview && (
                 <span className="bg-red-500 text-white text-[9px] font-bold px-1.5 py-0.5 rounded shadow-sm">
-                  審査あり
+                  選考あり
                 </span>
               )}
             </div>

--- a/components/job/JobDetailClient.tsx
+++ b/components/job/JobDetailClient.tsx
@@ -709,7 +709,7 @@ export function JobDetailClient({ job, facility, relatedJobs: _relatedJobs, faci
             )}
             {job.requiresInterview && (
               <span className="bg-red-500 text-white text-xs font-bold px-2 py-1 rounded shadow-md">
-                審査あり
+                選考あり
               </span>
             )}
           </div>
@@ -1379,7 +1379,7 @@ export function JobDetailClient({ job, facility, relatedJobs: _relatedJobs, faci
               </p>
             )}
             <p className="mt-2 text-xs text-gray-500">
-              ※この施設の審査あり求人における面接通過率です（採用・不採用の結果が出た応募が対象）
+              ※この施設の選考あり求人における面接通過率です（採用・不採用の結果が出た応募が対象）
             </p>
           </div>
         </div>
@@ -1602,9 +1602,9 @@ export function JobDetailClient({ job, facility, relatedJobs: _relatedJobs, faci
                   <div className="flex items-start gap-2">
                     <AlertTriangle className="w-5 h-5 text-yellow-600 flex-shrink-0 mt-0.5" />
                     <div>
-                      <p className="text-sm font-bold text-yellow-800">審査あり求人です</p>
+                      <p className="text-sm font-bold text-yellow-800">選考あり求人です</p>
                       <p className="text-xs text-yellow-700 mt-1">
-                        応募後、施設による審査があります。審査通過後にマッチングが成立します。
+                        応募後、施設による選考があります。選考通過後にマッチングが成立します。
                       </p>
                     </div>
                   </div>
@@ -1731,7 +1731,7 @@ export function JobDetailClient({ job, facility, relatedJobs: _relatedJobs, faci
                 disabled={isEditingSelfPR}
                 className="flex-1 px-4 py-2.5 bg-primary text-white font-medium rounded-lg hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                {job.jobType === 'OFFER' ? 'オファーを受ける' : (job.requiresInterview ? '応募する（審査あり）' : '応募する')}
+                {job.jobType === 'OFFER' ? 'オファーを受ける' : (job.requiresInterview ? '応募する（選考あり）' : '応募する')}
               </button>
             </div>
           </div>

--- a/components/job/WidgetJobCard.tsx
+++ b/components/job/WidgetJobCard.tsx
@@ -118,7 +118,7 @@ const WidgetJobCardComponent: React.FC<WidgetJobCardProps> = ({ job, facility, s
               <span className="bg-teal-500 text-white text-[9px] font-bold px-1.5 py-0.5 rounded shadow-sm">説明会</span>
             )}
             {job.requiresInterview && (
-              <span className="bg-red-500 text-white text-[9px] font-bold px-1.5 py-0.5 rounded shadow-sm">審査あり</span>
+              <span className="bg-red-500 text-white text-[9px] font-bold px-1.5 py-0.5 rounded shadow-sm">選考あり</span>
             )}
           </div>
           {shouldShowUnavailable && (


### PR DESCRIPTION
## Summary
- ワーカー向け画面の「審査あり」表記を「選考あり」に変更（クライアント依頼）
- 対象: 求人カード・求人詳細・ウィジェットカードのバッジ、説明文、応募ボタン
- 管理者画面は変更なし（従来通り「審査あり」を維持）

## 変更ファイル
- `components/job/JobCard.tsx` — バッジ表示2箇所
- `components/job/JobDetailClient.tsx` — バッジ・説明文・通過率注釈・応募ボタン計4箇所
- `components/job/WidgetJobCard.tsx` — バッジ表示1箇所

## Test plan
- [ ] 求人一覧で「選考あり」バッジが表示されること
- [ ] 求人詳細で「選考あり求人です」の説明文が表示されること
- [ ] 応募ボタンが「応募する（選考あり）」と表示されること
- [ ] 面接通過率の注釈が「選考あり求人における〜」と表示されること
- [ ] 管理者画面では従来通り「審査あり」のままであること

🤖 Generated with [Claude Code](https://claude.com/claude-code)