### PR TITLE
仕様変更: SMS認証コードの有効期限を10分から7日間に変更

### DIFF
--- a/src/lib/auth/phone-verification.ts
+++ b/src/lib/auth/phone-verification.ts
@@ -5,7 +5,7 @@
  */
 import { SignJWT, jwtVerify } from 'jose';
 
-const TOKEN_EXPIRY = '10m'; // 10分有効
+const TOKEN_EXPIRY = '7d'; // 7日間有効
 
 function getSecret(): Uint8Array {
   const secret = process.env.NEXTAUTH_SECRET;

--- a/src/lib/cpaasnow.ts
+++ b/src/lib/cpaasnow.ts
@@ -8,7 +8,7 @@ const API_TOKEN = process.env.CPAAS_NOW_API_TOKEN;
 
 // SMS本文テンプレート
 // {{verification_code}}: 認証コードに置換、{{expiration_minutes}}: 有効期限(分)に置換
-const SMS_TEMPLATE = '【タスタス】認証コード: {{verification_code}}\r\n有効期限: {{expiration_minutes}}分';
+const SMS_TEMPLATE = '【タスタス】認証コード: {{verification_code}}\r\n有効期限: 7日間';
 
 export interface SendCodeResult {
   success: boolean;
@@ -45,7 +45,7 @@ export async function sendVerificationCode(phoneNumber: string): Promise<SendCod
         message: SMS_TEMPLATE,
         code_type: 'numeric',
         code_size: 6,
-        expiration_minutes: 10,
+        expiration_minutes: 10080, // 7日間（60分 × 24時間 × 7日）
       }),
     });
 


### PR DESCRIPTION
## Summary
- SMS認証コード（CPaaS NOW）の有効期限を10分→7日間（10080分）に変更
- 認証成功後のJWTトークン有効期限も10分→7日間に変更
- SMSテンプレートの有効期限表示を「7日間」に修正

## 変更ファイル
- `src/lib/cpaasnow.ts` — `expiration_minutes: 10` → `10080`、SMSテンプレート表示修正
- `src/lib/auth/phone-verification.ts` — `TOKEN_EXPIRY: '10m'` → `'7d'`

## 注意事項
- CPaaS NOW APIが `expiration_minutes: 10080` を受け入れるか、サンドボックスでの動作確認を推奨
- DB変更なし（デプロイのみで反映）

## Test plan
- [ ] サンドボックス環境でSMS送信が成功することを確認
- [ ] 認証コードが7日間有効であることを確認
- [ ] SMSメッセージに「有効期限: 7日間」と表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)