### PR TITLE
機能追加: 新しい会員登録フロー（8ステップUI）とデュアル識別子ログイン

### DIFF
--- a/app/api/auth/auto-login/route.ts
+++ b/app/api/auth/auto-login/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { encode } from 'next-auth/jwt';
 import prisma from '@/lib/prisma';
 import { logActivity } from '@/lib/logger';
+import { issueSessionCookie } from '@/src/lib/auth/session-cookie';
 
 /**
  * サーバーサイド自動ログインエンドポイント
@@ -67,18 +67,6 @@ export async function GET(request: NextRequest) {
       },
     });
 
-    // NextAuth JWT トークンを生成
-    const jwtToken = await encode({
-      token: {
-        id: String(user.id),
-        email: user.email,
-        name: user.name,
-        sub: String(user.id),
-      },
-      secret: process.env.NEXTAUTH_SECRET!,
-      maxAge: 30 * 24 * 60 * 60, // 30日（lib/auth.tsのsession.maxAgeと同じ）
-    });
-
     // リダイレクト先のバリデーション（オープンリダイレクト防止）
     const isRelativeUrl = redirect.startsWith('/') && !redirect.startsWith('//');
     const safeRedirect = isRelativeUrl ? redirect : '/';
@@ -87,23 +75,11 @@ export async function GET(request: NextRequest) {
       new URL(safeRedirect, request.nextUrl.origin)
     );
 
-    // NextAuth セッションCookieを設定
-    const isProduction = process.env.NODE_ENV === 'production';
-    const cookieName = isProduction
-      ? '__Secure-next-auth.session-token'
-      : 'next-auth.session-token';
-
-    response.cookies.set(cookieName, jwtToken, {
-      httpOnly: true,
-      secure: isProduction,
-      sameSite: 'lax',
-      path: '/',
-      maxAge: 30 * 24 * 60 * 60, // 30日
+    await issueSessionCookie(response, {
+      id: user.id,
+      email: user.email,
+      name: user.name,
     });
-
-    // セキュリティヘッダー（トークン漏洩防止）
-    response.headers.set('Cache-Control', 'no-store');
-    response.headers.set('Referrer-Policy', 'no-referrer');
 
     console.log('[AutoLogin] Success for user:', user.id);
 

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -9,6 +9,8 @@ import { findLpByIpAddress } from '@/src/lib/lp-attribution';
 import { getClientIpAddress } from '@/src/lib/device-info';
 import { validatePhoneVerificationToken } from '@/src/lib/auth/phone-verification';
 import { syncWorkerToTasLink, mapUserToTasLinkPayload } from '@/src/lib/taslink';
+import { issueSessionCookie } from '@/src/lib/auth/session-cookie';
+import { normalizePhoneDigits, phoneLockKey } from '@/src/lib/auth/identifier';
 
 interface RegisterBody {
   email: string;
@@ -31,6 +33,11 @@ interface RegisterBody {
   experienceFields?: Record<string, unknown>;
   workHistories?: string[];
   qualificationCertificates?: Record<string, unknown>;
+  // 新登録フロー（モック8ステップ）項目
+  desiredWorkStyle?: string[];     // 希望の働き方（複数選択）
+  workFrequency?: string;           // 週の頻度（step 2b）
+  jobTiming?: string;               // いつ頃探しているか
+  employmentStatus?: string;        // 現在の就業状況
   // LP経由登録情報
   registrationLpId?: string;
   registrationCampaignCode?: string;
@@ -39,6 +46,10 @@ interface RegisterBody {
   lpAttributionSource?: string;
   // 電話番号SMS認証トークン
   phoneVerificationToken?: string;
+}
+
+function normalizeEmail(input: string): string {
+  return input.trim().toLowerCase();
 }
 
 export async function POST(request: NextRequest) {
@@ -66,6 +77,10 @@ export async function POST(request: NextRequest) {
       experienceFields,
       workHistories,
       qualificationCertificates,
+      desiredWorkStyle,
+      workFrequency,
+      jobTiming,
+      employmentStatus,
       registrationLpId,
       registrationCampaignCode,
       registrationGenrePrefix,
@@ -110,6 +125,32 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // パスワード: 最低 8 文字
+    if (typeof password !== 'string' || password.length < 8) {
+      return NextResponse.json(
+        { error: 'パスワードは8文字以上で入力してください' },
+        { status: 400 }
+      );
+    }
+
+    // メール形式チェック
+    const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (typeof email !== 'string' || !EMAIL_RE.test(email.trim())) {
+      return NextResponse.json(
+        { error: 'メールアドレスの形式が正しくありません' },
+        { status: 400 }
+      );
+    }
+
+    const normalizedEmail = normalizeEmail(email);
+    const normalizedPhone = normalizePhoneDigits(phoneNumber);
+    if (normalizedPhone.length < 10 || normalizedPhone.length > 11) {
+      return NextResponse.json(
+        { error: '電話番号の形式が正しくありません' },
+        { status: 400 }
+      );
+    }
+
     // 電話番号SMS認証トークンの検証
     if (!phoneVerificationToken) {
       return NextResponse.json(
@@ -118,7 +159,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const isPhoneVerified = await validatePhoneVerificationToken(phoneVerificationToken, phoneNumber);
+    const isPhoneVerified = await validatePhoneVerificationToken(phoneVerificationToken, normalizedPhone);
     if (!isPhoneVerified) {
       return NextResponse.json(
         { error: '電話番号の認証トークンが無効または期限切れです。再度認証を行ってください。' },
@@ -126,15 +167,14 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // メールアドレスの重複チェック
-    const existingUser = await prisma.user.findUnique({
-      where: { email },
+    // メールアドレスの重複チェック（case-insensitive、既存レガシーデータ対応）
+    const existingEmailUser = await prisma.user.findFirst({
+      where: { email: { equals: normalizedEmail, mode: 'insensitive' } },
     });
-
-    if (existingUser) {
+    if (existingEmailUser) {
       return NextResponse.json(
         { error: 'このメールアドレスは既に登録されています' },
-        { status: 400 }
+        { status: 409 }
       );
     }
 
@@ -146,35 +186,89 @@ export async function POST(request: NextRequest) {
       ? workHistories.filter((h: string) => h && h.trim() !== '')
       : [];
 
-    // ユーザー作成（name は空文字許容）
-    const user = await prisma.user.create({
-      data: {
-        email,
-        password_hash: hashedPassword,
-        name: resolvedName,
-        phone_number: phoneNumber,
-        phone_verified: true,
-        phone_verified_at: new Date(),
-        birth_date: birthDate ? new Date(birthDate + 'T00:00:00+09:00') : null,
-        qualifications: qualifications || [],
-        last_name_kana: lastNameKana || null,
-        first_name_kana: firstNameKana || null,
-        gender: gender || null,
-        nationality: nationality || null,
-        postal_code: postalCode || null,
-        prefecture: prefecture || null,
-        city: city || null,
-        address_line: addressLine || null,
-        building: building || null,
-        experience_fields: experienceFields && Object.keys(experienceFields).length > 0 ? experienceFields as Prisma.InputJsonValue : Prisma.DbNull,
-        work_histories: workHistoriesArray,
-        qualification_certificates: qualificationCertificates && Object.keys(qualificationCertificates).length > 0 ? qualificationCertificates as Prisma.InputJsonValue : Prisma.DbNull,
-        // LP経由登録情報（フォールバックチェーン適用済み）
-        registration_lp_id: resolvedLpId,
-        registration_campaign_code: resolvedCampaignCode,
-        registration_genre_prefix: resolvedGenrePrefix,
-      },
-    });
+    // 希望の働き方（複数選択）は CSV で保存（既存 String? カラム踏襲）
+    const desiredWorkStyleCsv = Array.isArray(desiredWorkStyle) && desiredWorkStyle.length > 0
+      ? desiredWorkStyle.filter(s => s && s.trim() !== '').join(',')
+      : null;
+
+    // 電話番号の race 軽減: Postgres advisory xact lock で同一電話番号の同時登録を直列化
+    const lockKey = phoneLockKey(normalizedPhone);
+
+    // ユーザー作成（name は空文字許容）。P2002 (email unique 衝突) で email race を検出
+    let user;
+    try {
+      user = await prisma.$transaction(async (tx) => {
+        // 電話番号に対する advisory lock（トランザクション終了まで保持、他セッションは待機）
+        await tx.$queryRaw(
+          Prisma.sql`SELECT pg_advisory_xact_lock(${lockKey}::bigint)`
+        );
+
+        // ロック取得後の再チェック（race safe）
+        // 既存データにハイフンや全角数字が残っている可能性に備え、SQL 側で正規化比較
+        // translate で全角数字 → 半角数字、regexp_replace で非数字除去
+        const phoneExists = await tx.$queryRaw<{ id: number }[]>(
+          Prisma.sql`SELECT id FROM users
+            WHERE regexp_replace(translate(phone_number, '０１２３４５６７８９', '0123456789'), '[^0-9]', '', 'g') = ${normalizedPhone}
+            AND phone_verified = true
+            AND deleted_at IS NULL
+            LIMIT 1`
+        );
+        if (phoneExists.length > 0) {
+          throw new Error('PHONE_ALREADY_REGISTERED');
+        }
+
+        return tx.user.create({
+          data: {
+            email: normalizedEmail,
+            password_hash: hashedPassword,
+            name: resolvedName,
+            phone_number: normalizedPhone,
+            phone_verified: true,
+            phone_verified_at: new Date(),
+            birth_date: birthDate ? new Date(birthDate + 'T00:00:00+09:00') : null,
+            qualifications: qualifications || [],
+            last_name_kana: lastNameKana || null,
+            first_name_kana: firstNameKana || null,
+            gender: gender || null,
+            nationality: nationality || null,
+            postal_code: postalCode || null,
+            prefecture: prefecture || null,
+            city: city || null,
+            address_line: addressLine || null,
+            building: building || null,
+            experience_fields: experienceFields && Object.keys(experienceFields).length > 0 ? experienceFields as Prisma.InputJsonValue : Prisma.DbNull,
+            work_histories: workHistoriesArray,
+            qualification_certificates: qualificationCertificates && Object.keys(qualificationCertificates).length > 0 ? qualificationCertificates as Prisma.InputJsonValue : Prisma.DbNull,
+            // 新登録フロー項目（既存カラムに対応）
+            desired_work_style: desiredWorkStyleCsv,
+            desired_work_days_week: workFrequency || null,
+            job_change_desire: jobTiming || null,
+            current_work_style: employmentStatus || null,
+            // LP経由登録情報（フォールバックチェーン適用済み）
+            registration_lp_id: resolvedLpId,
+            registration_campaign_code: resolvedCampaignCode,
+            registration_genre_prefix: resolvedGenrePrefix,
+          },
+        });
+      });
+    } catch (e) {
+      if (e instanceof Error && e.message === 'PHONE_ALREADY_REGISTERED') {
+        return NextResponse.json(
+          { error: 'この電話番号は既に登録されています' },
+          { status: 409 }
+        );
+      }
+      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
+        const target = (e.meta?.target as string[] | undefined)?.join(',') || '';
+        if (target.includes('email')) {
+          return NextResponse.json(
+            { error: 'このメールアドレスは既に登録されています' },
+            { status: 409 }
+          );
+        }
+      }
+      throw e;
+    }
 
     // 操作ログを記録（ユーザー登録成功）
     await logActivity({
@@ -228,16 +322,23 @@ export async function POST(request: NextRequest) {
       console.error('[TasLink] Registration sync failed:', getErrorMessage(tasLinkErr));
     }
 
-    return NextResponse.json({
-      message: '登録が完了しました。確認メールをお送りしましたので、メール内のリンクをクリックして認証を完了してください。',
+    // 登録完了と同時に NextAuth セッション Cookie を発行（サンクスページ到達時点でログイン済みに）
+    const response = NextResponse.json({
+      message: '登録が完了しました。',
       user: {
         id: user.id,
         email: user.email,
         name: user.name,
       },
-      requiresVerification: true,
+      redirect: '/register/worker/thanks',
       emailSent: !emailError,
     });
+    await issueSessionCookie(response, {
+      id: user.id,
+      email: user.email,
+      name: user.name,
+    });
+    return response;
   } catch (error) {
     console.error('Registration error:', error);
 

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -3,12 +3,13 @@
 import { useState, useEffect, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
-import { Mail, Lock, Eye, EyeOff } from 'lucide-react';
+import { User, Lock, Eye, EyeOff } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { getCsrfToken } from 'next-auth/react';
 import toast from 'react-hot-toast';
 import { useDebugError, extractDebugInfo } from '@/components/debug/DebugErrorBanner';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
+import { parseLoginIdentifier } from '@/src/lib/auth/identifier';
 
 export default function WorkerLogin() {
   return (
@@ -23,11 +24,10 @@ function WorkerLoginInner() {
   const searchParams = useSearchParams();
   const { login, isLoading: authLoading } = useAuth();
   const { showDebugError } = useDebugError();
-  const [email, setEmail] = useState('');
+  const [identifier, setIdentifier] = useState('');
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState('');
-  const [isEmailNotVerified, setIsEmailNotVerified] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [csrfReady, setCsrfReady] = useState(false);
 
@@ -42,36 +42,35 @@ function WorkerLoginInner() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
-    setIsEmailNotVerified(false);
 
-    if (!email || !password) {
-      setError('メールアドレスとパスワードを入力してください');
+    if (!identifier || !password) {
+      setError('メールアドレスまたは電話番号とパスワードを入力してください');
+      return;
+    }
+
+    const parsed = parseLoginIdentifier(identifier);
+    if (parsed.type === 'invalid') {
+      setError('メールアドレスまたは電話番号の形式が正しくありません');
       return;
     }
 
     setIsSubmitting(true);
 
     try {
-      const result = await login(email, password);
+      const result = await login(identifier, password);
 
       if (result.success) {
         toast.success('ログインしました');
         // セッションCookieが確実に反映されるようフルページナビゲーション
         window.location.href = '/';
       } else {
-        // メール未認証エラーの場合
-        if (result.error?.includes('EMAIL_NOT_VERIFIED')) {
-          setIsEmailNotVerified(true);
-          setError('メールアドレスが認証されていません。登録時に送信された確認メールのリンクをクリックしてください。');
-        } else {
-          showDebugError({
-            type: 'other',
-            operation: 'ログイン',
-            message: result.error || 'ログインに失敗しました',
-            context: { email }
-          });
-          setError(result.error || 'ログインに失敗しました');
-        }
+        showDebugError({
+          type: 'other',
+          operation: 'ログイン',
+          message: result.error || 'ログインに失敗しました',
+          context: { identifier }
+        });
+        setError(result.error || 'ログインに失敗しました');
       }
     } catch (err) {
       const debugInfo = extractDebugInfo(err);
@@ -81,7 +80,7 @@ function WorkerLoginInner() {
         message: debugInfo.message,
         details: debugInfo.details,
         stack: debugInfo.stack,
-        context: { email }
+        context: { identifier }
       });
       setError('ログイン中にエラーが発生しました');
     } finally {
@@ -113,34 +112,26 @@ function WorkerLoginInner() {
           {error && (
             <div className="mb-4 p-3 bg-white/90 border border-red-200 rounded-lg text-red-700 text-sm">
               <p>{error}</p>
-              {isEmailNotVerified && (
-                <Link
-                  href={`/auth/resend-verification?email=${encodeURIComponent(email)}`}
-                  className="mt-2 block text-primary font-medium hover:underline"
-                >
-                  確認メールを再送信する
-                </Link>
-              )}
             </div>
           )}
 
           <form onSubmit={handleSubmit} className="space-y-4">
-            {/* メールアドレス */}
+            {/* メールアドレス or 電話番号 */}
             <div>
               <label className="block text-sm font-medium mb-2 text-white">
