### PR TITLE
バグ修正: 登録500エラー診断改善 + 利用規約チェックボックスのタップ領域拡大

### DIFF
--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -355,16 +355,21 @@ export async function POST(request: NextRequest) {
       url: '/api/auth/register',
     }).catch(logErr => console.error('Failed to log activity:', logErr));
 
-    // デバッグ用：エラー詳細を返す（本番運用開始後は削除）
+    // 本番環境では詳細情報を秘匿（開発・EXPOSE_DEBUG_ERRORS=true の場合のみ公開）
+    const exposeDebug =
+      process.env.NODE_ENV !== 'production' ||
+      process.env.EXPOSE_DEBUG_ERRORS === 'true';
     const errorMessage = error instanceof Error ? error.message : String(error);
     const errorStack = error instanceof Error ? error.stack : undefined;
     return NextResponse.json(
       {
         error: '登録中にエラーが発生しました',
-        debug: {
-          message: errorMessage,
-          stack: errorStack?.split('\n').slice(0, 5).join('\n'),
-        }
+        ...(exposeDebug ? {
+          debug: {
+            message: errorMessage,
+            stack: errorStack?.split('\n').slice(0, 5).join('\n'),
+          },
+        } : {}),
       },
       { status: 500 }
     );

--- a/app/register/worker/page.tsx
+++ b/app/register/worker/page.tsx
@@ -309,13 +309,18 @@ function WorkerRegisterPageInner() {
       });
       const data = await res.json();
       if (!res.ok) {
+        // debug.message があれば詳細な原因も表示（ステージング診断用）
+        const detailMessage = data?.debug?.message
+          ? `${data.error || '登録に失敗しました'}（原因: ${data.debug.message}）`
+          : (data.error || '登録に失敗しました');
         showDebugError({
           type: 'other',
           operation: '会員登録',
-          message: data.error || '登録に失敗しました',
-          context: { status: res.status },
+          message: detailMessage,
+          details: data?.debug?.stack,
+          context: { status: res.status, debug: data?.debug },
         });
-        toast.error(data.error || '登録に失敗しました');
+        toast.error(detailMessage);
         setIsSubmitting(false);
         return;
       }
