### PR TITLE
バグ修正: PP/利用規約更新が公開ページに反映されない問題

### DIFF
--- a/src/lib/content-actions.ts
+++ b/src/lib/content-actions.ts
@@ -351,6 +351,14 @@ export async function updateSingleFaqOrder(id: number, sortOrder: number) {
 
 // ========== 利用規約・プライバシーポリシー ==========
 
+// 公開ページ（ISR/動的レンダリング）のキャッシュ無効化対象
+function getPublicLegalPaths(docType: 'TERMS' | 'PRIVACY', targetType: 'WORKER' | 'FACILITY'): string[] {
+    if (docType === 'PRIVACY' && targetType === 'WORKER') return ['/privacy'];
+    if (docType === 'TERMS' && targetType === 'WORKER') return ['/terms'];
+    if (docType === 'TERMS' && targetType === 'FACILITY') return ['/terms/facility'];
+    return [];
+}
+
 export async function getLegalDocument(docType: 'TERMS' | 'PRIVACY', targetType: 'WORKER' | 'FACILITY') {
     const doc = await prisma.legalDocument.findFirst({
         where: {
@@ -413,6 +421,9 @@ export async function createLegalDocument(data: {
     });
 
     revalidatePath('/system-admin/content/legal');
+    for (const path of getPublicLegalPaths(data.docType, data.targetType)) {
+        revalidatePath(path);
+    }
     return doc;
 }
 
@@ -443,6 +454,9 @@ export async function revertToLegalDocumentVersion(id: number) {
     });
 
     revalidatePath('/system-admin/content/legal');
+    for (const path of getPublicLegalPaths(targetDoc.doc_type as 'TERMS' | 'PRIVACY', targetDoc.target_type as 'WORKER' | 'FACILITY')) {
+        revalidatePath(path);
+    }
 }
 
 // ========== ご利用ガイド ==========


### PR DESCRIPTION
## 概要
クライアントから「システム管理からPPの変更をしたが反映されない」との報告あり。原因を特定し修正。

## 原因
- `app/privacy/page.tsx` は `export const revalidate = 3600`（1時間ISRキャッシュ）
- `src/lib/content-actions.ts` の `createLegalDocument` / `revertToLegalDocumentVersion` は `/system-admin/content/legal` のみ revalidate
- 公開ページ（`/privacy` など）の ISR キャッシュがパージされず、最大1時間旧コンテンツが表示されていた

## 修正内容
- 公開ページのパスを返すヘルパー `getPublicLegalPaths` を追加
- `createLegalDocument` / `revertToLegalDocumentVersion` から公開ページも revalidate

## 対象パス
| docType | targetType | 公開パス |
|---------|-----------|---------|
| PRIVACY | WORKER    | `/privacy` |
| TERMS   | WORKER    | `/terms` |
| TERMS   | FACILITY  | `/terms/facility` |

※ FACILITY PRIVACY の公開ページは存在しないため対象外

## Test plan
- [x] `npx next build` 成功（TypeScriptエラーなし）
- [ ] ステージングで /system-admin/content/legal からPPを編集 → 保存
- [ ] /privacy にアクセスし、保存内容が即座に反映されることを確認
- [ ] 利用規約（ワーカー/施設）でも同様に確認
- [ ] バージョン履歴から「この版に戻す」を実行し、公開ページに即反映されることを確認

## DB変更
なし（デプロイのみで反映）

🤖 Generated with [Claude Code](https://claude.com/claude-code)