### PR TITLE
バグ修正: SMS送信400エラー（expiration_minutes 60分上限対応）

### DIFF
--- a/src/lib/cpaasnow.ts
+++ b/src/lib/cpaasnow.ts
@@ -8,7 +8,13 @@ const API_TOKEN = process.env.CPAAS_NOW_API_TOKEN;
 
 // SMS本文テンプレート
 // {{verification_code}}: 認証コードに置換、{{expiration_minutes}}: 有効期限(分)に置換
-const SMS_TEMPLATE = '【タスタス】認証コード: {{verification_code}}\r\n有効期限: 7日間';
+// CPaaS NOW 要件: {{expiration_minutes}} プレースホルダを本文に含めること
+const SMS_TEMPLATE = '【タスタス】認証コード: {{verification_code}}\r\n有効期限: {{expiration_minutes}}分';
+
+// CPaaS NOW の API 制約により 5-60 分のみ有効。
+// SMS コード自体の有効期限（コード検証はこの時間内に実施する必要がある）。
+// 検証成功後に発行する JWT（src/lib/auth/phone-verification.ts）は 7 日間有効。
+const SMS_EXPIRATION_MINUTES = 60;
 
 export interface SendCodeResult {
   success: boolean;
@@ -45,7 +51,7 @@ export async function sendVerificationCode(phoneNumber: string): Promise<SendCod
         message: SMS_TEMPLATE,
         code_type: 'numeric',
         code_size: 6,
-        expiration_minutes: 10080, // 7日間（60分 × 24時間 × 7日）
+        expiration_minutes: SMS_EXPIRATION_MINUTES,
       }),
     });
 


### PR DESCRIPTION
## 概要
本番で SMS 送信時に以下のエラーが出ていた問題の修正：
\`\`\`
SMS送信に失敗しました（400）: {"code":"InvalidParameter","message":"パラメータに誤りがあります","details":[
  {"parameter":"expiration_minutes","message":"expiration_minutesは5から60までの数値で入力してください"},
  {"parameter":"message","message":"messageに「{{expiration_minutes}}」を含めてください"}
]}
\`\`\`

## 原因
PR #530（コミット e9c0ac8）で SMS コード有効期限を「10分 → 7日間（10080分）」に変更していたが：
- CPaaS NOW API は `expiration_minutes` を **5-60 分のみ許容**
- 本文（message）に `{{expiration_minutes}}` プレースホルダを含めることが必須

## 修正
- `SMS_EXPIRATION_MINUTES = 60`（CPaaS の最大値）
- `SMS_TEMPLATE` に `{{expiration_minutes}}` を含めるよう修正
- コメントで「JWT (src/lib/auth/phone-verification.ts) の 7 日間有効期限は別レイヤー」であることを明記

## 影響
- SMS コード自体の有効期限: 60 分（ユーザーはこの間に入力が必要）
- SMS 検証成功後に発行される JWT トークン: **7 日間有効のまま変更なし**（フォーム提出まで本人確認状態を維持）

## レビュー
- Codex Code Reviewer: APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)