-                メールアドレス
+                メールアドレス または 電話番号
               </label>
               <div className="relative">
-                <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
+                <User className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
                 <input
-                  type="email"
-                  id="login-email"
-                  name="email"
+                  type="text"
+                  id="login-identifier"
+                  name="identifier"
                   autoComplete="username"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
+                  value={identifier}
+                  onChange={(e) => setIdentifier(e.target.value)}
                   className="w-full pl-10 pr-4 py-3 border-0 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 bg-white"
-                  placeholder="yamada.taro@example.com"
+                  placeholder="メールアドレス または 電話番号"
                 />
               </div>
             </div>

--- a/app/my-jobs/MyJobsContent.tsx
+++ b/app/my-jobs/MyJobsContent.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 import { getMyApplications, cancelApplicationByWorker, cancelAppliedApplication } from '@/src/lib/actions';
 import toast from 'react-hot-toast';
 import { useDebugError, extractDebugInfo } from '@/components/debug/DebugErrorBanner';
+import { EmailVerificationRequiredModal } from '@/components/auth/EmailVerificationRequiredModal';
 
 type ApplicationStatus = 'APPLIED' | 'SCHEDULED' | 'WORKING' | 'COMPLETED_PENDING' | 'COMPLETED_RATED' | 'CANCELLED';
 type JobType = 'NORMAL' | 'LIMITED_WORKED' | 'LIMITED_FAVORITE' | 'ORIENTATION' | 'OFFER';
