### PR TITLE
機能追加: テスト用ワーカー完全削除機能（開発者ポータル）

### DIFF
--- a/app/system-admin/dev-portal/delete-worker/page.tsx
+++ b/app/system-admin/dev-portal/delete-worker/page.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import Link from 'next/link';
+import { ArrowLeft, AlertTriangle, Loader2, Trash2, CheckCircle2 } from 'lucide-react';
+import { deleteWorkerCompletely, DeleteWorkerResult } from '@/src/lib/actions/dev-user-delete';
+
+export default function DeleteWorkerPage() {
+  const [identifier, setIdentifier] = useState('');
+  const [confirmText, setConfirmText] = useState('');
+  const [result, setResult] = useState<DeleteWorkerResult | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const canSubmit = identifier.trim() !== '' && confirmText === '削除する' && !isPending;
+
+  const handleSubmit = () => {
+    if (!canSubmit) return;
+    setResult(null);
+    startTransition(async () => {
+      const res = await deleteWorkerCompletely(identifier.trim());
+      setResult(res);
+      if (res.success) {
+        setIdentifier('');
+        setConfirmText('');
+      }
+    });
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto p-6">
+      <div className="mb-6">
+        <Link
+          href="/system-admin/dev-portal"
+          className="inline-flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          開発者ポータルに戻る
+        </Link>
+      </div>
+
+      <div className="bg-white rounded-lg shadow p-6">
+        <div className="flex items-center gap-2 mb-2">
+          <Trash2 className="w-6 h-6 text-red-600" />
+          <h1 className="text-2xl font-bold">ワーカー完全削除（開発・テスト用）</h1>
+        </div>
+        <p className="text-sm text-gray-600 mb-6">
+          指定したワーカーユーザーと、それに紐付く応募・ブックマーク・メッセージ・プッシュ通知登録・出退勤・銀行口座などのデータを<strong>完全に削除</strong>します。
+        </p>
+
+        <div className="bg-red-50 border border-red-200 rounded-md p-4 mb-6">
+          <div className="flex gap-3">
+            <AlertTriangle className="w-5 h-5 text-red-600 flex-shrink-0 mt-0.5" />
+            <div className="text-sm text-red-800">
+              <p className="font-bold mb-2">⚠️ 重要な注意事項</p>
+              <ul className="list-disc pl-5 space-y-1">
+                <li>この操作は<strong>不可逆</strong>です。削除後の復元はできません。</li>
+                <li>対象ユーザーのオファー求人の <code className="bg-red-100 px-1 rounded">target_worker_id</code> は null にリセットされます（求人自体は削除されません）。</li>
+                <li>操作ログ（UserActivityLog）は履歴保持のため残存します。</li>
+                <li>本番環境では <code className="bg-red-100 px-1 rounded">ALLOW_DEV_USER_DELETE=true</code> が設定されていないと実行できません。</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium mb-1">
+              対象ユーザー（メールアドレス または ユーザーID）
+            </label>
+            <input
+              type="text"
+              value={identifier}
+              onChange={(e) => setIdentifier(e.target.value)}
+              disabled={isPending}
+              placeholder="例: test@example.com または 123"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1">
+              確認のため「<strong>削除する</strong>」と入力してください
+            </label>
+            <input
+              type="text"
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.target.value)}
+              disabled={isPending}
+              placeholder="削除する"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500"
+            />
+          </div>
+
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            className="w-full px-4 py-3 bg-red-600 text-white font-semibold rounded-md hover:bg-red-700 disabled:bg-gray-300 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+          >
+            {isPending ? (
+              <>
+                <Loader2 className="w-5 h-5 animate-spin" />
+                削除中...
+              </>
+            ) : (
+              <>
+                <Trash2 className="w-5 h-5" />
+                完全削除を実行
+              </>
+            )}
+          </button>
+        </div>
+
+        {result && (
+          <div
+            className={`mt-6 p-4 rounded-md border ${
+              result.success
+                ? 'bg-green-50 border-green-200'
+                : 'bg-red-50 border-red-200'
+            }`}
+          >
+            {result.success ? (
+              <>
+                <div className="flex items-center gap-2 mb-2">
+                  <CheckCircle2 className="w-5 h-5 text-green-600" />
+                  <p className="font-semibold text-green-800">削除完了</p>
+                </div>
+                {result.deletedUser && (
+                  <div className="text-sm text-green-800 space-y-1">
+                    <p>
+                      ユーザー: ID={result.deletedUser.id}, {result.deletedUser.name}（
+                      {result.deletedUser.email}）
+                    </p>
+                    {result.counts && (
+                      <ul className="list-disc pl-5 mt-2">
+                        <li>応募レコード: {result.counts.applications} 件（cascade 削除）</li>
+                        <li>ブックマーク: {result.counts.bookmarks} 件（cascade 削除）</li>
+                        <li>メッセージ: {result.counts.messages} 件（cascade 削除）</li>
+                        <li>レビュー: {result.counts.reviews} 件（cascade 削除）</li>
+                        <li>勤怠: {result.counts.attendances} 件（cascade 削除）</li>
+                        <li>
+                          オファー求人の target_worker_id クリア:{' '}
+                          {result.counts.offeredJobsCleared} 件
+                        </li>
+                        <li>
+                          JobWorkDate カウンター調整:{' '}
+                          {result.counts.workDateCountersAdjusted} 件
+                        </li>
+                        <li>
+                          Facility 評価再計算: {result.counts.facilityRatingsRecalculated} 件
+                        </li>
+                      </ul>
+                    )}
+                  </div>
+                )}
+              </>
+            ) : (
+              <>
+                <div className="flex items-center gap-2 mb-2">
+                  <AlertTriangle className="w-5 h-5 text-red-600" />
+                  <p className="font-semibold text-red-800">
+                    {result.blockers ? '削除不可（進行中業務あり）' : 'エラー'}
+                  </p>
+                </div>
+                <p className="text-sm text-red-800">{result.message}</p>
+                {result.blockers && result.blockers.length > 0 && (
+                  <ul className="list-disc pl-5 mt-2 text-sm text-red-800">
+                    {result.blockers.map((b, i) => (
+                      <li key={i}>{b}</li>
+                    ))}
+                  </ul>
+                )}
+              </>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/system-admin/dev-portal/page.tsx
+++ b/app/system-admin/dev-portal/page.tsx
@@ -243,6 +243,7 @@ const SYSTEM_ADMIN_TREE: SiteMapNode[] = [
             { name: 'debug-time', title: 'デバッグ時刻設定', href: '/system-admin/dev-portal/debug-time' },
             { name: 'error-alert', title: 'エラー通知設定', href: '/system-admin/dev-portal/error-alert' },
             { name: 'test-notifications', title: 'テスト通知送信', href: '/system-admin/dev-portal/test-notifications' },
+            { name: 'delete-worker', title: 'ワーカー完全削除（テスト用）', href: '/system-admin/dev-portal/delete-worker' },
         ]
     },
 ];
@@ -447,6 +448,15 @@ export default function DevPortalPage() {
                                 <p className="text-lg font-bold text-purple-600 group-hover:text-purple-700">指標・計算式</p>
                             </div>
                             <Calculator className="w-8 h-8 text-purple-200 group-hover:text-purple-300" />
+                        </div>
+                    </Link>
+                    <Link href="/system-admin/dev-portal/delete-worker" className="bg-white rounded-xl shadow-sm border border-gray-200 p-4 hover:border-red-300 hover:shadow-md transition-all group">
+                        <div className="flex items-center justify-between">
+                            <div>
+                                <p className="text-xs font-medium text-gray-500">テスト用</p>
+                                <p className="text-lg font-bold text-red-600 group-hover:text-red-700">ワーカー完全削除</p>
+                            </div>
+                            <AlertTriangle className="w-8 h-8 text-red-200 group-hover:text-red-300" />
                         </div>
                     </Link>
                 </div>

--- a/src/lib/actions/dev-user-delete.ts
+++ b/src/lib/actions/dev-user-delete.ts
@@ -1,0 +1,305 @@
+'use server';
+
+import prisma from '@/lib/prisma';
+import { requireSystemAdminAuth } from '@/lib/system-admin-session-server';
+import { logActivity } from '@/lib/logger';
+
+export interface DeleteWorkerResult {
+  success: boolean;
+  message?: string;
+  blockers?: string[];
+  deletedUser?: { id: number; email: string; name: string };
+  counts?: {
+    applications: number;
+    bookmarks: number;
+    messages: number;
+    reviews: number;
+    attendances: number;
+    offeredJobsCleared: number;
+    workDateCountersAdjusted: number;
+    facilityRatingsRecalculated: number;
+  };
+}
+
+/**
+ * 開発・テスト用: ワーカーユーザーを完全削除（退会処理とは別物）
+ *
+ * 安全方針:
+ * - system-admin 認証必須
+ * - 本番環境では `ALLOW_DEV_USER_DELETE=true` でないと実行不可
+ * - 進行中の業務があれば削除拒否（SCHEDULED/WORKING 応募、未退勤 attendance）
+ * - JobWorkDate カウンター（applied/matched）を削除対象 Application 分だけ減算
+ * - 削除対象 Review があれば Facility.rating / review_count を再計算
+ * - Job.target_worker_id は null 化（求人自体は保持）
+ * - UserActivityLog は FK 無しのため残存（履歴保持）
+ */
+export async function deleteWorkerCompletely(
+  identifier: string
+): Promise<DeleteWorkerResult> {
+  let admin;
+  try {
+    admin = await requireSystemAdminAuth();
+  } catch {
+    return { success: false, message: 'システム管理者認証が必要です' };
+  }
+
+  if (
+    process.env.NODE_ENV === 'production' &&
+    process.env.ALLOW_DEV_USER_DELETE !== 'true'
+  ) {
+    return {
+      success: false,
+      message:
+        '本番環境ではこの機能は無効です（ALLOW_DEV_USER_DELETE=true で有効化）',
+    };
+  }
+
+  if (!identifier || !identifier.trim()) {
+    return { success: false, message: 'メールアドレスまたはユーザーIDを入力してください' };
+  }
+
+  const trimmed = identifier.trim();
+  const idAsNumber = /^\d+$/.test(trimmed) ? parseInt(trimmed, 10) : null;
+
+  const user = idAsNumber
+    ? await prisma.user.findUnique({ where: { id: idAsNumber } })
+    : await prisma.user.findFirst({
+        where: { email: { equals: trimmed, mode: 'insensitive' } },
+      });
+
+  if (!user) {
+    return {
+      success: false,
+      message: `ユーザーが見つかりません（入力値: ${trimmed}）`,
+    };
+  }
+
+  // --- 事前セーフガード: 施設業務に影響する状態があれば削除拒否 ---
+  const blockers: string[] = [];
+
+  // APPLIED も施設側で審査中なのでブロック対象に含める
+  const activeApps = await prisma.application.count({
+    where: {
+      user_id: user.id,
+      status: { in: ['APPLIED', 'SCHEDULED', 'WORKING', 'COMPLETED_PENDING'] },
+    },
+  });
+  if (activeApps > 0) {
+    blockers.push(
+      `審査中/進行中/完了待ちの応募が ${activeApps} 件あります（APPLIED / SCHEDULED / WORKING / COMPLETED_PENDING）。施設側の業務に影響するため削除できません。`
+    );
+  }
+
+  const activeAttendance = await prisma.attendance.count({
+    where: {
+      user_id: user.id,
+      check_out_time: null,
+    },
+  });
+  if (activeAttendance > 0) {
+    blockers.push(
+      `未退勤の勤怠レコードが ${activeAttendance} 件あります。退勤処理を完了してから削除してください。`
+    );
+  }
+
+  // オファー対象になっている未応答求人があれば拒否（施設が候補として保持している）
+  const offeredActive = await prisma.job.count({
+    where: {
+      target_worker_id: user.id,
+      status: { in: ['PUBLISHED', 'WORKING'] },
+    },
+  });
+  if (offeredActive > 0) {
+    blockers.push(
+      `施設から届いている未応答オファー求人が ${offeredActive} 件あります。施設側の候補者管理に影響するため削除できません。`
+    );
+  }
+
+  // 労働条件通知書のダウンロードトークン（施設が発行中）があれば拒否
+  // worker_id は FK 無しなので cascade 削除されず、削除後に dangling 化する
+  const pendingLaborDocTokens = await prisma.laborDocumentDownloadToken.count({
+    where: {
+      worker_id: user.id,
+      expires_at: { gt: new Date() },
+    },
+  });
+  if (pendingLaborDocTokens > 0) {
+    blockers.push(
+      `施設が発行中の労働条件通知書ダウンロードトークンが ${pendingLaborDocTokens} 件あります。期限切れまで待つかトークンを失効させてください。`
+    );
+  }
+
+  if (blockers.length > 0) {
+    return {
+      success: false,
+      message: '削除前提条件を満たしていません',
+      blockers,
+    };
+  }
+
+  // 監査ログ用: 影響を受けた主要エンティティのIDを収集
+  let appIdsForLog: number[] = [];
+  let facilityIdsForLog: number[] = [];
+  let threadIdsForLog: number[] = [];
+
+  try {
+    const result = await prisma.$transaction(async (tx) => {
+      // 1. Job.target_worker_id を null 化（FK onDelete 無しのため必須）
+      const offeredJobsCleared = await tx.job.updateMany({
+        where: { target_worker_id: user.id },
+        data: { target_worker_id: null },
+      });
+
+      // 2. 削除対象 Application（キャンセル済み・過去完了済み）を列挙し、
+      //    JobWorkDate のカウンターを減算
+      const appsToDelete = await tx.application.findMany({
+        where: { user_id: user.id },
+        select: { id: true, status: true, work_date_id: true },
+      });
+      appIdsForLog = appsToDelete.map((a) => a.id);
+
+      // MessageThread も削除対象（cascade で消えるので事前に ID を記録）
+      const threadsToDelete = await tx.messageThread.findMany({
+        where: { worker_id: user.id },
+        select: { id: true },
+      });
+      threadIdsForLog = threadsToDelete.map((t) => t.id);
+
+      let workDateCountersAdjusted = 0;
+      // applied_count はすべての非CANCELLED応募、matched_count は SCHEDULED/WORKING/COMPLETED_* でカウントされる想定
+      const wdCountMap = new Map<number, { applied: number; matched: number }>();
+      for (const app of appsToDelete) {
+        if (!app.work_date_id) continue;
+        const current = wdCountMap.get(app.work_date_id) ?? { applied: 0, matched: 0 };
+        // CANCELLED は applied_count から減算しない（応募時に decrement 済みのはず）
+        if (app.status !== 'CANCELLED') {
+          current.applied += 1;
+        }
+        // マッチング成立済みの状態だけ matched を減らす
+        if (['WORKING', 'COMPLETED_PENDING', 'COMPLETED_RATED'].includes(app.status)) {
+          current.matched += 1;
+        }
+        wdCountMap.set(app.work_date_id, current);
+      }
+      for (const [wdId, c] of Array.from(wdCountMap.entries())) {
+        if (c.applied === 0 && c.matched === 0) continue;
+        await tx.jobWorkDate.update({
+          where: { id: wdId },
+          data: {
+            applied_count: c.applied > 0 ? { decrement: c.applied } : undefined,
+            matched_count: c.matched > 0 ? { decrement: c.matched } : undefined,
+          },
+        });
+        workDateCountersAdjusted += 1;
+      }
+
+      // 3. 影響を受ける Facility ID を収集（Review 削除に伴う rating 再計算用）
+      // 施設の公開評価は「ワーカーが施設を評価した」レビューのみで集計される
+      // （既存実装 src/lib/actions/review-worker.ts と同じルール）
+      const affectedWorkerReviews = await tx.review.findMany({
+        where: { user_id: user.id, reviewer_type: 'WORKER' },
+        select: { facility_id: true },
+      });
+      const affectedFacilityIds = Array.from(
+        new Set(affectedWorkerReviews.map((r) => r.facility_id))
+      );
+      facilityIdsForLog = affectedFacilityIds;
+      // 全レビュー削除数（worker→facility + facility→worker）
+      const reviewsCount = await tx.review.count({
+        where: { user_id: user.id },
+      });
+
+      // カウンター取得（削除前）
+      const [bookmarksCount, messagesCount, attendancesCount] = await Promise.all([
+        tx.bookmark.count({
+          where: { OR: [{ user_id: user.id }, { target_user_id: user.id }] },
+        }),
+        tx.message.count({
+          where: { OR: [{ from_user_id: user.id }, { to_user_id: user.id }] },
+        }),
+        tx.attendance.count({ where: { user_id: user.id } }),
+      ]);
+
+      // 4. User 削除（他の関連テーブルは onDelete: Cascade）
+      await tx.user.delete({ where: { id: user.id } });
+
+      // 5. Facility rating を再計算（worker→facility レビューのみで平均、小数1桁丸め）
+      // 既存 src/lib/actions/review-worker.ts と同じロジックで整合をとる
+      let facilityRatingsRecalculated = 0;
+      for (const facilityId of affectedFacilityIds) {
+        const workerReviews = await tx.review.findMany({
+          where: { facility_id: facilityId, reviewer_type: 'WORKER' },
+          select: { rating: true },
+        });
+        const avg =
+          workerReviews.length > 0
+            ? workerReviews.reduce((s, r) => s + r.rating, 0) / workerReviews.length
+            : 0;
+        await tx.facility.update({
+          where: { id: facilityId },
+          data: {
+            rating: Math.round(avg * 10) / 10,
+            review_count: workerReviews.length,
+          },
+        });
+        facilityRatingsRecalculated += 1;
+      }
+
+      return {
+        applications: appsToDelete.length,
+        bookmarks: bookmarksCount,
+        messages: messagesCount,
+        reviews: reviewsCount,
+        attendances: attendancesCount,
+        offeredJobsCleared: offeredJobsCleared.count,
+        workDateCountersAdjusted,
+        facilityRatingsRecalculated,
+      };
+    });
+
+    logActivity({
+      userType: 'SYSTEM_ADMIN',
+      userId: admin.adminId,
+      userEmail: admin.email,
+      action: 'DELETE_USER_TEST',
+      targetType: 'User',
+      targetId: user.id,
+      requestData: {
+        deletedUserId: user.id,
+        deletedUserEmail: user.email,
+        deletedUserName: user.name,
+        counts: result,
+        // 追跡用: 削除で影響を受けた主要エンティティ ID 群
+        impactedApplicationIds: appIdsForLog,
+        impactedFacilityIds: facilityIdsForLog,
+        impactedMessageThreadIds: threadIdsForLog,
+      },
+      result: 'SUCCESS',
+    }).catch(() => {});
+
+    return {
+      success: true,
+      deletedUser: { id: user.id, email: user.email, name: user.name },
+      counts: result,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('[deleteWorkerCompletely] Error:', error);
+
+    logActivity({
+      userType: 'SYSTEM_ADMIN',
+      userId: admin.adminId,
+      userEmail: admin.email,
+      action: 'DELETE_USER_TEST_FAILED',
+      targetType: 'User',
+      targetId: user.id,
+      result: 'ERROR',
+      errorMessage: message,
+    }).catch(() => {});
+
+    return {
+      success: false,
+      message: `削除に失敗しました: ${message}`,
+    };
+  }
+}


### PR DESCRIPTION
## 概要
登録フロー等のデバッグで同一メール/電話番号を繰り返し使いたいケース向けに、システム管理→開発者ポータル配下にワーカーを関連データごと完全削除する機能を追加。

**退会処理とは別物**（将来別実装）。ユーザー指定の通り「奥にしまう」配置。

## 配置
- UI: \`/system-admin/dev-portal/delete-worker\`
- Server Action: \`src/lib/actions/dev-user-delete.ts\`

## 安全対策（網羅的副作用チェック済み）

### アクセス制御
- system-admin 認証必須
- 本番環境では \`ALLOW_DEV_USER_DELETE=true\` 環境変数でないと無効

### 事前ブロック条件（施設業務への悪影響防止）
| 条件 | 理由 |
|---|---|
| APPLIED/SCHEDULED/WORKING/COMPLETED_PENDING 応募がある | 施設側の審査中・進行中業務を壊さない |
| 未退勤の勤怠レコードがある | 打刻整合性確保 |
| target_worker_id 指定の PUBLISHED/WORKING オファー求人がある | 施設側の候補者管理を壊さない |
| 期限内の LaborDocumentDownloadToken がある | 施設の労働条件通知書DLを dangling 化させない |

### トランザクション内整合性処理
- \`Job.target_worker_id\` を null 化（FK に onDelete 無いため手動）
- \`JobWorkDate.applied_count / matched_count\` を削除対象 Application 分だけ decrement（カウンター乖離防止）
- Review 削除に伴い \`Facility.rating / review_count\` を再計算（既存 \`review-worker.ts\` と同ロジック = \`reviewer_type=WORKER\` のみ、小数1桁丸め）
- 他テーブルは Prisma schema の \`onDelete: Cascade\` で自動削除

### 監査性
- 削除前後の状態を \`logActivity\` に記録
- 影響範囲（application ID 群、facility ID 群、MessageThread ID 群）を JSON で保存 → 後追い可能

## レビュー
- Codex 網羅的影響レビュー: APPROVE（2回の REQUEST CHANGES 指摘を解消後）

## 動作
1. system-admin でログイン
2. 開発者ポータル → ワーカー完全削除カード
3. メール or ユーザーID 入力 + 確認テキスト「削除する」
4. 進行中業務があれば削除拒否（理由一覧表示）
5. 問題なければ削除実行 + 削除件数サマリー表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)