### PR TITLE
機能改善: 募集終了求人を一覧の下部にまとめて表示

### DIFF
--- a/src/lib/actions/job-worker.ts
+++ b/src/lib/actions/job-worker.ts
@@ -405,7 +405,7 @@ export async function getJobs(
     }
 
     // Date型を文字列に変換してシリアライズ可能にする
-    return jobs.map((job) => {
+    const result = jobs.map((job) => {
         // 一番近い勤務日を取得（互換性のため）
         const nearestWorkDate = job.workDates.length > 0 ? job.workDates[0] : null;
         // 総応募数を計算
@@ -502,6 +502,16 @@ export async function getJobs(
             isRecruitmentClosed: workDatesWithAvailability.length > 0 && workDatesWithAvailability.every(wd => wd.isRecruitmentClosed),
         };
     });
+
+    // 募集終了求人を下にまとめる（応募可能な求人が上、募集終了が下）
+    result.sort((a, b) => {
+        const aActive = a.hasAvailableWorkDate && !a.isRecruitmentClosed;
+        const bActive = b.hasAvailableWorkDate && !b.isRecruitmentClosed;
+        if (aActive === bActive) return 0;
+        return aActive ? -1 : 1;
+    });
+
+    return result;
 }
 
 /**
@@ -1330,6 +1340,14 @@ export async function getJobsListWithPagination(
     }
 
     const cleanedJobs = filteredJobsWithDistance.map(({ _distance, ...job }) => job);
+
+    // 募集終了求人を下にまとめる（応募可能な求人が上、募集終了が下）
+    cleanedJobs.sort((a, b) => {
+        const aActive = a.hasAvailableWorkDate && !a.isExpired && !a.isRecruitmentClosed;
+        const bActive = b.hasAvailableWorkDate && !b.isExpired && !b.isRecruitmentClosed;
+        if (aActive === bActive) return 0;
+        return aActive ? -1 : 1;
+    });
 
     return {
         jobs: cleanedJobs,


### PR DESCRIPTION
## Summary
- 求人一覧で応募可能な求人が上、募集終了の求人が下に表示されるようソート処理を追加
- `getJobsListWithPagination`（メイン一覧）と `getJobs`（関連求人）の両方に適用
- 既存のソート順（作成日/時給/距離）は同グループ内で維持

## Test plan
- [ ] ホーム画面で募集終了求人が下部にまとまっていることを確認
- [ ] 公開求人一覧（未ログイン）でも同様の並び順になることを確認
- [ ] 時給順・距離順ソートを切り替えても募集終了が下にまとまることを確認
- [ ] 求人詳細ページの「同じ施設の求人」でも同様に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)