### PR TITLE
機能追加: TasLink外部API連携（ワーカープロフィール同期）

### DIFF
--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -8,6 +8,7 @@ import { logActivity, getErrorMessage, getErrorStack } from '@/lib/logger';
 import { findLpByIpAddress } from '@/src/lib/lp-attribution';
 import { getClientIpAddress } from '@/src/lib/device-info';
 import { validatePhoneVerificationToken } from '@/src/lib/auth/phone-verification';
+import { syncWorkerToTasLink, mapUserToTasLinkPayload } from '@/src/lib/taslink';
 
 interface RegisterBody {
   email: string;
@@ -215,6 +216,16 @@ export async function POST(request: NextRequest) {
       );
     } catch (notifyErr) {
       console.error('Failed to notify admin:', getErrorMessage(notifyErr));
+    }
+
+    // TasLinkへワーカー情報を同期（同期完了を待つが、失敗しても登録は成功させる）
+    try {
+      const tasLinkPayload = mapUserToTasLinkPayload(user);
+      if (tasLinkPayload) {
+        await syncWorkerToTasLink(user.id, tasLinkPayload);
+      }
+    } catch (tasLinkErr) {
+      console.error('[TasLink] Registration sync failed:', getErrorMessage(tasLinkErr));
     }
 
     return NextResponse.json({

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -116,6 +116,11 @@ model User {
   /// 登録時のキャンペーンコードのジャンルプレフィックス（例: "AAA"）
   registration_genre_prefix  String? @map("registration_genre_prefix") @db.VarChar(3)
 
+  /// TasLink外部連携ID
+  taslink_id        String?   @map("taslink_id")
+  /// TasLink最終同期日時
+  taslink_synced_at DateTime? @map("taslink_synced_at")
+
   @@index([registration_lp_id])
   @@index([registration_genre_prefix])
   @@map("users")

--- a/src/lib/actions/user-profile.ts
+++ b/src/lib/actions/user-profile.ts
@@ -7,6 +7,7 @@ import { geocodeAddress } from '@/src/lib/geocoding';
 import { logActivity, getErrorMessage, getErrorStack } from '@/lib/logger';
 import { generateBankAccountName } from '@/lib/string-utils';
 import { validatePhoneVerificationToken } from '@/src/lib/auth/phone-verification';
+import { syncWorkerToTasLink, mapUserToTasLinkPayload } from '@/src/lib/taslink';
 
 /**
  * SMS認証成功時に電話番号を即座にDBに保存する
@@ -241,6 +242,28 @@ export async function updateUserSelfPR(selfPR: string): Promise<{ success: boole
             where: { id: user.id },
             data: { self_pr: selfPR.trim() || null, updated_by_type: 'WORKER', updated_by_id: user.id },
         });
+
+        // TasLinkへ自己PR更新を同期（DBからフルプロフィールを取得して送信）
+        try {
+            const fullUser = await prisma.user.findUnique({
+                where: { id: user.id },
+                select: {
+                    id: true, name: true, last_name_kana: true, first_name_kana: true,
+                    gender: true, birth_date: true, phone_number: true, email: true,
+                    postal_code: true, prefecture: true, city: true, address_line: true,
+                    qualifications: true, desired_work_days: true, desired_work_style: true,
+                    work_histories: true, self_pr: true,
+                },
+            });
+            if (fullUser) {
+                const tasLinkPayload = mapUserToTasLinkPayload(fullUser);
+                if (tasLinkPayload) {
+                    await syncWorkerToTasLink(user.id, tasLinkPayload);
+                }
+            }
+        } catch (tasLinkErr) {
+            console.error('[TasLink] Self-PR sync failed:', getErrorMessage(tasLinkErr));
+        }
 
         return { success: true };
     } catch (error) {
@@ -544,6 +567,34 @@ export async function updateUserProfile(formData: FormData) {
             },
             result: 'SUCCESS',
         }).catch(() => {});
+
+        // TasLinkへプロフィール更新を同期（同期完了を待つが、失敗しても更新は成功させる）
+        try {
+            const tasLinkPayload = mapUserToTasLinkPayload({
+                id: user.id,
+                name,
+                last_name_kana: lastNameKana,
+                first_name_kana: firstNameKana,
+                gender,
+                birth_date: birthDate ? new Date(birthDate) : null,
+                phone_number: phoneNumber,
+                email,
+                postal_code: postalCode,
+                prefecture,
+                city,
+                address_line: addressLine,
+                qualifications,
+                desired_work_days: desiredWorkDays,
+                desired_work_style: desiredWorkStyle,
+                work_histories: workHistories,
+                self_pr: selfPR,
+            });
+            if (tasLinkPayload) {
+                await syncWorkerToTasLink(user.id, tasLinkPayload);
+            }
+        } catch (tasLinkErr) {
+            console.error('[TasLink] Profile sync failed:', getErrorMessage(tasLinkErr));
+        }
 
         return {
             success: true,

--- a/src/lib/taslink.ts
+++ b/src/lib/taslink.ts
@@ -1,0 +1,289 @@
+/**
+ * TasLink 外部API連携クライアント
+ * ワーカー（求職者）情報をTasLinkへ同期するサーバーサイドモジュール
+ *
+ * NOTE for TasLink developers:
+ * - externalId にはタスタス側の user.id（数値→文字列）を使用
+ * - POST /api/v1/external/workers で upsert（同じexternalIdなら更新）
+ * - レスポンスの id フィールドをタスタス側DBに保存している
+ *   → レスポンス形式が { data: { id: "xxx" } } 等の場合はパース処理の調整が必要
+ * - qualifications → jobTypes/qualifications のマッピングは暫定実装
+ *   → TasLink側マスタと完全一致しない値は "その他" にフォールバックしている
+ */
+
+import prisma from '@/lib/prisma';
+
+const API_URL = process.env.TASLINK_API_URL;
+const API_KEY = process.env.TASLINK_API_KEY;
+
+// --- 型定義 ---
+
+/** TasLink Worker APIに送信するペイロード */
+export interface TasLinkWorkerPayload {
+  externalId: string;
+  lastName: string;
+  firstName: string;
+  lastNameKana?: string;
+  firstNameKana?: string;
+  gender?: 'MALE' | 'FEMALE' | 'OTHER' | 'UNSPECIFIED';
+  dateOfBirth?: string;
+  phone?: string;
+  email?: string;
+  postalCode?: string;
+  prefecture?: string;
+  city?: string;
+  address?: string;
+  jobTypes?: string[];
+  qualifications?: string[];
+  availableDays?: string[];
+  workPreference?: 'ONE_TIME' | 'ONGOING' | 'BOTH';
+  workHistory?: string;
+  notes?: string;
+  registrationSource?: string;
+}
+
+/** TasLink API同期結果 */
+export interface TasLinkSyncResult {
+  success: boolean;
+  tasLinkId?: string;
+  error?: string;
+}
+
+/** Userモデルからマッピングに必要なフィールド */
+export interface UserDataForSync {
+  id: number;
+  name: string;
+  last_name_kana?: string | null;
+  first_name_kana?: string | null;
+  gender?: string | null;
+  birth_date?: Date | null;
+  phone_number?: string | null;
+  email?: string | null;
+  postal_code?: string | null;
+  prefecture?: string | null;
+  city?: string | null;
+  address_line?: string | null;
+  qualifications?: string[];
+  desired_work_days?: string[];
+  desired_work_style?: string | null;
+  work_histories?: string[];
+  self_pr?: string | null;
+}
+
+// --- マッピング定数 ---
+
+/**
+ * タスタス資格名 → TasLink職種マスタ (jobTypes)
+ * NOTE: TasLink側の職種マスタにないものは "その他" にフォールバック
+ */
+const JOB_TYPE_MAP: Record<string, string> = {
+  '看護師': '看護師',
+  '准看護師': '准看護師',
+  '介護士': '介護士',
+  '介護福祉士': '介護福祉士',
+  '初任者研修': '初任者研修',
+  '実務者研修': '実務者研修',
+  '理学療法士': '理学療法士',
+  '作業療法士': '作業療法士',
+};
+
+/**
+ * タスタス資格名 → TasLink資格マスタ (qualifications)
+ * NOTE: TasLink側の資格マスタと名称が異なるものは変換が必要
+ */
+const QUALIFICATION_MAP: Record<string, string> = {
+  '看護師': '看護師免許',
+  '准看護師': '准看護師免許',
+  '介護福祉士': '介護福祉士',
+  '初任者研修': '介護職員初任者研修',
+  '実務者研修': '介護職員実務者研修',
+  '社会福祉士': '社会福祉士',
+  '理学療法士': '理学療法士',
+  '作業療法士': '作業療法士',
+  '言語聴覚士': '言語聴覚士',
+  '管理栄養士': '管理栄養士',
+  '栄養士': '栄養士',
+  '保育士': '保育士',
+};
+
+// --- マッピング関数 ---
+
+/** 性別をTasLink形式に変換 */
+function mapGender(gender: string | null | undefined): TasLinkWorkerPayload['gender'] {
+  if (!gender) return 'UNSPECIFIED';
+  const mapping: Record<string, TasLinkWorkerPayload['gender']> = {
+    '男性': 'MALE',
+    '女性': 'FEMALE',
+    'その他': 'OTHER',
+    'MALE': 'MALE',
+    'FEMALE': 'FEMALE',
+    'OTHER': 'OTHER',
+  };
+  return mapping[gender] || 'UNSPECIFIED';
+}
+
+/** 就業形態希望をTasLink形式に変換 */
+function mapWorkPreference(style: string | null | undefined): TasLinkWorkerPayload['workPreference'] | undefined {
+  if (!style) return undefined;
+  const mapping: Record<string, TasLinkWorkerPayload['workPreference']> = {
+    '単発': 'ONE_TIME',
+    '単発希望': 'ONE_TIME',
+    '継続': 'ONGOING',
+    '継続希望': 'ONGOING',
+    'どちらも': 'BOTH',
+    'どちらも可': 'BOTH',
+  };
+  return mapping[style] || undefined;
+}
+
+/** タスタス資格配列 → TasLink jobTypes 配列に変換（重複排除） */
+function mapToJobTypes(qualifications: string[]): string[] {
+  const mapped = qualifications.map(q => JOB_TYPE_MAP[q] || 'その他');
+  return Array.from(new Set(mapped));
+}
+
+/** タスタス資格配列 → TasLink qualifications 配列に変換（重複排除） */
+function mapToQualifications(qualifications: string[]): string[] {
+  const mapped = qualifications.map(q => QUALIFICATION_MAP[q] || 'その他');
+  return Array.from(new Set(mapped));
+}
+
+/**
+ * nameフィールドを姓名に分割
+ * 全角・半角スペース両対応
+ */
+function splitName(name: string): { lastName: string; firstName: string } | null {
+  if (!name.trim()) return null;
+  const parts = name.trim().split(/\s+/);
+  if (parts.length >= 2) {
+    return { lastName: parts[0], firstName: parts.slice(1).join(' ') };
+  }
+  // 姓のみ（スペースなし）の場合
+  return { lastName: parts[0], firstName: '' };
+}
+
+/** Date → JST基準のISO 8601日付文字列 (YYYY-MM-DD) */
+function toJSTDateStr(date: Date): string {
+  const jst = new Date(date.getTime() + 9 * 60 * 60 * 1000);
+  return jst.toISOString().split('T')[0];
+}
+
+/** UserデータをTasLink APIペイロードに変換。名前が空の場合はnullを返す */
+export function mapUserToTasLinkPayload(user: UserDataForSync): TasLinkWorkerPayload | null {
+  const nameResult = splitName(user.name);
+  if (!nameResult || !nameResult.lastName) {
+    // lastName が空の場合、TasLink APIの必須フィールドを満たせないため同期スキップ
+    return null;
+  }
+
+  const payload: TasLinkWorkerPayload = {
+    externalId: String(user.id),
+    lastName: nameResult.lastName,
+    firstName: nameResult.firstName,
+  };
+
+  if (user.last_name_kana) payload.lastNameKana = user.last_name_kana;
+  if (user.first_name_kana) payload.firstNameKana = user.first_name_kana;
+  payload.gender = mapGender(user.gender);
+  if (user.birth_date) payload.dateOfBirth = toJSTDateStr(user.birth_date);
+  if (user.phone_number) payload.phone = user.phone_number;
+  if (user.email) payload.email = user.email;
+  if (user.postal_code) payload.postalCode = user.postal_code;
+  if (user.prefecture) payload.prefecture = user.prefecture;
+  if (user.city) payload.city = user.city;
+  if (user.address_line) payload.address = user.address_line;
+  if (user.qualifications && user.qualifications.length > 0) {
+    payload.jobTypes = mapToJobTypes(user.qualifications);
+    payload.qualifications = mapToQualifications(user.qualifications);
+  }
+  if (user.desired_work_days && user.desired_work_days.length > 0) {
+    payload.availableDays = user.desired_work_days;
+  }
+  const workPref = mapWorkPreference(user.desired_work_style);
+  if (workPref) payload.workPreference = workPref;
+  if (user.work_histories && user.work_histories.length > 0) {
+    payload.workHistory = user.work_histories.join('\n');
+  }
+  if (user.self_pr) payload.notes = user.self_pr;
+
+  return payload;
+}
+
+// --- API呼び出し ---
+
+/**
+ * ワーカー情報をTasLinkに同期
+ * POST /api/v1/external/workers（externalIdによるupsert）
+ *
+ * 成功時はtaslink_idとtaslink_synced_atをDBに保存する。
+ * エラー時はログ出力のみ、例外はスローしない。
+ * awaitで呼び出すため、TasLink APIの応答を待ってからレスポンスを返す。
+ */
+export async function syncWorkerToTasLink(
+  userId: number,
+  payload: TasLinkWorkerPayload,
+): Promise<TasLinkSyncResult> {
+  if (!API_URL || !API_KEY) {
+    console.warn('[TasLink] Not configured (TASLINK_API_URL or TASLINK_API_KEY missing), skipping sync');
+    return { success: false, error: 'TasLink not configured' };
+  }
+
+  try {
+    const response = await fetch(`${API_URL}/api/v1/external/workers`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': API_KEY,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (response.status === 200 || response.status === 201) {
+      const data = await response.json();
+      // NOTE: TasLink APIのレスポンス形式に応じてパスを調整すること
+      const tasLinkId = String(data.id ?? data.data?.id ?? '');
+
+      // DB に TasLink ID と同期日時を保存
+      if (tasLinkId) {
+        try {
+          await prisma.user.update({
+            where: { id: userId },
+            data: {
+              taslink_id: tasLinkId,
+              taslink_synced_at: new Date(),
+            },
+          });
+        } catch (dbError) {
+          console.error('[TasLink] DB update failed (API sync succeeded):', dbError instanceof Error ? dbError.message : String(dbError));
+          return { success: true, tasLinkId, error: 'API sync succeeded but DB update failed' };
+        }
+      }
+
+      console.log('[TasLink] Worker synced successfully:', { userId, tasLinkId });
+      return { success: true, tasLinkId };
+    }
+
+    if (response.status === 400) {
+      const errorBody = await response.text();
+      console.error('[TasLink] Validation error:', { userId, status: 400, body: errorBody.slice(0, 500) });
+      return { success: false, error: `Validation error (400): ${errorBody.slice(0, 200)}` };
+    }
+
+    if (response.status === 401) {
+      console.error('[TasLink] Authentication failed: invalid API key');
+      return { success: false, error: 'Authentication failed (401)' };
+    }
+
+    if (response.status === 429) {
+      console.warn('[TasLink] Rate limited:', { userId });
+      return { success: false, error: 'Rate limited (429)' };
+    }
+
+    const errorBody = await response.text();
+    console.error('[TasLink] Sync failed:', { userId, status: response.status, body: errorBody.slice(0, 500) });
+    return { success: false, error: `Sync failed (${response.status}): ${errorBody.slice(0, 200)}` };
+  } catch (error) {
+    console.error('[TasLink] Network error:', error instanceof Error ? error.message : String(error));
+    return { success: false, error: `Network error: ${error instanceof Error ? error.message : String(error)}` };
+  }
+}


### PR DESCRIPTION
## Summary
- ワーカーの登録・プロフィール更新・自己PR更新時にTasLink APIへ自動同期する機能を追加
- TasLink API仕様書（2026-04-04版）に基づき、Worker エンティティの連携を実装
- 同期失敗時もタスタス側の処理は正常に完了する（エラーハンドリング分離）

## 変更ファイル
| ファイル | 変更内容 |
|---|---|
| `prisma/schema.prisma` | User モデルに `taslink_id`, `taslink_synced_at` 追加 |
| `src/lib/taslink.ts` | **新規** - TasLink APIクライアント（マッピング・認証・エラーハンドリング） |
| `app/api/auth/register/route.ts` | 登録完了後にTasLink同期フック追加 |
| `src/lib/actions/user-profile.ts` | updateUserProfile, updateUserSelfPR にTasLink同期フック追加 |

## セルフレビューで修正した内容
- [x] DB更新失敗時のエラーハンドリング分離（API成功 + DB失敗を区別）
- [x] jobTypes / qualifications の個別マッピング関数作成（職種マスタと資格マスタの違い対応）
- [x] lastName/firstName 空文字ガード（名前未設定時は同期スキップ）
- [x] updateUserSelfPR をフルペイロード化（空文字で既存データ上書き防止）
- [x] birth_date の JST基準変換（UTC→JST 1日ズレ防止）
- [x] 429 Rate Limit ハンドリング追加
- [x] APIレスポンスパースの安全化（`data.id ?? data.data?.id`）
- [x] コメント修正（「fire-and-forget」→「同期完了を待つが失敗しても成功させる」）
- [x] TasLink同期の実行順序をログ記録の後に統一

## TasLink開発者への注意事項
1. **レスポンス形式の確認が必要**: `data.id` でパースしているが、`{ data: { id: "xxx" } }` 形式の場合は調整が必要（`taslink.ts` L232参照）
2. **jobTypes/qualifications マッピングは暫定**: タスタス側の資格名とTasLink側マスタが完全一致しないものは `"その他"` にフォールバック。マッピング定義の拡充が必要な場合は `JOB_TYPE_MAP` / `QUALIFICATION_MAP` を更新
3. **externalId**: タスタスの `user.id`（数値→文字列）を使用。同じexternalIdで再送信するとupsert動作

## デプロイ時の作業
```
【デプロイ前確認】
- DB変更: あり（taslink_id, taslink_synced_at カラム追加）
- 必要な作業:
  - [ ] 本番/ステージングで npx prisma db push（手動実行）
  - [ ] Vercelダッシュボードで環境変数追加: TASLINK_API_URL, TASLINK_API_KEY
```

## Test plan
- [ ] ビルド確認（`npm run build` TypeScriptエラーなし）✅ 確認済み
- [ ] 開発環境で登録→コンソールログにTasLink同期ログ出力確認
- [ ] プロフィール更新→TasLink同期ログ確認
- [ ] TASLINK_API_URL 未設定時→warn出力でスキップ確認
- [ ] TasLink API障害時→タスタス側の登録・更新が正常完了すること確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)