@@ -65,6 +66,7 @@ export function MyJobsContent({ initialTab }: MyJobsContentProps) {
   // SCHEDULED/WORKINGキャンセル用モーダル
   const [scheduledCancelModalApp, setScheduledCancelModalApp] = useState<Application | null>(null);
   const [scheduledCancelling, setScheduledCancelling] = useState(false);
+  const [emailNotVerifiedModal, setEmailNotVerifiedModal] = useState<{ open: boolean; email: string }>({ open: false, email: '' });
 
   // URLパラメータの変更を監視してタブを更新（Linkでの遷移時）
   useEffect(() => {
@@ -194,6 +196,9 @@ export function MyJobsContent({ initialTab }: MyJobsContentProps) {
         setApplications(prev =>
           prev.map(a => a.id === scheduledCancelModalApp.id ? { ...a, status: 'CANCELLED' as ApplicationStatus } : a)
         );
+      } else if ('errorCode' in result && result.errorCode === 'EMAIL_NOT_VERIFIED') {
+        const email = ('email' in result && typeof result.email === 'string') ? result.email : '';
+        setEmailNotVerifiedModal({ open: true, email });
       } else {
         showDebugError({
           type: 'delete',
@@ -234,6 +239,13 @@ export function MyJobsContent({ initialTab }: MyJobsContentProps) {
 
   return (
     <>
+      {/* メール未認証モーダル */}
+      <EmailVerificationRequiredModal
+        open={emailNotVerifiedModal.open}
+        email={emailNotVerifiedModal.email}
+        onClose={() => setEmailNotVerifiedModal({ open: false, email: '' })}
+      />
+
       {/* 求人カード一覧 */}
       <div className="p-3 space-y-2">
         {filteredApplications.length === 0 ? (

--- a/app/mypage/profile/ProfileEditClient.tsx
+++ b/app/mypage/profile/ProfileEditClient.tsx
@@ -195,7 +195,8 @@ export default function ProfileEditClient({ userProfile }: ProfileEditClientProp
 
     // 2. 働き方と希望
     currentWorkStyle: userProfile.current_work_style || '',
-    desiredWorkStyle: userProfile.desired_work_style || '',
+    // desired_work_style は CSV 形式の可能性があるため、最初の値をドロップダウン初期値として取り出す
+    desiredWorkStyle: (userProfile.desired_work_style || '').split(',')[0] || '',
     jobChangeDesire: userProfile.job_change_desire || '',
     desiredWorkDaysPerWeek: userProfile.desired_work_days_week || '',
     desiredWorkPeriod: userProfile.desired_work_period || '',

--- a/app/register/worker/page.tsx
+++ b/app/register/worker/page.tsx
@@ -1,26 +1,65 @@
 'use client';
 
-import { useState, useEffect, Suspense } from 'react';
+import { useState, useEffect, Suspense, useMemo } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { ArrowLeft, Check } from 'lucide-react';
-import Link from 'next/link';
 import toast from 'react-hot-toast';
-import { isValidEmail, isValidPhoneNumber } from '@/utils/inputValidation';
-import { isKatakanaOnly } from '@/utils/inputValidation';
 import { SmsVerification } from '@/components/ui/SmsVerification';
-import { KatakanaInput } from '@/components/ui/KatakanaInput';
-import { NameWithKanaInput } from '@/components/ui/NameWithKanaInput';
-import AddressSelector from '@/components/ui/AddressSelector';
 import { useDebugError, extractDebugInfo } from '@/components/debug/DebugErrorBanner';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
-import { trackGA4Event } from '@/src/lib/ga4-events';
 import { getLegalDocument } from '@/src/lib/content-actions';
-import { QUALIFICATION_GROUPS } from '@/constants/qualifications';
+import { trackGA4Event } from '@/src/lib/ga4-events';
 import RegistrationPageTracker from '@/components/tracking/RegistrationPageTracker';
+
+type StepId = '1' | '2' | '2b' | '3' | '4' | '5' | '6' | '7' | '8';
+
+// 資格オプション：表示ラベルとDB保存値のマッピング
+const QUALIFICATION_OPTIONS: { label: string; value: string }[] = [
+  { label: '正看護師', value: '看護師' },
+  { label: '准看護師', value: '准看護師' },
+  { label: '介護福祉士', value: '介護福祉士' },
+  { label: '実務者研修（ヘルパー1級）', value: '実務者研修' },
+  { label: '初任者研修（ヘルパー2級）', value: '初任者研修' },
+  { label: 'その他', value: 'その他' },
+];
+
+const DESIRED_WORK_STYLE_OPTIONS = [
+  '単発・スポット',
+  '常勤・正社員',
+  '非常勤・パート（扶養内）',
+  '非常勤・パート（扶養外）',
+  '派遣',
+  'こだわらない',
+];
+
+const WORK_FREQUENCY_OPTIONS = ['週1回', '週2〜3回', '週4〜5回', '週5回'];
+const JOB_TIMING_OPTIONS = ['いますぐ', '1ヶ月以内', '3ヶ月以内', 'いまは情報収集のみ'];
+const EMPLOYMENT_STATUS_OPTIONS = [
+  '就業中（常勤・正社員）',
+  '就業中（非常勤・パート）',
+  '離職中',
+  '学生',
+];
+
+// step2 で「どのくらい働きたいですか？」を見せる条件
+function shouldShowStep2b(desiredWorkStyle: string[]): boolean {
+  return desiredWorkStyle.some(v =>
+    v === '単発・スポット' ||
+    v === '非常勤・パート（扶養内）' ||
+    v === '非常勤・パート（扶養外）' ||
+    v === '派遣' ||
+    v === 'こだわらない'
+  );
+}
 
 export default function WorkerRegisterPage() {
   return (
-    <Suspense fallback={<div className="min-h-screen bg-gray-50 py-8"><div className="max-w-xl mx-auto px-4 text-center text-gray-500">読み込み中...</div></div>}>
+    <Suspense
+      fallback={
+        <div className="min-h-screen bg-white flex items-center justify-center">
+          <LoadingSpinner size="lg" />
+        </div>
+      }
+    >
       <RegistrationPageTracker />
       <WorkerRegisterPageInner />
     </Suspense>
@@ -31,870 +70,780 @@ function WorkerRegisterPageInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { showDebugError } = useDebugError();
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [showErrors, setShowErrors] = useState(false);
-  const [currentStep, setCurrentStep] = useState(1);
-  const [agreedToTerms, setAgreedToTerms] = useState(false);
-  const [showTermsModal, setShowTermsModal] = useState(false);
-  const [agreedToPrivacy, setAgreedToPrivacy] = useState(false);
-  const [phoneVerificationToken, setPhoneVerificationToken] = useState<string | null>(null);
-  const [showPrivacyModal, setShowPrivacyModal] = useState(false);
 
-  // 利用規約・PPのDB取得
+  const [currentStep, setCurrentStep] = useState<StepId>('1');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [agreedToTerms, setAgreedToTerms] = useState(false);
+  const [agreedToPrivacy, setAgreedToPrivacy] = useState(false);
+  const [showTermsModal, setShowTermsModal] = useState(false);
+  const [showPrivacyModal, setShowPrivacyModal] = useState(false);
+  const [phoneVerificationToken, setPhoneVerificationToken] = useState<string | null>(null);
+  const [isLoadingAddress, setIsLoadingAddress] = useState(false);
+
+  // 利用規約・PP
   const [termsContent, setTermsContent] = useState<string>('');
   const [privacyContent, setPrivacyContent] = useState<string>('');
-  const [termsLastUpdated, setTermsLastUpdated] = useState<string>('');
-  const [privacyLastUpdated, setPrivacyLastUpdated] = useState<string>('');
-  const [isLoadingLegal, setIsLoadingLegal] = useState(true);
 
-  const [formData, setFormData] = useState({
-    // ステップ1: アカウント情報・基本情報
-    email: '',
-    emailConfirm: '',
-    phoneNumber: '',
-    password: '',
-    passwordConfirm: '',
+  // フォームデータ
+  const [form, setForm] = useState({
+    qualifications: [] as string[],       // DB 保存値の配列
+    qualificationOther: '',                // その他自由記述
+    desiredWorkStyle: [] as string[],     // 複数選択
+    workFrequency: '',                     // step 2b（条件付き）
+    jobTiming: '',
+    employmentStatus: '',
+    postalCode: '',
+    prefecture: '',
+    city: '',
+    gender: '',
+    birthYear: '',
+    birthMonth: '',
+    birthDay: '',
     lastName: '',
     firstName: '',
     lastNameKana: '',
     firstNameKana: '',
-    birthDate: '',
-    // ステップ2: 住所・資格
-    postalCode: '',
-    prefecture: '',
-    city: '',
-    addressLine: '',
-    building: '',
-    qualifications: [] as string[],
+    phoneNumber: '',
+    email: '',
+    password: '',
   });
 
-  // LP経由登録情報（localStorage → URLパラメータ のフォールバックチェーン）
-  const [lpInfo, setLpInfo] = useState<{ lpId: string | null; campaignCode: string | null; genrePrefix: string | null }>({
-    lpId: null,
-    campaignCode: null,
-    genrePrefix: null,
-  });
-  const [lpSource, setLpSource] = useState<'localStorage' | 'urlParams' | 'none'>('none');
+  // LP 情報（localStorage / URL params）
+  const [lpInfo, setLpInfo] = useState<{
+    lpId: string | null;
+    campaignCode: string | null;
+    genrePrefix: string | null;
+    source: 'localStorage' | 'urlParams' | 'none';
+  }>({ lpId: null, campaignCode: null, genrePrefix: null, source: 'none' });
 
-  // ページロード時にLP情報を取得（localStorage優先、URLパラメータフォールバック）
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      let fromLocalStorage = false;
-
-      try {
-        // 第1優先: localStorage（lp_tracking_data）
-        const trackingDataStr = localStorage.getItem('lp_tracking_data');
-        if (trackingDataStr) {
-          const trackingData = JSON.parse(trackingDataStr);
-          if (trackingData.expiry && Date.now() <= trackingData.expiry) {
-            setLpInfo({
-              lpId: trackingData.lpId || null,
-              campaignCode: trackingData.campaignCode || null,
-              genrePrefix: trackingData.genrePrefix || null,
-            });
-            fromLocalStorage = true;
-          }
+    // localStorage 優先、次に URL パラメータ
+    try {
+      const stored = typeof window !== 'undefined' ? localStorage.getItem('lpInfo') : null;
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        if (parsed?.lpId) {
+          setLpInfo({
+            lpId: parsed.lpId,
+            campaignCode: parsed.campaignCode ?? null,
+            genrePrefix: parsed.genrePrefix ?? null,
+            source: 'localStorage',
+          });
+          return;
         }
-        // 第1優先: localStorage（個別キー）
-        if (!fromLocalStorage) {
-          const storedLpId = localStorage.getItem('lp_id');
-          const storedCampaignCode = localStorage.getItem('lp_campaign_code');
-          if (storedLpId) {
-            let genrePrefix = null;
-            if (storedCampaignCode) {
-              const match = storedCampaignCode.match(/^([A-Z]{3})-/);
-              if (match) {
-                genrePrefix = match[1];
-              }
-            }
-            setLpInfo({
-              lpId: storedLpId,
-              campaignCode: storedCampaignCode,
-              genrePrefix,
-            });
-            fromLocalStorage = true;
-          }
-        }
-      } catch (e) {
-        console.error('Failed to get LP info from localStorage:', e);
       }
-
-      if (fromLocalStorage) {
-        setLpSource('localStorage');
-        return;
-      }
-
-      // 第2優先: URLクエリパラメータ（CTAリンク経由で引き継がれた情報）
-      const urlLp = searchParams?.get('lp');
-      if (urlLp) {
-        setLpInfo({
-          lpId: urlLp,
-          campaignCode: searchParams?.get('c') || null,
-          genrePrefix: searchParams?.get('g') || null,
-        });
-        setLpSource('urlParams');
-      }
+    } catch {
+      // noop
+    }
+    const lp = searchParams?.get('lp') ?? null;
+    const c = searchParams?.get('c') ?? null;
+    const g = searchParams?.get('g') ?? null;
+    if (lp) {
+      setLpInfo({ lpId: lp, campaignCode: c, genrePrefix: g, source: 'urlParams' });
     }
   }, [searchParams]);
 
-  // 利用規約・PPをDBから取得
+  // 利用規約・PP取得（表示時）
   useEffect(() => {
-    const fetchLegalDocs = async () => {
+    (async () => {
       try {
-        const [termsDoc, privacyDoc] = await Promise.all([
+        const [terms, privacy] = await Promise.all([
           getLegalDocument('TERMS', 'WORKER'),
           getLegalDocument('PRIVACY', 'WORKER'),
         ]);
-        if (termsDoc) {
-          setTermsContent(termsDoc.content);
-          setTermsLastUpdated(
-            termsDoc.published_at
-              ? new Date(termsDoc.published_at).toLocaleDateString('ja-JP', { year: 'numeric', month: 'long', day: 'numeric' })
-              : ''
-          );
-        }
-        if (privacyDoc) {
-          setPrivacyContent(privacyDoc.content);
-          setPrivacyLastUpdated(
-            privacyDoc.published_at
-              ? new Date(privacyDoc.published_at).toLocaleDateString('ja-JP', { year: 'numeric', month: 'long', day: 'numeric' })
-              : ''
-          );
-        }
-      } catch (error) {
-        console.error('Failed to fetch legal documents:', error);
-      } finally {
-        setIsLoadingLegal(false);
+        if (terms?.content) setTermsContent(terms.content);
+        if (privacy?.content) setPrivacyContent(privacy.content);
+      } catch {
+        // 取得失敗しても登録は継続可能
       }
-    };
-    fetchLegalDocs();
+    })();
   }, []);
 
-  // 資格チェックボックスのトグル
-  const handleQualificationToggle = (qualification: string) => {
-    setFormData(prev => ({
-      ...prev,
-      qualifications: prev.qualifications.includes(qualification)
-        ? prev.qualifications.filter(q => q !== qualification)
-        : [...prev.qualifications, qualification],
-    }));
+  // ステップ順序（条件付きで 2b を挿入）
+  const stepSequence = useMemo<StepId[]>(() => {
+    const base: StepId[] = ['1', '2'];
+    if (shouldShowStep2b(form.desiredWorkStyle)) base.push('2b');
+    base.push('3', '4', '5', '6', '7', '8');
+    return base;
+  }, [form.desiredWorkStyle]);
+
+  const stepIndex = stepSequence.indexOf(currentStep);
+  const totalSteps = stepSequence.length;
+
+  const setField = <K extends keyof typeof form>(k: K, v: (typeof form)[K]) => {
+    setForm(prev => ({ ...prev, [k]: v }));
   };
 
-  // ステップ1のバリデーション
-  const validateStep1 = (): boolean => {
-    const errors: string[] = [];
-
-    if (!formData.email) errors.push('メールアドレス');
-    if (!formData.emailConfirm) errors.push('メールアドレス（確認）');
-    if (!formData.phoneNumber) errors.push('電話番号');
-    if (!formData.password) errors.push('パスワード');
-    if (!formData.passwordConfirm) errors.push('パスワード（確認）');
-    if (!formData.lastName) errors.push('姓');
-    if (!formData.firstName) errors.push('名');
-    if (!formData.lastNameKana) errors.push('姓（カナ）');
-    if (!formData.firstNameKana) errors.push('名（カナ）');
-    if (!formData.birthDate) errors.push('生年月日');
-
-    if (errors.length > 0) {
-      toast.error(`以下の項目を入力してください: ${errors.join('、')}`);
-      return false;
-    }
-
-    if (!isValidEmail(formData.email)) {
-      toast.error('メールアドレスの形式が正しくありません');
-      return false;
-    }
-
-    if (formData.email !== formData.emailConfirm) {
-      toast.error('メールアドレスが一致しません');
-      return false;
-    }
-
-    if (!isValidPhoneNumber(formData.phoneNumber)) {
-      toast.error('有効な日本の電話番号を入力してください（例: 09012345678）');
-      return false;
-    }
-
-    if (!phoneVerificationToken) {
-      toast.error('電話番号のSMS認証を完了してください');
-      return false;
-    }
-
-    if (formData.password.length < 8) {
-      toast.error('パスワードは8文字以上で入力してください');
-      return false;
-    }
-
-    if (formData.password !== formData.passwordConfirm) {
-      toast.error('パスワードが一致しません');
-      return false;
-    }
-
-    if (formData.lastNameKana && !isKatakanaOnly(formData.lastNameKana)) {
-      toast.error('姓（カナ）はカタカナで入力してください');
-      return false;
-    }
-
-    if (formData.firstNameKana && !isKatakanaOnly(formData.firstNameKana)) {
-      toast.error('名（カナ）はカタカナで入力してください');
-      return false;
-    }
-
-    return true;
+  const toggleArrayValue = (field: 'qualifications' | 'desiredWorkStyle', value: string) => {
+    setForm(prev => {
+      const curr = prev[field];
+      return {
+        ...prev,
+        [field]: curr.includes(value) ? curr.filter(v => v !== value) : [...curr, value],
+      };
+    });
   };
 
-  // ステップ1→2への遷移
-  const handleNextStep = () => {
-    setShowErrors(true);
-    if (validateStep1()) {
-      setShowErrors(false);
-      setCurrentStep(2);
-      window.scrollTo(0, 0);
-    }
-  };
-
-  // ステップ2→1への戻り
-  const handlePrevStep = () => {
-    setShowErrors(false);
-    setCurrentStep(1);
-    window.scrollTo(0, 0);
-  };
-
-  // 登録送信
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setShowErrors(true);
-
-    // ステップ2のバリデーション
-    const errors: string[] = [];
-    if (!formData.prefecture) errors.push('都道府県');
-    if (!formData.city) errors.push('市区町村');
-    if (!formData.addressLine) errors.push('番地');
-    if (formData.qualifications.length === 0) errors.push('保有資格');
-
-    if (errors.length > 0) {
-      toast.error(`以下の項目を入力してください: ${errors.join('、')}`);
-      return;
-    }
-
-    if (!agreedToTerms) {
-      toast.error('利用規約に同意してください');
-      const termsSection = document.getElementById('terms-section');
-      if (termsSection) {
-        termsSection.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  // 各ステップのバリデーション
+  const isStepValid = (): boolean => {
+    switch (currentStep) {
+      case '1': {
+        if (form.qualifications.length === 0) return false;
+        if (form.qualifications.includes('その他') && !form.qualificationOther.trim()) return false;
+        return true;
       }
+      case '2':
+        return form.desiredWorkStyle.length > 0;
+      case '2b':
+        return !!form.workFrequency;
+      case '3':
+        return !!form.jobTiming;
+      case '4':
+        return !!form.employmentStatus;
+      case '5':
+        return !!form.postalCode && form.postalCode.replace(/[^0-9]/g, '').length === 7;
+      case '6':
+        return !!form.gender && !!form.birthYear && !!form.birthMonth && !!form.birthDay;
+      case '7':
+        return !!form.lastName.trim() && !!form.firstName.trim() && !!form.lastNameKana.trim() && !!form.firstNameKana.trim();
+      case '8':
+        return (
+          !!form.phoneNumber &&
+          !!phoneVerificationToken &&
+          !!form.email &&
+          /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email) &&
+          !!form.password &&
+          form.password.length >= 8 &&
+          agreedToTerms &&
+          agreedToPrivacy
+        );
+    }
+  };
+
+  const goNext = () => {
+    if (!isStepValid()) return;
+    if (currentStep === '8') {
+      handleSubmit();
       return;
     }
+    const nextIdx = stepIndex + 1;
+    if (nextIdx < stepSequence.length) {
+      setCurrentStep(stepSequence[nextIdx]);
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  };
 
-    if (!agreedToPrivacy) {
-      toast.error('プライバシーポリシーに同意してください');
-      const termsSection = document.getElementById('terms-section');
-      if (termsSection) {
-        termsSection.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  const goBack = () => {
+    const prevIdx = stepIndex - 1;
+    if (prevIdx >= 0) {
+      setCurrentStep(stepSequence[prevIdx]);
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  };
+
+  // 郵便番号 → 住所自動入力（zipcloud）
+  const handlePostalLookup = async (code: string) => {
+    const digits = code.replace(/[^0-9]/g, '');
+    if (digits.length !== 7) return;
+    setIsLoadingAddress(true);
+    try {
+      const res = await fetch(`https://zipcloud.ibsnet.co.jp/api/search?zipcode=${digits}`);
+      const data = await res.json();
+      if (data.results?.length > 0) {
+        const r = data.results[0];
+        setForm(prev => ({
+          ...prev,
+          postalCode: digits,
+          prefecture: r.address1 || '',
+          city: `${r.address2 || ''}${r.address3 || ''}`,
+        }));
       }
-      return;
+    } catch {
+      // ignore
+    } finally {
+      setIsLoadingAddress(false);
     }
+  };
 
+  const handleSubmit = async () => {
+    if (isSubmitting) return;
     setIsSubmitting(true);
 
     try {
-      const response = await fetch('/api/auth/register', {
+      // 資格: mock ラベル → DB 値にマッピング、「その他」自由記述は追記
+      const qualificationsToSave = [...form.qualifications];
+      if (form.qualifications.includes('その他') && form.qualificationOther.trim()) {
+        qualificationsToSave.push(form.qualificationOther.trim());
+      }
+
+      // 生年月日 YYYY-MM-DD
+      const birthDate = `${form.birthYear}-${String(form.birthMonth).padStart(2, '0')}-${String(form.birthDay).padStart(2, '0')}`;
+
+      const res = await fetch('/api/auth/register', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          email: formData.email,
-          password: formData.password,
-          phoneNumber: formData.phoneNumber,
+          email: form.email,
+          password: form.password,
+          lastName: form.lastName,
+          firstName: form.firstName,
+          phoneNumber: form.phoneNumber,
           phoneVerificationToken,
-          // 新規追加フィールド
-          lastName: formData.lastName,
-          firstName: formData.firstName,
-          lastNameKana: formData.lastNameKana,
-          firstNameKana: formData.firstNameKana,
-          birthDate: formData.birthDate,
-          postalCode: formData.postalCode,
-          prefecture: formData.prefecture,
-          city: formData.city,
-          addressLine: formData.addressLine,
-          building: formData.building,
-          qualifications: formData.qualifications,
-          // LP経由登録情報（フォールバックチェーン: localStorage → URLパラメータ → サーバーサイドIP照合）
+          birthDate,
+          qualifications: qualificationsToSave,
+          lastNameKana: form.lastNameKana,
+          firstNameKana: form.firstNameKana,
+          gender: form.gender,
+          postalCode: form.postalCode,
+          prefecture: form.prefecture,
+          city: form.city,
+          desiredWorkStyle: form.desiredWorkStyle,
+          workFrequency: form.workFrequency || undefined,
+          jobTiming: form.jobTiming,
+          employmentStatus: form.employmentStatus,
           registrationLpId: lpInfo.lpId,
           registrationCampaignCode: lpInfo.campaignCode,
           registrationGenrePrefix: lpInfo.genrePrefix,
-          lpAttributionSource: lpSource,
+          lpAttributionSource: lpInfo.source,
         }),
       });
-
-      const data = await response.json();
-
-      if (!response.ok) {
-        throw new Error(data.error || '登録に失敗しました');
+      const data = await res.json();
+      if (!res.ok) {
+        showDebugError({
+          type: 'other',
+          operation: '会員登録',
+          message: data.error || '登録に失敗しました',
+          context: { status: res.status },
+        });
+        toast.error(data.error || '登録に失敗しました');
+        setIsSubmitting(false);
+        return;
       }
 
-      toast.success('登録が完了しました。メールをご確認ください。');
-      trackGA4Event('sign_up', {
-        method: 'email',
-        lp_id: lpInfo.lpId || undefined,
-        campaign_code: lpInfo.campaignCode || undefined,
-      });
+      // GA4 登録完了イベント
+      try {
+        trackGA4Event('worker_register_complete', {
+          lp_id: lpInfo.lpId || '',
+          genre: lpInfo.genrePrefix || '',
+        });
+      } catch {}
 
-      // メール認証待ちページへリダイレクト
-      router.push(`/auth/verify-pending?email=${encodeURIComponent(formData.email)}`);
-      return;
-    } catch (error) {
-      const debugInfo = extractDebugInfo(error);
+      router.replace(data.redirect || '/register/worker/thanks');
+    } catch (err) {
+      const info = extractDebugInfo(err);
       showDebugError({
-        type: 'save',
-        operation: 'ワーカー新規登録',
-        message: debugInfo.message,
-        details: debugInfo.details,
-        stack: debugInfo.stack,
-        context: {
-          email: formData.email,
-        }
+        type: 'other',
+        operation: '会員登録（例外）',
+        message: info.message,
+        details: info.details,
+        stack: info.stack,
       });
-      toast.error(error instanceof Error ? error.message : '登録中にエラーが発生しました');
-    } finally {
+      toast.error('登録中にエラーが発生しました');
       setIsSubmitting(false);
     }
   };
 
-  const handleCancel = () => {
-    if (confirm('入力内容が失われますが、よろしいですか？')) {
-      window.history.back();
-    }
-  };
-
   return (
-    <div className="min-h-screen bg-gray-50 py-8">
-      <div className="max-w-xl mx-auto px-4">
-        <div className="mb-6">
-          <Link href="/job-list" className="inline-flex items-center gap-2 text-primary hover:underline">
-            <ArrowLeft className="w-4 h-4" />
-            戻る
-          </Link>
+    <div className="min-h-screen bg-[#F8FCFE]">
+      <div className="max-w-md mx-auto bg-white min-h-screen relative">
+        {/* ヘッダー */}
+        <div className="bg-gradient-to-br from-[#E8F7FB] via-[#D4F1F9] to-[#E8F0FE] px-5 pt-6 pb-8 text-center">
+          <div className="text-[#2AADCF] font-bold text-lg">タスタス</div>
+          <h1 className="text-xl font-bold text-gray-800 mt-1">あなたの現状を教えてください</h1>
         </div>
 
-        {/* ステップインジケーター */}
-        <div className="flex items-center justify-center mb-8">
-          <div className="flex items-center gap-0">
-            {/* ステップ1 */}
-            <div className="flex items-center">
-              <div className={`w-10 h-10 rounded-full flex items-center justify-center text-sm font-bold ${
-                currentStep === 1 ? 'bg-primary text-white' : currentStep > 1 ? 'bg-green-500 text-white' : 'bg-gray-200 text-gray-500'
-              }`}>
-                {currentStep > 1 ? <Check className="w-5 h-5" /> : '1'}
-              </div>
-              <span className={`ml-2 text-sm font-medium ${currentStep === 1 ? 'text-primary' : 'text-gray-500'}`}>
-                アカウント・基本情報
-              </span>
-            </div>
-            {/* 接続線 */}
-            <div className={`w-12 h-0.5 mx-2 ${currentStep > 1 ? 'bg-green-500' : 'bg-gray-200'}`} />
-            {/* ステップ2 */}
-            <div className="flex items-center">
-              <div className={`w-10 h-10 rounded-full flex items-center justify-center text-sm font-bold ${
-                currentStep === 2 ? 'bg-primary text-white' : 'bg-gray-200 text-gray-500'
-              }`}>
-                2
-              </div>
-              <span className={`ml-2 text-sm font-medium ${currentStep === 2 ? 'text-primary' : 'text-gray-500'}`}>
-                住所・資格
-              </span>
-            </div>
-          </div>
+        {/* プログレスバー */}
+        <div className="flex items-center justify-center gap-2 py-5">
+          {stepSequence.map((_, i) => (
+            <div
+              key={i}
+              className={`w-3 h-3 rounded-full transition-all ${
+                i === stepIndex
+                  ? 'bg-[#2AADCF] scale-125 shadow-[0_2px_8px_rgba(42,173,207,0.3)]'
+                  : i < stepIndex
+                  ? 'bg-[#2AADCF]'
+                  : 'bg-gray-300'
+              }`}
+            />
+          ))}
         </div>
 
-        <div className="bg-white rounded-lg shadow-lg p-8">
-          <h1 className="text-2xl font-bold text-gray-900 mb-2">新規ワーカー登録</h1>
-          <p className="text-gray-600 mb-6">
-            {currentStep === 1
-              ? 'アカウント情報と基本情報を入力してください。'
-              : '住所と保有資格を入力してください。'}
-          </p>
-
-          <form onSubmit={handleSubmit} noValidate>
-            {/* ============ ステップ1: アカウント・基本情報 ============ */}
-            {currentStep === 1 && (
-              <div className="space-y-6">
-                {/* アカウント情報セクション */}
-                <div>
-                  <h2 className="text-lg font-bold text-gray-800 mb-4 pb-2 border-b">アカウント情報</h2>
-                  <div className="space-y-4">
-                    {/* メールアドレス */}
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">
-                        メールアドレス <span className="text-red-500">*</span>
-                      </label>
-                      <input
-                        type="email"
-                        value={formData.email}
-                        onChange={(e) => setFormData({ ...formData, email: e.target.value })}
-                        className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary ${showErrors && !formData.email ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
-                        placeholder="example@email.com"
-                      />
-                      {showErrors && !formData.email && (
-                        <p className="text-red-500 text-xs mt-1">メールアドレスを入力してください</p>
-                      )}
-                    </div>
-                    {/* メールアドレス（確認） */}
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">
-                        メールアドレス（確認） <span className="text-red-500">*</span>
-                      </label>
-                      <input
-                        type="email"
-                        value={formData.emailConfirm}
-                        onChange={(e) => setFormData({ ...formData, emailConfirm: e.target.value })}
-                        className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary ${showErrors && !formData.emailConfirm ? 'border-red-500 bg-red-50' : formData.emailConfirm && formData.email !== formData.emailConfirm ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
-                        placeholder="確認のため再入力"
-                      />
-                      {showErrors && !formData.emailConfirm && (
-                        <p className="text-red-500 text-xs mt-1">メールアドレス（確認）を入力してください</p>
-                      )}
-                      {formData.emailConfirm && formData.email !== formData.emailConfirm && (
-                        <p className="text-red-500 text-xs mt-1">メールアドレスが一致しません</p>
-                      )}
-                      {formData.emailConfirm && formData.email === formData.emailConfirm && (
-                        <p className="text-green-600 text-xs mt-1">✓ 一致しています</p>
-                      )}
-                    </div>
-                    {/* 電話番号（SMS認証） */}
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">
-                        電話番号 <span className="text-red-500">*</span>
-                      </label>
-                      <SmsVerification
-                        phoneNumber={formData.phoneNumber}
-                        onPhoneNumberChange={(value) => {
-                          setFormData({ ...formData, phoneNumber: value });
-                          setPhoneVerificationToken(null);
-                        }}
-                        onVerified={(token) => setPhoneVerificationToken(token)}
-                        showError={showErrors && !formData.phoneNumber}
-                        errorMessage="電話番号を入力してください"
-                        inputClassName={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary ${showErrors && !formData.phoneNumber ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
-                      />
-                    </div>
-                    {/* パスワード */}
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">
-                        パスワード <span className="text-red-500">*</span>
-                      </label>
-                      <input
-                        type="password"
-                        value={formData.password}
-                        onChange={(e) => setFormData({ ...formData, password: e.target.value })}
-                        className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary ${showErrors && !formData.password ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
-                        placeholder="8文字以上"
-                        minLength={8}
-                      />
-                      <p className="text-xs text-gray-500 mt-1">8文字以上で入力してください</p>
-                      {showErrors && !formData.password && (
-                        <p className="text-red-500 text-xs mt-1">パスワードを入力してください</p>
-                      )}
-                    </div>
-                    {/* パスワード（確認） */}
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">
-                        パスワード（確認） <span className="text-red-500">*</span>
-                      </label>
-                      <input
-                        type="password"
-                        value={formData.passwordConfirm}
-                        onChange={(e) => setFormData({ ...formData, passwordConfirm: e.target.value })}
-                        className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary ${showErrors && !formData.passwordConfirm ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
-                        placeholder="パスワードを再入力"
-                        minLength={8}
-                      />
-                      {showErrors && !formData.passwordConfirm && (
-                        <p className="text-red-500 text-xs mt-1">パスワード（確認）を入力してください</p>
-                      )}
-                    </div>
-                  </div>
-                </div>
-
-                {/* 基本情報セクション */}
-                <div>
-                  <h2 className="text-lg font-bold text-gray-800 mb-4 pb-2 border-b">基本情報</h2>
-                  <div className="space-y-4">
-                    {/* 氏名 */}
-                    <div className="grid grid-cols-2 gap-4">
-                      <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-1">
-                          姓 <span className="text-red-500">*</span>
-                        </label>
-                        <NameWithKanaInput
-                          value={formData.lastName}
-                          onChange={(value) => setFormData(prev => ({ ...prev, lastName: value }))}
-                          onKanaChange={(kana) => setFormData(prev => ({ ...prev, lastNameKana: kana }))}
-                          kanaValue={formData.lastNameKana}
-                          className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary ${showErrors && !formData.lastName ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
-                          placeholder="山田"
-                        />
-                        {showErrors && !formData.lastName && (
-                          <p className="text-red-500 text-xs mt-1">姓を入力してください</p>
-                        )}
-                      </div>
-                      <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-1">
-                          名 <span className="text-red-500">*</span>
-                        </label>
-                        <NameWithKanaInput
-                          value={formData.firstName}
-                          onChange={(value) => setFormData(prev => ({ ...prev, firstName: value }))}
-                          onKanaChange={(kana) => setFormData(prev => ({ ...prev, firstNameKana: kana }))}
-                          kanaValue={formData.firstNameKana}
-                          className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary ${showErrors && !formData.firstName ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
-                          placeholder="太郎"
-                        />
-                        {showErrors && !formData.firstName && (
-                          <p className="text-red-500 text-xs mt-1">名を入力してください</p>
-                        )}
-                      </div>
-                    </div>
-                    {/* 氏名カナ */}
-                    <div className="grid grid-cols-2 gap-4">
-                      <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-1">
-                          姓（カナ） <span className="text-red-500">*</span>
-                        </label>
-                        <KatakanaInput
-                          value={formData.lastNameKana}
-                          onChange={(value) => setFormData({ ...formData, lastNameKana: value })}
-                          className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary ${showErrors && !formData.lastNameKana ? 'border-red-500 bg-red-50' : formData.lastNameKana && !isKatakanaOnly(formData.lastNameKana) ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
-                          placeholder="ヤマダ"
-                        />
-                        {showErrors && !formData.lastNameKana && (
-                          <p className="text-red-500 text-xs mt-1">姓（カナ）を入力してください</p>
-                        )}
-                        {formData.lastNameKana && !isKatakanaOnly(formData.lastNameKana) && (
-                          <p className="text-red-500 text-xs mt-1">カタカナで入力してください</p>
-                        )}
-                        <p className="text-xs text-gray-500 mt-1">※漢字入力で自動変換・ひらがなも変換可</p>
-                      </div>
-                      <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-1">
-                          名（カナ） <span className="text-red-500">*</span>
-                        </label>
-                        <KatakanaInput
-                          value={formData.firstNameKana}
-                          onChange={(value) => setFormData({ ...formData, firstNameKana: value })}
-                          className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary ${showErrors && !formData.firstNameKana ? 'border-red-500 bg-red-50' : formData.firstNameKana && !isKatakanaOnly(formData.firstNameKana) ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
-                          placeholder="タロウ"
-                        />
-                        {showErrors && !formData.firstNameKana && (
-                          <p className="text-red-500 text-xs mt-1">名（カナ）を入力してください</p>
-                        )}
-                        {formData.firstNameKana && !isKatakanaOnly(formData.firstNameKana) && (
-                          <p className="text-red-500 text-xs mt-1">カタカナで入力してください</p>
-                        )}
-                        <p className="text-xs text-gray-500 mt-1">※漢字入力で自動変換・ひらがなも変換可</p>
-                      </div>
-                    </div>
-                    {/* 生年月日 */}
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">
-                        生年月日 <span className="text-red-500">*</span>
-                      </label>
-                      <input
-                        type="date"
-                        value={formData.birthDate}
-                        onChange={(e) => setFormData({ ...formData, birthDate: e.target.value })}
-                        className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary ${showErrors && !formData.birthDate ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
-                      />
-                      {showErrors && !formData.birthDate && (
-                        <p className="text-red-500 text-xs mt-1">生年月日を入力してください</p>
-                      )}
-                    </div>
-                  </div>
-                </div>
-
-                {/* ステップ1ボタン */}
-                <div className="flex justify-end gap-3 pt-4 border-t">
-                  <button
-                    type="button"
-                    onClick={handleCancel}
-                    className="px-6 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 transition-colors"
-                  >
-                    キャンセル
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleNextStep}
-                    className="px-6 py-2 bg-primary hover:bg-primary-dark text-white rounded-md transition-colors font-bold"
-                  >
-                    次へ
-                  </button>
-                </div>
+        {/* ステップコンテンツ */}
+        <div className="px-5 pb-32">
+          {currentStep === '1' && (
+            <StepContainer question="どんな資格をお持ちですか？" hint="複数選択できます">
+              <div className="grid grid-cols-2 gap-2.5">
+                {QUALIFICATION_OPTIONS.map(opt => (
+                  <CardOption
+                    key={opt.value}
+                    label={opt.label}
+                    selected={form.qualifications.includes(opt.value)}
+                    onClick={() => toggleArrayValue('qualifications', opt.value)}
+                  />
+                ))}
               </div>
-            )}
-
-            {/* ============ ステップ2: 住所・資格・同意 ============ */}
-            {currentStep === 2 && (
-              <div className="space-y-6">
-                {/* 住所セクション */}
-                <div>
-                  <h2 className="text-lg font-bold text-gray-800 mb-4 pb-2 border-b">住所</h2>
-                  <AddressSelector
-                    prefecture={formData.prefecture}
-                    city={formData.city}
-                    addressLine={formData.addressLine}
-                    building={formData.building}
-                    postalCode={formData.postalCode}
-                    onChange={(data) => {
-                      setFormData(prev => ({
-                        ...prev,
-                        prefecture: data.prefecture,
-                        city: data.city,
-                        addressLine: data.addressLine || '',
-                        building: data.building || '',
-                        postalCode: data.postalCode || '',
-                      }));
-                    }}
-                    required={true}
-                    showErrors={showErrors}
+              {form.qualifications.includes('その他') && (
+                <div className="mt-3">
+                  <input
+                    type="text"
+                    value={form.qualificationOther}
+                    onChange={e => setField('qualificationOther', e.target.value)}
+                    placeholder="資格名を入力してください"
+                    className="w-full px-4 py-3 border-2 border-gray-200 rounded-[10px] focus:border-[#2AADCF] focus:outline-none"
                   />
                 </div>
+              )}
+            </StepContainer>
+          )}
 
-                {/* 保有資格セクション */}
-                <div>
-                  <h2 className="text-lg font-bold text-gray-800 mb-4 pb-2 border-b">保有資格</h2>
-                  <p className="text-sm text-gray-600 mb-2">
-                    保有している資格にチェックを入れてください。
-                  </p>
-                  <p className="text-sm text-red-600 font-medium mb-4">
-                    ※応募するには会員登録後、資格証明書の写真の提出が必要です
-                  </p>
-                  {showErrors && formData.qualifications.length === 0 && (
-                    <p className="text-red-500 text-xs mb-3">少なくとも1つの資格を選択してください</p>
-                  )}
-                  <div className={`space-y-4 ${showErrors && formData.qualifications.length === 0 ? 'ring-2 ring-red-500 rounded-lg p-3' : ''}`}>
-                    {QUALIFICATION_GROUPS.map((group) => (
-                      <div key={group.name}>
-                        <h4 className="text-sm font-semibold text-gray-700 mb-2">{group.name}</h4>
-                        <div className="grid grid-cols-2 gap-2">
-                          {group.qualifications.map((qual) => (
-                            <label key={qual} className="flex items-center gap-2 cursor-pointer text-sm">
-                              <input
-                                type="checkbox"
-                                checked={formData.qualifications.includes(qual)}
-                                onChange={() => handleQualificationToggle(qual)}
-                                className="w-4 h-4 text-primary border-gray-300 rounded focus:ring-primary"
-                              />
-                              <span>{qual}</span>
-                            </label>
-                          ))}
-                        </div>
-                      </div>
-                    ))}
+          {currentStep === '2' && (
+            <StepContainer question="希望の働き方" hint="複数選択できます">
+              <div className="grid grid-cols-2 gap-2.5">
+                {DESIRED_WORK_STYLE_OPTIONS.map(opt => (
+                  <CardOption
+                    key={opt}
+                    label={opt}
+                    selected={form.desiredWorkStyle.includes(opt)}
+                    onClick={() => toggleArrayValue('desiredWorkStyle', opt)}
+                  />
+                ))}
+              </div>
+            </StepContainer>
+          )}
+
+          {currentStep === '2b' && (
+            <StepContainer question="どのくらい働きたいですか？">
+              <div className="grid grid-cols-2 gap-2.5">
+                {WORK_FREQUENCY_OPTIONS.map(opt => (
+                  <CardOption
+                    key={opt}
+                    label={opt}
+                    selected={form.workFrequency === opt}
+                    onClick={() => setField('workFrequency', opt)}
+                  />
+                ))}
+                {form.desiredWorkStyle.includes('単発・スポット') && (
+                  <CardOption
+                    label="不定期/決まっていない"
+                    fullWidth
+                    selected={form.workFrequency === '不定期/決まっていない'}
+                    onClick={() => setField('workFrequency', '不定期/決まっていない')}
+                  />
+                )}
+              </div>
+            </StepContainer>
+          )}
+
+          {currentStep === '3' && (
+            <StepContainer question="いつ頃の求人をお探しですか？">
+              <div className="grid grid-cols-2 gap-2.5">
+                {JOB_TIMING_OPTIONS.map(opt => (
+                  <CardOption
+                    key={opt}
+                    label={opt}
+                    selected={form.jobTiming === opt}
+                    onClick={() => setField('jobTiming', opt)}
+                  />
+                ))}
+              </div>
+            </StepContainer>
+          )}
+
+          {currentStep === '4' && (
+            <StepContainer question="お仕事のご状況">
+              <div className="grid grid-cols-2 gap-2.5">
+                {EMPLOYMENT_STATUS_OPTIONS.map(opt => (
+                  <CardOption
+                    key={opt}
+                    label={opt}
+                    selected={form.employmentStatus === opt}
+                    onClick={() => setField('employmentStatus', opt)}
+                  />
+                ))}
+              </div>
+            </StepContainer>
+          )}
+
+          {currentStep === '5' && (
+            <StepContainer question="お住まいの地域">
+              <FieldLabel required>郵便番号</FieldLabel>
+              <input
+                type="tel"
+                inputMode="numeric"
+                maxLength={8}
+                value={form.postalCode}
+                onChange={e => {
+                  const v = e.target.value;
+                  setField('postalCode', v);
+                  if (v.replace(/[^0-9]/g, '').length === 7) {
+                    handlePostalLookup(v);
+                  }
+                }}
+                placeholder="例：1500022"
+                className="w-full px-4 py-3 border-2 border-gray-200 rounded-[10px] focus:border-[#2AADCF] focus:outline-none"
+              />
+              {isLoadingAddress && <p className="text-xs text-gray-500 mt-1">住所を取得中...</p>}
+              {form.prefecture && (
+                <div className="mt-4 space-y-3">
+                  <div>
+                    <FieldLabel>都道府県</FieldLabel>
+                    <input
+                      type="text"
+                      readOnly
+                      value={form.prefecture}
+                      className="w-full px-4 py-3 border-2 border-gray-200 rounded-[10px] bg-gray-50"
+                    />
+                  </div>
+                  <div>
+                    <FieldLabel>市区町村</FieldLabel>
+                    <input
+                      type="text"
+                      readOnly
+                      value={form.city}
+                      className="w-full px-4 py-3 border-2 border-gray-200 rounded-[10px] bg-gray-50"
+                    />
                   </div>
                 </div>
+              )}
+            </StepContainer>
+          )}
 
-                {/* 利用規約・プライバシーポリシー同意 */}
-                <div id="terms-section" className={`p-4 bg-gray-50 rounded-lg border ${showErrors && (!agreedToTerms || !agreedToPrivacy) ? 'border-red-500' : 'border-gray-200'}`}>
-                  <div className="space-y-4">
-                    {/* 利用規約 */}
-                    <div className="space-y-2">
-                      <button
-                        type="button"
-                        onClick={() => setShowTermsModal(true)}
-                        className="text-primary hover:underline text-sm font-medium"
-                      >
-                        利用規約を確認する
-                      </button>
-                      <label className="flex items-start gap-3 cursor-pointer p-3 bg-white rounded-lg border border-gray-200">
-                        <input
-                          type="checkbox"
-                          checked={agreedToTerms}
-                          onChange={(e) => setAgreedToTerms(e.target.checked)}
-                          className="w-5 h-5 text-primary border-gray-300 rounded focus:ring-primary mt-0.5"
-                        />
-                        <span className="text-sm">
-                          <span className="font-medium">利用規約に同意します</span>
-                          <span className="text-red-500 ml-1">*</span>
-                          {termsLastUpdated && (
-                          <span className="text-gray-500 block text-xs mt-1">
-                            （最終更新日: {termsLastUpdated}）
-                          </span>
-                        )}
-                        </span>
-                      </label>
-                      {showErrors && !agreedToTerms && (
-                        <p className="text-red-500 text-xs">利用規約に同意してください</p>
-                      )}
-                    </div>
-
-                    {/* プライバシーポリシー */}
-                    <div className="space-y-2">
-                      <button
-                        type="button"
-                        onClick={() => setShowPrivacyModal(true)}
-                        className="text-primary hover:underline text-sm font-medium"
-                      >
-                        プライバシーポリシーを確認する
-                      </button>
-                      <label className="flex items-start gap-3 cursor-pointer p-3 bg-white rounded-lg border border-gray-200">
-                        <input
-                          type="checkbox"
-                          checked={agreedToPrivacy}
-                          onChange={(e) => setAgreedToPrivacy(e.target.checked)}
-                          className="w-5 h-5 text-primary border-gray-300 rounded focus:ring-primary mt-0.5"
-                        />
-                        <span className="text-sm">
-                          <span className="font-medium">プライバシーポリシーに同意します</span>
-                          <span className="text-red-500 ml-1">*</span>
-                          {privacyLastUpdated && (
-                          <span className="text-gray-500 block text-xs mt-1">
-                            （最終更新日: {privacyLastUpdated}）
-                          </span>
-                        )}
-                        </span>
-                      </label>
-                      {showErrors && !agreedToPrivacy && (
-                        <p className="text-red-500 text-xs">プライバシーポリシーに同意してください</p>
-                      )}
-                    </div>
-                  </div>
-                </div>
-
-                {/* 案内文 */}
-                <div className="p-4 bg-blue-50 rounded-lg border border-blue-200">
-                  <p className="text-sm text-blue-800">
-                    登録後、求人に応募する際には追加の情報（緊急連絡先、銀行口座、身分証明書、資格証明書など）が必要です。マイページからいつでも入力できます。
-                  </p>
-                </div>
-
-                {/* ステップ2ボタン */}
-                <div className="flex justify-end gap-3 pt-4 border-t">
-                  <button
-                    type="button"
-                    onClick={handlePrevStep}
-                    className="px-6 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 transition-colors"
-                  >
-                    戻る
-                  </button>
-                  <button
-                    type="submit"
-                    disabled={isSubmitting}
-                    className="px-6 py-2 bg-primary hover:bg-primary-dark text-white rounded-md transition-colors font-bold disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 min-w-[100px]"
-                  >
-                    {isSubmitting && <LoadingSpinner size="sm" color="white" />}
-                    {isSubmitting ? '登録中...' : '登録する'}
-                  </button>
+          {currentStep === '6' && (
+            <StepContainer question="性別・生年月日">
+              <div className="mb-5">
+                <FieldLabel required>性別</FieldLabel>
+                <div className="grid grid-cols-2 gap-2.5">
+                  {['男性', '女性'].map(g => (
+                    <CardOption
+                      key={g}
+                      label={g}
+                      selected={form.gender === g}
+                      onClick={() => setField('gender', g)}
+                    />
+                  ))}
                 </div>
               </div>
-            )}
-          </form>
+              <FieldLabel required>生年月日</FieldLabel>
+              <div className="flex gap-2">
+                <select
+                  value={form.birthYear}
+                  onChange={e => setField('birthYear', e.target.value)}
+                  className="flex-1 px-3 py-3 border-2 border-gray-200 rounded-[10px] focus:border-[#2AADCF] focus:outline-none"
+                >
+                  <option value="">年</option>
+                  {Array.from({ length: 2008 - 1950 + 1 }, (_, i) => 2008 - i).map(y => (
+                    <option key={y} value={y}>{y}年</option>
+                  ))}
+                </select>
+                <select
+                  value={form.birthMonth}
+                  onChange={e => setField('birthMonth', e.target.value)}
+                  className="flex-1 px-3 py-3 border-2 border-gray-200 rounded-[10px] focus:border-[#2AADCF] focus:outline-none"
+                >
+                  <option value="">月</option>
+                  {Array.from({ length: 12 }, (_, i) => i + 1).map(m => (
+                    <option key={m} value={m}>{m}月</option>
+                  ))}
+                </select>
+                <select
+                  value={form.birthDay}
+                  onChange={e => setField('birthDay', e.target.value)}
+                  className="flex-1 px-3 py-3 border-2 border-gray-200 rounded-[10px] focus:border-[#2AADCF] focus:outline-none"
+                >
+                  <option value="">日</option>
+                  {Array.from({ length: 31 }, (_, i) => i + 1).map(d => (
+                    <option key={d} value={d}>{d}日</option>
+                  ))}
+                </select>
+              </div>
+            </StepContainer>
+          )}
+
+          {currentStep === '7' && (
+            <StepContainer question="おなまえ">
+              <div className="mb-4">
+                <FieldLabel required>姓</FieldLabel>
+                <input
+                  type="text"
+                  value={form.lastName}
+                  onChange={e => setField('lastName', e.target.value)}
+                  placeholder="例：山田"
+                  className="w-full px-4 py-3 border-2 border-gray-200 rounded-[10px] focus:border-[#2AADCF] focus:outline-none"
+                />
+              </div>
+              <div className="mb-4">
+                <FieldLabel required>名</FieldLabel>
+                <input
+                  type="text"
+                  value={form.firstName}
+                  onChange={e => setField('firstName', e.target.value)}
+                  placeholder="例：花子"
+                  className="w-full px-4 py-3 border-2 border-gray-200 rounded-[10px] focus:border-[#2AADCF] focus:outline-none"
+                />
+              </div>
+              <div className="mb-4">
+                <FieldLabel required>せい（カナ）</FieldLabel>
+                <input
+                  type="text"
+                  value={form.lastNameKana}
+                  onChange={e => setField('lastNameKana', e.target.value)}
+                  placeholder="例：ヤマダ"
+                  className="w-full px-4 py-3 border-2 border-gray-200 rounded-[10px] focus:border-[#2AADCF] focus:outline-none"
+                />
+              </div>
+              <div>
+                <FieldLabel required>めい（カナ）</FieldLabel>
+                <input
+                  type="text"
+                  value={form.firstNameKana}
+                  onChange={e => setField('firstNameKana', e.target.value)}
+                  placeholder="例：ハナコ"
+                  className="w-full px-4 py-3 border-2 border-gray-200 rounded-[10px] focus:border-[#2AADCF] focus:outline-none"
+                />
+              </div>
+            </StepContainer>
+          )}
+
+          {currentStep === '8' && (
+            <StepContainer question="ご連絡先・パスワード">
+              <div className="mb-4">
+                <FieldLabel required>電話番号（SMS認証が必要です）</FieldLabel>
+                <SmsVerification
+                  phoneNumber={form.phoneNumber}
+                  onPhoneNumberChange={v => {
+                    // 電話番号を変更したら既存の認証トークンを破棄（未認証状態に戻す）
+                    setField('phoneNumber', v);
+                    setPhoneVerificationToken(null);
+                  }}
+                  onVerified={token => setPhoneVerificationToken(token)}
+                />
+              </div>
+              <div className="mb-4">
+                <FieldLabel required>メールアドレス</FieldLabel>
+                <input
+                  type="email"
+                  value={form.email}
+                  onChange={e => setField('email', e.target.value)}
+                  placeholder="例：example@mail.com"
+                  className="w-full px-4 py-3 border-2 border-gray-200 rounded-[10px] focus:border-[#2AADCF] focus:outline-none"
+                />
+              </div>
+              <div className="mb-4">
+                <FieldLabel required>パスワード（8文字以上）</FieldLabel>
+                <input
+                  type="password"
+                  value={form.password}
+                  onChange={e => setField('password', e.target.value)}
+                  placeholder="8文字以上"
+                  className="w-full px-4 py-3 border-2 border-gray-200 rounded-[10px] focus:border-[#2AADCF] focus:outline-none"
+                />
+              </div>
+              <div className="space-y-2 mt-6">
+                <label className="flex items-start gap-2 text-sm cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={agreedToTerms}
+                    onChange={e => setAgreedToTerms(e.target.checked)}
+                    className="mt-0.5"
+                  />
+                  <span>
+                    <button
+                      type="button"
+                      onClick={() => setShowTermsModal(true)}
+                      className="text-[#2AADCF] underline"
+                    >
+                      利用規約
+                    </button>
+                    に同意する
+                  </span>
+                </label>
+                <label className="flex items-start gap-2 text-sm cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={agreedToPrivacy}
+                    onChange={e => setAgreedToPrivacy(e.target.checked)}
+                    className="mt-0.5"
+                  />
+                  <span>
+                    <button
+                      type="button"
+                      onClick={() => setShowPrivacyModal(true)}
+                      className="text-[#2AADCF] underline"
+                    >
+                      プライバシーポリシー
+                    </button>
+                    に同意する
+                  </span>
+                </label>
+              </div>
+              <div className="flex justify-center gap-4 mt-6 text-xs text-gray-500">
+                <span>🔒 SSL暗号化通信</span>
+                <span>🛡️ 個人情報保護</span>
+              </div>
+            </StepContainer>
+          )}
         </div>
+
+        {/* フッターナビ */}
+        <div className="fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-md bg-[#F0F3F5] p-4 flex gap-3 items-center z-50" style={{ paddingBottom: 'max(16px, env(safe-area-inset-bottom))' }}>
+          {currentStep !== '1' && (
+            <button
+              type="button"
+              onClick={goBack}
+              className="w-14 h-14 flex-shrink-0 rounded-full border-2 border-[#2AADCF] text-[#2AADCF] bg-white flex items-center justify-center text-xl"
+              disabled={isSubmitting}
+            >
+              ←
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={goNext}
+            disabled={!isStepValid() || isSubmitting}
+            className={`flex-1 py-4 rounded-full font-semibold text-white shadow-[0_4px_16px_rgba(42,173,207,0.3)] transition-all ${
+              isStepValid() && !isSubmitting
+                ? 'bg-[#2AADCF] hover:bg-[#1A8FAD]'
+                : 'bg-[#C8E4ED] cursor-not-allowed'
+            }`}
+          >
+            {isSubmitting
+              ? '送信中...'
+              : currentStep === '8'
+              ? '利用規約・プライバシーポリシーに同意して登録'
+              : '次へ'}
+          </button>
+        </div>
+
+        {/* 利用規約モーダル */}
+        {showTermsModal && (
+          <LegalModal
+            title="利用規約"
+            content={termsContent}
+            onClose={() => setShowTermsModal(false)}
+          />
+        )}
+        {showPrivacyModal && (
+          <LegalModal
+            title="プライバシーポリシー"
+            content={privacyContent}
+            onClose={() => setShowPrivacyModal(false)}
+          />
+        )}
       </div>
+    </div>
+  );
+}
 
-      {/* 利用規約モーダル */}
-      {showTermsModal && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-lg max-w-2xl w-full max-h-[80vh] flex flex-col">
-            <div className="flex items-center justify-between p-4 border-b">
-              <h2 className="text-lg font-bold">利用規約</h2>
-              <button
-                type="button"
-                onClick={() => setShowTermsModal(false)}
-                className="p-2 hover:bg-gray-100 rounded-full transition-colors"
-                aria-label="閉じる"
-              >
-                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                </svg>
-              </button>
-            </div>
-            <div className="flex-1 overflow-y-auto p-4">
-              {termsLastUpdated && <p className="text-xs text-gray-500 mb-4">最終更新日: {termsLastUpdated}</p>}
-              {isLoadingLegal ? (
-                <p className="text-sm text-gray-500">読み込み中...</p>
-              ) : termsContent ? (
-                <div
-                  className="prose prose-sm max-w-none prose-h2:text-base prose-h2:font-bold prose-h2:text-gray-900 prose-h2:mt-6 prose-h2:mb-3 prose-p:text-gray-700 prose-p:leading-relaxed prose-p:my-2 prose-ul:my-2 prose-li:text-gray-700"
-                  dangerouslySetInnerHTML={{ __html: termsContent }}
-                />
-              ) : (
-                <p className="text-sm text-gray-500">利用規約を読み込めませんでした。</p>
-              )}
-            </div>
-            <div className="p-4 border-t flex justify-end gap-3">
-              <button
-                type="button"
-                onClick={() => setShowTermsModal(false)}
-                className="px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 transition-colors"
-              >
-                閉じる
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  setAgreedToTerms(true);
-                  setShowTermsModal(false);
-                }}
-                className="px-4 py-2 bg-primary text-white rounded-md hover:bg-primary-dark transition-colors"
-              >
-                同意して閉じる
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+// --- 共通コンポーネント ---
 
-      {/* プライバシーポリシーモーダル */}
-      {showPrivacyModal && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-lg max-w-2xl w-full max-h-[80vh] flex flex-col">
-            <div className="flex items-center justify-between p-4 border-b">
-              <h2 className="text-lg font-bold">プライバシーポリシー</h2>
-              <button
-                type="button"
-                onClick={() => setShowPrivacyModal(false)}
-                className="p-2 hover:bg-gray-100 rounded-full transition-colors"
-                aria-label="閉じる"
-              >
-                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                </svg>
-              </button>
-            </div>
-            <div className="flex-1 overflow-y-auto p-4">
-              {privacyLastUpdated && <p className="text-xs text-gray-500 mb-4">最終更新日: {privacyLastUpdated}</p>}
-              {isLoadingLegal ? (
-                <p className="text-sm text-gray-500">読み込み中...</p>
-              ) : privacyContent ? (
-                <div
-                  className="prose prose-sm max-w-none prose-h2:text-base prose-h2:font-bold prose-h2:text-gray-900 prose-h2:mt-6 prose-h2:mb-3 prose-p:text-gray-700 prose-p:leading-relaxed prose-p:my-2 prose-ul:my-2 prose-li:text-gray-700"
-                  dangerouslySetInnerHTML={{ __html: privacyContent }}
-                />
-              ) : (
-                <p className="text-sm text-gray-500">プライバシーポリシーを読み込めませんでした。</p>
-              )}
-            </div>
-            <div className="p-4 border-t flex justify-end gap-3">
-              <button
-                type="button"
-                onClick={() => setShowPrivacyModal(false)}
-                className="px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 transition-colors"
-              >
-                閉じる
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  setAgreedToPrivacy(true);
-                  setShowPrivacyModal(false);
-                }}
-                className="px-4 py-2 bg-primary text-white rounded-md hover:bg-primary-dark transition-colors"
-              >
-                同意して閉じる
-              </button>
-            </div>
-          </div>
-        </div>
+function StepContainer({
+  question,
+  hint,
+  children,
+}: {
+  question: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <h2 className="text-lg font-bold text-gray-800 mb-5 text-center leading-relaxed">{question}</h2>
+      {hint && <p className="text-xs text-gray-500 text-center mb-4">{hint}</p>}
+      {children}
+    </div>
+  );
+}
+
+function CardOption({
+  label,
+  selected,
+  onClick,
+  fullWidth = false,
+}: {
+  label: string;
+  selected: boolean;
+  onClick: () => void;
+  fullWidth?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex items-center justify-center text-center p-4 min-h-[72px] rounded-2xl transition-all select-none ${
+        fullWidth ? 'col-span-2' : ''
+      } ${
+        selected
+          ? 'bg-[#2AADCF] text-white shadow-[0_4px_16px_rgba(42,173,207,0.35)]'
+          : 'bg-gray-100 text-gray-800'
+      } active:scale-95`}
+    >
+      <span className="text-sm font-semibold leading-snug whitespace-pre-line">{label}</span>
+    </button>
+  );
+}
+
+function FieldLabel({
+  children,
+  required = false,
+}: {
+  children: React.ReactNode;
+  required?: boolean;
+}) {
+  return (
+    <div className="text-sm font-semibold text-gray-800 mb-2 flex items-center gap-2">
+      {children}
+      {required && (
+        <span className="text-[10px] bg-[#FF6B8A] text-white px-2 py-0.5 rounded font-semibold">必須</span>
       )}
+    </div>
+  );
+}
+
+function LegalModal({
+  title,
+  content,
+  onClose,
+}: {
+  title: string;
+  content: string;
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 z-[100] flex items-end justify-center"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="legal-modal-title"
+    >
+      <div
+        className="bg-white w-full max-w-md rounded-t-3xl p-6 max-h-[80vh] overflow-y-auto"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <h3 id="legal-modal-title" className="text-lg font-bold">{title}</h3>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-gray-400 text-2xl leading-none px-2"
+            aria-label="閉じる"
+          >
+            ×
+          </button>
+        </div>
+        <div
+          className="prose prose-sm max-w-none"
+          dangerouslySetInnerHTML={{ __html: content || '<p>読み込み中...</p>' }}
+        />
+      </div>
     </div>
   );
 }

--- a/app/register/worker/thanks/ThanksClient.tsx
+++ b/app/register/worker/thanks/ThanksClient.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { trackGA4Event } from '@/src/lib/ga4-events';
+
+interface Props {
+  userName: string;
+  lineUrl: string;
+}
+
+export default function ThanksClient({ userName, lineUrl }: Props) {
+  useEffect(() => {
+    try {
+      trackGA4Event('worker_register_thanks_view', {});
+    } catch {
+      // noop
+    }
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-[#F8FCFE]">
+      <div className="max-w-md mx-auto bg-white min-h-screen">
+        <div className="bg-gradient-to-br from-[#E8F7FB] via-[#D4F1F9] to-[#E8F0FE] px-5 pt-6 pb-8 text-center">
+          <div className="text-[#2AADCF] font-bold text-lg">タスタス</div>
+          <h1 className="text-xl font-bold text-gray-800 mt-1">登録完了</h1>
+        </div>
+
+        <div className="px-5 py-10 text-center">
+          <div className="mx-auto mb-5 w-20 h-20 rounded-full bg-gradient-to-br from-[#E8F7FB] to-[#D4F1F9] flex items-center justify-center text-3xl">
+            🎉
+          </div>
+          <h2 className="text-xl font-bold text-gray-800 mb-2">
+            会員登録が完了しました！
+          </h2>
+          <p className="text-sm text-gray-500 leading-relaxed mb-8">
+            {userName ? `${userName} さん、ありがとうございます。` : ''}
+            <br />
+            LINE登録者限定で、
+            <br />
+            ご希望に合った施設をお探しいたします！
+          </p>
+
+          <div className="flex flex-col gap-3 max-w-xs mx-auto">
+            {lineUrl ? (
+              <a
+                href={lineUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="py-4 px-6 rounded-full text-lg font-bold text-white shadow-[0_6px_24px_rgba(6,199,85,0.35)]"
+                style={{ background: 'linear-gradient(135deg,#06C755 0%,#05B34C 100%)' }}
+                onClick={() => {
+                  try {
+                    trackGA4Event('worker_register_thanks_line_click', {});
+                  } catch {}
+                }}
+              >
+                📲 LINEで相談する
+              </a>
+            ) : null}
+
+            <Link
+              href="/job-list"
+              className="py-3 px-6 rounded-full text-sm font-medium text-gray-500 border border-gray-200 bg-white"
+              onClick={() => {
+                try {
+                  trackGA4Event('worker_register_thanks_jobs_click', {});
+                } catch {}
+              }}
+            >
+              求人ページはこちら
+            </Link>
+
+            <Link
+              href="/mypage"
+              className="py-3 px-6 rounded-full text-sm font-medium text-[#2AADCF] underline"
+            >
+              マイページへ移動
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/register/worker/thanks/page.tsx
+++ b/app/register/worker/thanks/page.tsx
@@ -1,0 +1,18 @@
+import { redirect } from 'next/navigation';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import ThanksClient from './ThanksClient';
+
+export const dynamic = 'force-dynamic';
+
+export default async function RegisterThanksPage() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    // 登録完了を経ずに直接アクセスされた場合のフォールバック
+    redirect('/login');
+  }
+
+  const lineUrl = process.env.NEXT_PUBLIC_REGISTER_LINE_URL || '';
+
+  return <ThanksClient userName={session.user.name ?? ''} lineUrl={lineUrl} />;
+}

--- a/components/auth/EmailVerificationRequiredModal.tsx
+++ b/components/auth/EmailVerificationRequiredModal.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
+import toast from 'react-hot-toast';
+
+interface Props {
+  open: boolean;
+  email: string;
+  onClose: () => void;
+}
+
+// サーバー側クールダウン（email-verification.ts の RESEND_COOLDOWN_MINUTES = 5分）と揃える
+const CLIENT_COOLDOWN_MS = 5 * 60_000;
+
+export function EmailVerificationRequiredModal({ open, email, onClose }: Props) {
+  const [isSending, setIsSending] = useState(false);
+  const [sentOnce, setSentOnce] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [cooldownRemaining, setCooldownRemaining] = useState(0); // クライアント側の連打防止
+  const closeBtnRef = useRef<HTMLButtonElement>(null);
+
+  // open/email 変更時に状態リセット
+  useEffect(() => {
+    if (!open) return;
+    setSentOnce(false);
+    setErrorMessage(null);
+    setCooldownRemaining(0);
+  }, [open, email]);
+
+  // ESC & 初期フォーカス
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    // 開いた直後に閉じるボタンへフォーカス
+    setTimeout(() => closeBtnRef.current?.focus(), 10);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  // cooldown カウントダウン
+  useEffect(() => {
+    if (cooldownRemaining <= 0) return;
+    const t = setTimeout(() => setCooldownRemaining(r => r - 1), 1000);
+    return () => clearTimeout(t);
+  }, [cooldownRemaining]);
+
+  if (!open) return null;
+
+  const handleResend = async () => {
+    if (isSending || !email || cooldownRemaining > 0) return;
+    setIsSending(true);
+    setErrorMessage(null);
+    try {
+      const res = await fetch('/api/auth/resend-verification', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        toast.success(data.message || '認証メールを再送しました');
+        setSentOnce(true);
+        setCooldownRemaining(Math.ceil(CLIENT_COOLDOWN_MS / 1000));
+      } else {
+        // サーバー側クールダウン等のエラーはインラインで表示
+        setErrorMessage(data.error || '再送に失敗しました');
+      }
+    } catch {
+      setErrorMessage('再送中にネットワークエラーが発生しました');
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  const buttonLabel = (() => {
+    if (isSending) return '送信中...';
+    if (cooldownRemaining > 0) {
+      const min = Math.floor(cooldownRemaining / 60);
+      const sec = cooldownRemaining % 60;
+      return `再送可能まで ${min}:${String(sec).padStart(2, '0')}`;
+    }
+    if (sentOnce) return '認証メールを再送する';
+    return '認証メールを送信する';
+  })();
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 z-[100] flex items-end justify-center sm:items-center"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="email-verify-modal-title"
+    >
+      <div
+        className="bg-white w-full max-w-md sm:rounded-3xl rounded-t-3xl p-6"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <h3 id="email-verify-modal-title" className="text-lg font-bold text-gray-800">
+            メール認証が必要です
+          </h3>
+          <button
+            ref={closeBtnRef}
+            type="button"
+            onClick={onClose}
+            className="text-gray-400 text-2xl leading-none px-2"
+            aria-label="閉じる"
+          >
+            ×
+          </button>
+        </div>
+
+        <p className="text-sm text-gray-700 leading-relaxed mb-3">
+          求人への応募にはメールアドレスの認証が必要です。
+          <br />
+          登録時に <span className="font-semibold">{email}</span> 宛にお送りした認証メールのリンクをクリックしてください。
+        </p>
+        <p className="text-xs text-gray-500 mb-4">
+          メールが見つからない場合は、迷惑メールフォルダもご確認ください。
+        </p>
+
+        {errorMessage && (
+          <div
+            role="alert"
+            aria-live="polite"
+            className="mb-4 p-3 rounded-lg bg-red-50 border border-red-200 text-red-700 text-sm"
+          >
+            {errorMessage}
+          </div>
+        )}
+
+        <div className="flex flex-col gap-3">
+          <button
+            type="button"
+            onClick={handleResend}
+            disabled={isSending || cooldownRemaining > 0}
+            className="w-full py-3 rounded-full bg-[#2AADCF] text-white font-semibold shadow-md disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {buttonLabel}
+          </button>
+          <Link
+            href="/mypage/profile"
+            className="text-center text-sm text-[#2AADCF] underline"
+            onClick={onClose}
+          >
+            メールアドレスを変更する
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/job/JobDetailClient.tsx
+++ b/components/job/JobDetailClient.tsx
@@ -16,6 +16,7 @@ import toast from 'react-hot-toast';
 import { useErrorToast } from '@/components/ui/PersistentErrorToast';
 import { trackGA4Event } from '@/src/lib/ga4-events';
 import { useDebugError, extractDebugInfo } from '@/components/debug/DebugErrorBanner';
+import { EmailVerificationRequiredModal } from '@/components/auth/EmailVerificationRequiredModal';
 
 // デフォルトのプレースホルダー画像
 const DEFAULT_JOB_IMAGE = '/images/samples/job_default_noimage.png';
@@ -96,6 +97,8 @@ export function JobDetailClient({ job, facility, relatedJobs: _relatedJobs, faci
   // プロフィール未完了モーダル
   const [showProfileModal, setShowProfileModal] = useState(false);
   const [profileMissingFields, setProfileMissingFields] = useState<string[]>([]);
+  // メール未認証モーダル
+  const [emailNotVerifiedModal, setEmailNotVerifiedModal] = useState<{ open: boolean; email: string }>({ open: false, email: '' });
 
   // 応募確認モーダル
   const [showApplyConfirmModal, setShowApplyConfirmModal] = useState(false);
@@ -462,7 +465,7 @@ export function JobDetailClient({ job, facility, relatedJobs: _relatedJobs, faci
     setSelectedWorkDateIds([]); // 選択をクリア
 
     const isOffer = job.jobType === 'OFFER';
-    toast.success(isOffer ? 'オファーを受け付けました' : '応募を受け付けました');
+    const optimisticToastId = toast.success(isOffer ? 'オファーを受け付けました' : '応募を受け付けました');
 
     // 4. バックグラウンドでAPI実行
     try {
@@ -495,9 +498,16 @@ export function JobDetailClient({ job, facility, relatedJobs: _relatedJobs, faci
       } else {
         // 失敗時：ロールバック
         setAppliedWorkDateIds(previousAppliedIds);
+        // 楽観UI で出した成功トーストのみを打ち消す（他のトーストに影響しない）
+        toast.dismiss(optimisticToastId);
 
+        // メール未認証エラーの場合はモーダル表示
+        if ('errorCode' in result && result.errorCode === 'EMAIL_NOT_VERIFIED') {
+          const email = ('email' in result && typeof result.email === 'string') ? result.email : '';
+          setEmailNotVerifiedModal({ open: true, email });
+        }
         // プロフィール未完了エラーの場合はモーダル表示
-        if ('missingFields' in result && result.missingFields) {
+        else if ('missingFields' in result && result.missingFields) {
           const missingFields = result.missingFields as string[];
           setProfileMissingFields(missingFields);
           setShowProfileModal(true);
@@ -537,6 +547,8 @@ export function JobDetailClient({ job, facility, relatedJobs: _relatedJobs, faci
       console.error('Application error:', error);
       // 失敗時：ロールバック
       setAppliedWorkDateIds(previousAppliedIds);
+      // 楽観UI で出した成功トーストのみを打ち消す
+      toast.dismiss(optimisticToastId);
       // デバッグ用エラー通知
       const debugInfo = extractDebugInfo(error);
       showDebugError({
@@ -1576,6 +1588,13 @@ export function JobDetailClient({ job, facility, relatedJobs: _relatedJobs, faci
           </div>
         </div>
       )}
+
+      {/* メール未認証モーダル */}
+      <EmailVerificationRequiredModal
+        open={emailNotVerifiedModal.open}
+        email={emailNotVerifiedModal.email}
+        onClose={() => setEmailNotVerifiedModal({ open: false, email: '' })}
+      />
 
       {/* 応募確認モーダル */}
       {showApplyConfirmModal && (

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -20,7 +20,7 @@ interface AuthContextType {
   user: Session['user'] | null;
   isAuthenticated: boolean;
   isLoading: boolean;
-  login: (email: string, password: string) => Promise<{ success: boolean; error?: string }>;
+  login: (identifier: string, password: string) => Promise<{ success: boolean; error?: string }>;
   logout: () => Promise<void>;
   // 施設管理者認証（改善版）
   admin: FacilityAdmin | null;
@@ -125,11 +125,11 @@ function AuthContextProvider({ children }: { children: ReactNode }) {
     };
   }, [admin]);
 
-  // ワーカーログイン
-  const login = async (email: string, password: string) => {
+  // ワーカーログイン（メール or 電話番号）
+  const login = async (identifier: string, password: string) => {
     try {
       const result = await signIn('credentials', {
-        email,
+        identifier,
         password,
         redirect: false,
       });

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,14 +1,17 @@
 import { NextAuthOptions } from 'next-auth';
 import CredentialsProvider from 'next-auth/providers/credentials';
 import bcrypt from 'bcryptjs';
+import { Prisma } from '@prisma/client';
 import prisma from './prisma';
 import { logActivity } from './logger';
+import { parseLoginIdentifier } from '@/src/lib/auth/identifier';
 
 export const authOptions: NextAuthOptions = {
   providers: [
     CredentialsProvider({
       name: 'credentials',
       credentials: {
+        identifier: { label: 'Email or Phone', type: 'text' },
         email: { label: 'Email', type: 'email' },
         password: { label: 'Password', type: 'password' },
         autoLoginToken: { label: 'Auto Login Token', type: 'text' },
@@ -63,41 +66,87 @@ export const authOptions: NextAuthOptions = {
         }
 
         // 通常ログインモード
-        if (!credentials?.email || !credentials?.password) {
-          throw new Error('メールアドレスとパスワードを入力してください');
+        const rawIdentifier = credentials?.identifier ?? credentials?.email;
+        if (!rawIdentifier || !credentials?.password) {
+          throw new Error('ログイン情報とパスワードを入力してください');
         }
 
-        const user = await prisma.user.findUnique({
-          where: { email: credentials.email },
-        });
-
-
-        if (!user) {
-          // ログイン失敗（ユーザー不在）をログ記録
+        const parsed = parseLoginIdentifier(rawIdentifier);
+        if (parsed.type === 'invalid') {
           logActivity({
             userType: 'WORKER',
-            userEmail: credentials.email,
+            userEmail: rawIdentifier,
+            action: 'LOGIN_FAILED',
+            result: 'ERROR',
+            errorMessage: '識別子が不正な形式です',
+          }).catch(() => {});
+          throw new Error('メールアドレスまたはパスワードが正しくありません');
+        }
+
+        let user;
+        if (parsed.type === 'email') {
+          // 既存ユーザーの大小文字混在に対応。ただし case-variant 重複時は
+          // 認証先が曖昧になるためログイン不可とする
+          const emailMatches = await prisma.user.findMany({
+            where: { email: { equals: parsed.value, mode: 'insensitive' } },
+            orderBy: { id: 'desc' },
+          });
+          if (emailMatches.length > 1) {
+            console.warn(
+              '[AUTH] Multiple users for case-insensitive email match:',
+              parsed.value
+            );
+            logActivity({
+              userType: 'WORKER',
+              userEmail: parsed.value,
+              action: 'LOGIN_FAILED',
+              result: 'ERROR',
+              errorMessage: 'メールアドレスが重複しているためログイン不可',
+            }).catch(() => {});
+            throw new Error('メールアドレスまたはパスワードが正しくありません');
+          }
+          user = emailMatches[0];
+        } else {
+          // 電話番号ログイン: DB 側も正規化して比較（レガシーデータのハイフン・全角数字対応）
+          const rows = await prisma.$queryRaw<{ id: number }[]>(
+            Prisma.sql`SELECT id FROM users
+              WHERE regexp_replace(translate(phone_number, '０１２３４５６７８９', '0123456789'), '[^0-9]', '', 'g') = ${parsed.value}
+              AND phone_verified = true
+              AND deleted_at IS NULL
+              ORDER BY id DESC`
+          );
+          const candidates = rows.length > 0
+            ? await prisma.user.findMany({
+                where: { id: { in: rows.map((r) => r.id) } },
+                orderBy: { id: 'desc' },
+              })
+            : [];
+          if (candidates.length > 1) {
+            console.warn(
+              '[AUTH] Multiple phone_verified users for phone:',
+              parsed.value
+            );
+            logActivity({
+              userType: 'WORKER',
+              userEmail: parsed.value,
+              action: 'LOGIN_FAILED',
+              result: 'ERROR',
+              errorMessage: '電話番号が重複しているためログイン不可',
+            }).catch(() => {});
+            throw new Error('メールアドレスまたはパスワードが正しくありません');
+          }
+          user = candidates[0];
+        }
+
+        if (!user) {
+          logActivity({
+            userType: 'WORKER',
+            userEmail: rawIdentifier,
             action: 'LOGIN_FAILED',
             result: 'ERROR',
             errorMessage: 'ユーザーが見つかりません',
           }).catch(() => {});
           throw new Error('メールアドレスまたはパスワードが正しくありません');
-        }
-
-        // メールアドレス未認証チェック
-        if (!user.email_verified) {
-          // ログイン失敗（メール未認証）をログ記録
-          logActivity({
-            userType: 'WORKER',
-            userId: user.id,
-            userEmail: user.email,
-            action: 'LOGIN_FAILED',
-            targetType: 'User',
-            targetId: user.id,
-            result: 'ERROR',
-            errorMessage: 'メール未認証',
-          }).catch(() => {});
-          throw new Error('EMAIL_NOT_VERIFIED');
         }
 
         // テストユーザーログイン用の特別パスワード（開発環境 + 環境変数フラグ必須）
@@ -138,7 +187,7 @@ export const authOptions: NextAuthOptions = {
           action: 'LOGIN',
           targetType: 'User',
           targetId: user.id,
-          requestData: { method: 'credentials' },
+          requestData: { method: parsed.type === 'phone' ? 'phone_credentials' : 'credentials' },
           result: 'SUCCESS',
         }).catch(() => {});
 

--- a/src/lib/actions/application-worker.ts
+++ b/src/lib/actions/application-worker.ts
@@ -229,6 +229,16 @@ export async function applyForJob(jobId: string, workDateId?: number) {
             return { success: false, error: 'アカウントが停止されているため、応募できません' };
         }
 
+        if (!user.email_verified) {
+            console.log('[applyForJob] Email not verified:', user.id);
+            return {
+                success: false,
+                errorCode: 'EMAIL_NOT_VERIFIED',
+                error: 'メールアドレスの認証が必要です',
+                email: user.email,
+            };
+        }
+
         const profileCheck = await checkProfileComplete(user.id);
         if (!profileCheck.isComplete) {
             console.log('[applyForJob] Profile incomplete:', profileCheck.missingFields);
@@ -445,6 +455,15 @@ export async function applyForJobMultipleDates(jobId: string, workDateIds: numbe
 
         const user = await getAuthenticatedUser();
         if (user.is_suspended) return { success: false, error: 'アカウントが停止されているため、応募できません' };
+
+        if (!user.email_verified) {
+            return {
+                success: false,
+                errorCode: 'EMAIL_NOT_VERIFIED',
+                error: 'メールアドレスの認証が必要です',
+                email: user.email,
+            };
+        }
 
         const profileCheck = await checkProfileComplete(user.id);
         if (!profileCheck.isComplete) {
@@ -806,6 +825,16 @@ export async function cancelApplicationByWorker(applicationId: number) {
         const user = await getAuthenticatedUser();
         console.log('[cancelApplicationByWorker] User:', user.id, 'Application:', applicationId);
 
+        if (!user.email_verified) {
+            console.log('[cancelApplicationByWorker] Email not verified:', user.id);
+            return {
+                success: false,
+                errorCode: 'EMAIL_NOT_VERIFIED',
+                error: 'メールアドレスの認証が必要です',
+                email: user.email,
+            };
+        }
+
         const application = await prisma.application.findFirst({
             where: { id: applicationId, user_id: user.id },
             include: {
@@ -988,6 +1017,16 @@ export async function acceptOffer(jobId: string, workDateId: number) {
         if (user.is_suspended) {
             console.log('[acceptOffer] User is suspended:', user.id);
             return { success: false, error: 'アカウントが停止されているため、オファーを受けられません' };
+        }
+
+        if (!user.email_verified) {
+            console.log('[acceptOffer] Email not verified:', user.id);
+            return {
+                success: false,
+                errorCode: 'EMAIL_NOT_VERIFIED',
+                error: 'メールアドレスの認証が必要です',
+                email: user.email,
+            };
         }
 
         const profileCheck = await checkProfileComplete(user.id);

--- a/src/lib/actions/user-profile.ts
+++ b/src/lib/actions/user-profile.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { prisma } from '@/lib/prisma';
+import { Prisma } from '@prisma/client';
 import { revalidatePath } from 'next/cache';
 import { getAuthenticatedUser } from './helpers';
 import { geocodeAddress } from '@/src/lib/geocoding';
@@ -8,6 +9,7 @@ import { logActivity, getErrorMessage, getErrorStack } from '@/lib/logger';
 import { generateBankAccountName } from '@/lib/string-utils';
 import { validatePhoneVerificationToken } from '@/src/lib/auth/phone-verification';
 import { syncWorkerToTasLink, mapUserToTasLinkPayload } from '@/src/lib/taslink';
+import { normalizePhoneDigits, phoneLockKey as computePhoneLockKey } from '@/src/lib/auth/identifier';
 
 /**
  * SMS認証成功時に電話番号を即座にDBに保存する
@@ -16,19 +18,48 @@ export async function savePhoneVerification(phoneNumber: string, verificationTok
     try {
         const user = await getAuthenticatedUser();
 
-        const isValid = await validatePhoneVerificationToken(verificationToken, phoneNumber);
+        const normalizedPhone = normalizePhoneDigits(phoneNumber);
+        if (normalizedPhone.length < 10 || normalizedPhone.length > 11) {
+            return { success: false, error: '電話番号の形式が正しくありません' };
+        }
+
+        const isValid = await validatePhoneVerificationToken(verificationToken, normalizedPhone);
         if (!isValid) {
             return { success: false, error: '認証トークンが無効または期限切れです' };
         }
 
-        await prisma.user.update({
-            where: { id: user.id },
-            data: {
-                phone_number: phoneNumber,
-                phone_verified: true,
-                phone_verified_at: new Date(),
-            },
-        });
+        // 他ユーザーとの電話番号重複チェック（advisory lock で race 回避 + SQL 正規化比較）
+        const lockKey = computePhoneLockKey(normalizedPhone);
+        try {
+            await prisma.$transaction(async (tx) => {
+                await tx.$queryRaw(
+                    Prisma.sql`SELECT pg_advisory_xact_lock(${lockKey}::bigint)`
+                );
+                const dup = await tx.$queryRaw<{ id: number }[]>(
+                    Prisma.sql`SELECT id FROM users
+                        WHERE regexp_replace(translate(phone_number, '０１２３４５６７８９', '0123456789'), '[^0-9]', '', 'g') = ${normalizedPhone}
+                        AND phone_verified = true
+                        AND deleted_at IS NULL
+                        AND id <> ${user.id}
+                        LIMIT 1`
+                );
+                if (dup.length > 0) throw new Error('PHONE_DUPLICATE');
+
+                await tx.user.update({
+                    where: { id: user.id },
+                    data: {
+                        phone_number: normalizedPhone,
+                        phone_verified: true,
+                        phone_verified_at: new Date(),
+                    },
+                });
+            });
+        } catch (e) {
+            if (e instanceof Error && e.message === 'PHONE_DUPLICATE') {
+                return { success: false, error: 'この電話番号は既に他のアカウントで使われています' };
+            }
+            throw e;
+        }
 
         return { success: true };
     } catch (error) {
@@ -382,8 +413,39 @@ export async function updateUserProfile(formData: FormData) {
             };
         }
 
-        // 電話番号変更時のSMS認証チェック
-        const isPhoneChanged = phoneNumber !== user.phone_number;
+        // メール正規化（trim + lowercase）と他ユーザーとの重複チェック（case-insensitive）
+        const normalizedEmail = email.trim().toLowerCase();
+        if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalizedEmail)) {
+            return { success: false, error: 'メールアドレスの形式が正しくありません' };
+        }
+        const isEmailChanged = normalizedEmail !== user.email.toLowerCase();
+        if (isEmailChanged) {
+            const duplicatedEmail = await prisma.user.findFirst({
+                where: {
+                    email: { equals: normalizedEmail, mode: 'insensitive' },
+                    NOT: { id: user.id },
+                },
+                select: { id: true },
+            });
+            if (duplicatedEmail) {
+                return {
+                    success: false,
+                    error: 'このメールアドレスは既に他のアカウントで使われています',
+                };
+            }
+        }
+
+        // 電話番号を digits-only に正規化（register 側と一貫性維持）
+        const normalizedPhone = normalizePhoneDigits(phoneNumber);
+        if (normalizedPhone.length < 10 || normalizedPhone.length > 11) {
+            return {
+                success: false,
+                error: '電話番号の形式が正しくありません',
+            };
+        }
+
+        // 電話番号変更判定: DB 側の値も normalize してから比較（既存レガシーデータの表記ゆれ吸収）
+        const isPhoneChanged = normalizedPhone !== normalizePhoneDigits(user.phone_number);
         if (isPhoneChanged) {
             if (!phoneVerificationToken) {
                 return {
@@ -391,11 +453,27 @@ export async function updateUserProfile(formData: FormData) {
                     error: '電話番号の変更にはSMS認証が必要です',
                 };
             }
-            const isPhoneVerified = await validatePhoneVerificationToken(phoneVerificationToken, phoneNumber);
+            const isPhoneVerified = await validatePhoneVerificationToken(phoneVerificationToken, normalizedPhone);
             if (!isPhoneVerified) {
                 return {
                     success: false,
                     error: '電話番号の認証トークンが無効または期限切れです。再度認証を行ってください。',
+                };
+            }
+
+            // 他ユーザーとの電話番号重複チェック（SQL 側で正規化して比較）
+            const duplicatedPhone = await prisma.$queryRaw<{ id: number }[]>(
+                Prisma.sql`SELECT id FROM users
+                    WHERE regexp_replace(translate(phone_number, '０１２３４５６７８９', '0123456789'), '[^0-9]', '', 'g') = ${normalizedPhone}
+                    AND phone_verified = true
+                    AND deleted_at IS NULL
+                    AND id <> ${user.id}
+                    LIMIT 1`
+            );
+            if (duplicatedPhone.length > 0) {
+                return {
+                    success: false,
+                    error: 'この電話番号は既に他のアカウントで使われています',
                 };
             }
         }
@@ -485,13 +563,11 @@ export async function updateUserProfile(formData: FormData) {
             }
         }
 
-        // プロフィール更新
-        await prisma.user.update({
-            where: { id: user.id },
-            data: {
+        // プロフィール更新（phone 変更時は advisory lock で race 回避）
+        const updateData = {
                 name,
-                email,
-                phone_number: phoneNumber,
+                email: normalizedEmail,
+                phone_number: normalizedPhone,
                 ...(isPhoneChanged ? {
                     phone_verified: true,
                     phone_verified_at: new Date(),
@@ -539,8 +615,45 @@ export async function updateUserProfile(formData: FormData) {
                 // 更新者追跡
                 updated_by_type: 'WORKER',
                 updated_by_id: user.id,
-            },
-        });
+        };
+
+        if (isPhoneChanged) {
+            const lockKey = computePhoneLockKey(normalizedPhone);
+            try {
+                await prisma.$transaction(async (tx) => {
+                    await tx.$queryRaw(
+                        Prisma.sql`SELECT pg_advisory_xact_lock(${lockKey}::bigint)`
+                    );
+                    // ロック取得後、直前再チェック（正規化比較）
+                    const dup = await tx.$queryRaw<{ id: number }[]>(
+                        Prisma.sql`SELECT id FROM users
+                            WHERE regexp_replace(translate(phone_number, '０１２３４５６７８９', '0123456789'), '[^0-9]', '', 'g') = ${normalizedPhone}
+                            AND phone_verified = true
+                            AND deleted_at IS NULL
+                            AND id <> ${user.id}
+                            LIMIT 1`
+                    );
+                    if (dup.length > 0) throw new Error('PHONE_DUPLICATE_RACE');
+                    await tx.user.update({
+                        where: { id: user.id },
+                        data: updateData,
+                    });
+                });
+            } catch (e) {
+                if (e instanceof Error && e.message === 'PHONE_DUPLICATE_RACE') {
+                    return {
+                        success: false,
+                        error: 'この電話番号は既に他のアカウントで使われています',
+                    };
+                }
+                throw e;
+            }
+        } else {
+            await prisma.user.update({
+                where: { id: user.id },
+                data: updateData,
+            });
+        }
 
         // プロフィール関連ページのキャッシュを無効化
         revalidatePath('/mypage/profile');

--- a/src/lib/auth/identifier.ts
+++ b/src/lib/auth/identifier.ts
@@ -1,0 +1,56 @@
+export type LoginIdentifier =
+  | { type: 'email'; value: string }
+  | { type: 'phone'; value: string }
+  | { type: 'invalid' };
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function normalize(input: string): string {
+  return input
+    .trim()
+    .replace(/[Ａ-Ｚａ-ｚ０-９]/g, (ch) =>
+      String.fromCharCode(ch.charCodeAt(0) - 0xfee0)
+    )
+    .replace(/＠/g, '@')
+    .replace(/\u3000/g, ' ');
+}
+
+/**
+ * 電話番号を「数字のみ」の正規化形式に変換する。
+ * 全角数字・ハイフン・スペース・括弧などをすべて除去。
+ */
+export function normalizePhoneDigits(input: string | undefined | null): string {
+  if (!input) return '';
+  return input
+    .replace(/[０-９]/g, (ch) => String.fromCharCode(ch.charCodeAt(0) - 0xfee0))
+    .replace(/[^0-9]/g, '');
+}
+
+/**
+ * 正規化済み電話番号を Postgres advisory lock キー用の bigint に変換する。
+ */
+export function phoneLockKey(normalized: string): bigint {
+  return BigInt(normalized.replace(/^0+/, '') || '0');
+}
+
+export function parseLoginIdentifier(raw: string | undefined | null): LoginIdentifier {
+  if (!raw) return { type: 'invalid' };
+
+  const normalized = normalize(raw);
+  if (!normalized) return { type: 'invalid' };
+
+  if (EMAIL_RE.test(normalized)) {
+    return { type: 'email', value: normalized.toLowerCase() };
+  }
+
+  // 電話番号候補: 数字・ハイフン・スペース・括弧・プラスのみを許可
+  if (!/^[0-9\s\-+()]+$/.test(normalized)) {
+    return { type: 'invalid' };
+  }
+  const digitsOnly = normalized.replace(/[^0-9]/g, '');
+  if (digitsOnly.length === 10 || digitsOnly.length === 11) {
+    return { type: 'phone', value: digitsOnly };
+  }
+
+  return { type: 'invalid' };
+}

--- a/src/lib/auth/phone-verification.ts
+++ b/src/lib/auth/phone-verification.ts
@@ -2,8 +2,12 @@
  * 電話番号認証用JWT生成・検証ユーティリティ
  * CPaaS NOWでのSMS認証成功後に短期トークンを発行し、
  * 登録・プロフィール更新時にサーバー側で検証する
+ *
+ * 入力の表記ゆれ（ハイフン・全角数字など）で検証結果が変わらないよう、
+ * 発行・検証の両方で digits-only に正規化してから一致比較する。
  */
 import { SignJWT, jwtVerify } from 'jose';
+import { normalizePhoneDigits } from '@/src/lib/auth/identifier';
 
 const TOKEN_EXPIRY = '7d'; // 7日間有効
 
@@ -23,7 +27,8 @@ export async function createPhoneVerificationToken(phone: string): Promise<strin
   const secret = getSecret();
 
   return new SignJWT({
-    phone,
+    // payload は正規化後の digits-only で保存
+    phone: normalizePhoneDigits(phone),
     verifiedAt: Date.now(),
     purpose: 'phone-verification',
   })
@@ -36,7 +41,7 @@ export async function createPhoneVerificationToken(phone: string): Promise<strin
 /**
  * 電話番号認証JWTトークンを検証
  * @param token JWTトークン
- * @param expectedPhone 期待する電話番号（リクエストの電話番号と一致するか確認）
+ * @param expectedPhone 期待する電話番号（正規化前後どちらでも可）
  * @returns 検証成功ならtrue
  */
 export async function validatePhoneVerificationToken(
@@ -48,10 +53,14 @@ export async function validatePhoneVerificationToken(
     const { payload } = await jwtVerify(token, secret);
 
     // 電話番号の一致を確認
-    if (payload.phone !== expectedPhone) {
+    // 後方互換: 旧トークン（payload.phone が raw 形式）も受けるため両側 normalize して比較
+    const expectedNormalized = normalizePhoneDigits(expectedPhone);
+    const payloadPhone = typeof payload.phone === 'string' ? payload.phone : '';
+    const payloadNormalized = normalizePhoneDigits(payloadPhone);
+    if (payloadNormalized !== expectedNormalized) {
       console.warn('[Phone Verification] Phone mismatch:', {
-        expected: expectedPhone,
-        got: payload.phone,
+        expected: expectedNormalized,
+        got: payloadPhone,
       });
       return false;
     }

--- a/src/lib/auth/session-cookie.ts
+++ b/src/lib/auth/session-cookie.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server';
+import { encode } from 'next-auth/jwt';
+
+const SESSION_MAX_AGE_SECONDS = 30 * 24 * 60 * 60;
+
+export type SessionCookieUser = {
+  id: number;
+  email: string;
+  name: string;
+};
+
+export async function issueSessionCookie(
+  response: NextResponse,
+  user: SessionCookieUser
+): Promise<void> {
+  const secret = process.env.NEXTAUTH_SECRET;
+  if (!secret) {
+    throw new Error('NEXTAUTH_SECRET is not configured');
+  }
+
+  const jwtToken = await encode({
+    token: {
+      id: String(user.id),
+      email: user.email,
+      name: user.name,
+      sub: String(user.id),
+    },
+    secret,
+    maxAge: SESSION_MAX_AGE_SECONDS,
+  });
+
+  const isProduction = process.env.NODE_ENV === 'production';
+  const cookieName = isProduction
+    ? '__Secure-next-auth.session-token'
+    : 'next-auth.session-token';
+
+  response.cookies.set(cookieName, jwtToken, {
+    httpOnly: true,
+    secure: isProduction,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: SESSION_MAX_AGE_SECONDS,
+  });
+
+  response.headers.set('Cache-Control', 'no-store');
+  response.headers.set('Referrer-Policy', 'no-referrer');
+}


### PR DESCRIPTION
## Summary
- モックHTML（タスタス新登録イメージ更新版）に基づく8ステップSPA UI に差替
- ログインを電話番号 or メールアドレス（どちらでも可）+ パスワードに
- メール認証のブロックを「登録時」から「応募時（applyForJob / applyForJobMultipleDates / acceptOffer / cancelApplicationByWorker の4関数）」に移動
- 登録完了と同時にサンクスページへ遷移し、NextAuth JWT Cookie をサーバーサイドで発行（CV用ランディング）

## 主な変更
| 変更 | 概要 |
|---|---|
| `app/register/worker/page.tsx` | 全面書き換え（8-step + 2b条件分岐 + SmsVerification 統合） |
| `app/register/worker/thanks/` | 新設。Server Component で getServerSession |
| `app/api/auth/register/route.ts` | 新フィールド受信、pg_advisory_xact_lock で phone race 軽減、SQL regexp_replace + translate で正規化比較、issueSessionCookie |
| `lib/auth.ts` | identifier 対応、email_verified チェック削除、phone login も SQL 正規化検索 |
| `src/lib/auth/session-cookie.ts` | NextAuth JWT + Cookie 発行を共通化 |
| `src/lib/auth/identifier.ts` | parseLoginIdentifier / normalizePhoneDigits / phoneLockKey |
| `src/lib/actions/application-worker.ts` | 4関数に email_verified チェック |
| `components/auth/EmailVerificationRequiredModal.tsx` | 応募時の未認証ブロックモーダル（5分クールダウン） |
| `src/lib/actions/user-profile.ts` | phone 正規化 + race 回避、email case-insensitive 重複検出、email normalize 保存 |

## レビュー実施
- Codex Plan Reviewer: APPROVE（最終）
- Codex Code Reviewer: SHIP（最終）
- 全 13 タスクごとに Codex レビュー → 合格してから次タスクに進む運用

## Prismaスキーマ変更
**なし**（既存カラムで全項目カバー）

## 動作確認（ローカル）
- [ ] 8-step の UI 表示（条件付き 2b）
- [ ] 郵便番号 → 住所自動入力（zipcloud）
- [ ] SMS認証（dev モック）
- [ ] 登録 → サンクス → /job-list 遷移
- [ ] 未認証メールでの応募 → モーダル表示
- [ ] 電話/メール両方でログイン
- [ ] ハイフン・全角数字入りの電話番号で識別成功

## 既知の制限（要フォロー）
- `desired_work_style` は複数選択を CSV 保存。プロフィール編集画面は先頭値のみ表示（モック設計上の妥協）
- TasLink 連携の workPreference 変換は新値に未対応（既存挙動維持。別タスクでマッピング拡張）

🤖 Generated with [Claude Code](https://claude.com/claude-code)