@@ -638,37 +643,37 @@ function WorkerRegisterPageInner() {
                   className="w-full px-4 py-3 border-2 border-gray-200 rounded-[10px] focus:border-[#2AADCF] focus:outline-none"
                 />
               </div>
-              <div className="space-y-2 mt-6">
-                <label className="flex items-start gap-2 text-sm cursor-pointer">
+              <div className="space-y-1 mt-6">
+                <label className="flex items-start gap-3 text-sm cursor-pointer py-2 px-1 min-h-[44px] active:bg-gray-50 rounded-lg select-none">
                   <input
                     type="checkbox"
                     checked={agreedToTerms}
                     onChange={e => setAgreedToTerms(e.target.checked)}
-                    className="mt-0.5"
+                    className="mt-1 w-5 h-5 flex-shrink-0 accent-[#2AADCF] cursor-pointer"
                   />
-                  <span>
+                  <span className="leading-relaxed">
                     <button
                       type="button"
-                      onClick={() => setShowTermsModal(true)}
-                      className="text-[#2AADCF] underline"
+                      onClick={e => { e.preventDefault(); setShowTermsModal(true); }}
+                      className="text-[#2AADCF] underline font-medium"
                     >
                       利用規約
                     </button>
                     に同意する
                   </span>
                 </label>
-                <label className="flex items-start gap-2 text-sm cursor-pointer">
+                <label className="flex items-start gap-3 text-sm cursor-pointer py-2 px-1 min-h-[44px] active:bg-gray-50 rounded-lg select-none">
                   <input
                     type="checkbox"
                     checked={agreedToPrivacy}
                     onChange={e => setAgreedToPrivacy(e.target.checked)}
-                    className="mt-0.5"
+                    className="mt-1 w-5 h-5 flex-shrink-0 accent-[#2AADCF] cursor-pointer"
                   />
-                  <span>
+                  <span className="leading-relaxed">
                     <button
                       type="button"
-                      onClick={() => setShowPrivacyModal(true)}
-                      className="text-[#2AADCF] underline"
+                      onClick={e => { e.preventDefault(); setShowPrivacyModal(true); }}
+                      className="text-[#2AADCF] underline font-medium"
                     >
                       プライバシーポリシー
                     </button>

--- a/app/register/worker/page.tsx
+++ b/app/register/worker/page.tsx
@@ -644,42 +644,44 @@ function WorkerRegisterPageInner() {
                 />
               </div>
               <div className="space-y-1 mt-6">
-                <label className="flex items-start gap-3 text-sm cursor-pointer py-2 px-1 min-h-[44px] active:bg-gray-50 rounded-lg select-none">
+                <div className="flex items-start gap-3 py-2 px-1 min-h-[44px] select-none">
                   <input
+                    id="agree-terms"
                     type="checkbox"
                     checked={agreedToTerms}
                     onChange={e => setAgreedToTerms(e.target.checked)}
                     className="mt-1 w-5 h-5 flex-shrink-0 accent-[#2AADCF] cursor-pointer"
                   />
-                  <span className="leading-relaxed">
+                  <div className="leading-relaxed text-sm flex-1">
                     <button
                       type="button"
-                      onClick={e => { e.preventDefault(); setShowTermsModal(true); }}
+                      onClick={() => setShowTermsModal(true)}
                       className="text-[#2AADCF] underline font-medium"
                     >
                       利用規約
                     </button>
-                    に同意する
-                  </span>
-                </label>
-                <label className="flex items-start gap-3 text-sm cursor-pointer py-2 px-1 min-h-[44px] active:bg-gray-50 rounded-lg select-none">
+                    <label htmlFor="agree-terms" className="cursor-pointer">に同意する</label>
+                  </div>
+                </div>
+                <div className="flex items-start gap-3 py-2 px-1 min-h-[44px] select-none">
                   <input
+                    id="agree-privacy"
                     type="checkbox"
                     checked={agreedToPrivacy}
                     onChange={e => setAgreedToPrivacy(e.target.checked)}
                     className="mt-1 w-5 h-5 flex-shrink-0 accent-[#2AADCF] cursor-pointer"
                   />
-                  <span className="leading-relaxed">
+                  <div className="leading-relaxed text-sm flex-1">
                     <button
                       type="button"
-                      onClick={e => { e.preventDefault(); setShowPrivacyModal(true); }}
+                      onClick={() => setShowPrivacyModal(true)}
                       className="text-[#2AADCF] underline font-medium"
                     >
                       プライバシーポリシー
                     </button>
-                    に同意する
-                  </span>
-                </label>
+                    <label htmlFor="agree-privacy" className="cursor-pointer">に同意する</label>
+                  </div>
+                </div>
               </div>
               <div className="flex justify-center gap-4 mt-6 text-xs text-gray-500">
                 <span>🔒 SSL暗号化通信</span>

--- a/src/lib/auth/identifier.ts
+++ b/src/lib/auth/identifier.ts
@@ -27,10 +27,12 @@ export function normalizePhoneDigits(input: string | undefined | null): string {
 }
 
 /**
- * 正規化済み電話番号を Postgres advisory lock キー用の bigint に変換する。
+ * 正規化済み電話番号を Postgres advisory lock キー用の数値文字列に変換する。
+ * BigInt を直接 $queryRaw に渡すと driver 側でシリアライズ問題が起きるため、
+ * 文字列として渡して SQL 側で `::bigint` キャストする。
  */
-export function phoneLockKey(normalized: string): bigint {
-  return BigInt(normalized.replace(/^0+/, '') || '0');
+export function phoneLockKey(normalized: string): string {
+  return normalized.replace(/^0+/, '') || '0';
 }
 
 export function parseLoginIdentifier(raw: string | undefined | null): LoginIdentifier {


### PR DESCRIPTION
## 概要
スマホ本番で登録完了時に「登録中にエラーが発生しました」が出てサンクスページに進めない問題の診断改善と、チェックボックスの誤タップ対策。

## 変更内容

### 1. 500エラー診断を改善
- \`src/lib/auth/identifier.ts\`: \`phoneLockKey\` を \`bigint\` → \`string\` に変更。SQL側で \`::bigint\` キャストしているため、BigInt driver 問題（500 の有力候補）を回避
- \`app/register/worker/page.tsx\`: 登録失敗時に \`data.debug.message\` をユーザー表示エラーに含める。ステージングで原因特定を容易にする
- \`app/api/auth/register/route.ts\`: \`debug\` フィールドを \`NODE_ENV !== 'production' || EXPOSE_DEBUG_ERRORS=true\` でガード。本番の情報漏洩防止

### 2. スマホUX改善
- 利用規約・プライバシー同意チェックボックスのタップ領域を拡大（min-h-[44px] = Apple HIGの推奨最小）
- チェックボックスサイズ 20x20（w-5 h-5）
- accent-color で色を統一
- \`<label>\` 内 \`<button>\` のネスト構造を htmlFor パターンに修正（不正HTML解消）

## ステージング確認方法
\`.env\` または Vercel 環境変数に \`EXPOSE_DEBUG_ERRORS=true\` を追加して再デプロイすると、登録500時に詳細エラー情報がクライアントに返却され、原因特定ができる。**本番環境では設定しない**。

## レビュー
- Codex Code Reviewer: APPROVE（2回の REQUEST CHANGES 後に解消）

🤖 Generated with [Claude Code](https://claude.com/claude-code)