### PR TITLE
機能追加: ワーカー完全削除に強制削除モード追加

### DIFF
--- a/app/system-admin/dev-portal/delete-worker/page.tsx
+++ b/app/system-admin/dev-portal/delete-worker/page.tsx
@@ -8,20 +8,26 @@ import { deleteWorkerCompletely, DeleteWorkerResult } from '@/src/lib/actions/de
 export default function DeleteWorkerPage() {
   const [identifier, setIdentifier] = useState('');
   const [confirmText, setConfirmText] = useState('');
+  const [forceMode, setForceMode] = useState(false);
+  const [forceConfirmText, setForceConfirmText] = useState('');
   const [result, setResult] = useState<DeleteWorkerResult | null>(null);
   const [isPending, startTransition] = useTransition();
 
-  const canSubmit = identifier.trim() !== '' && confirmText === '削除する' && !isPending;
+  const baseValid = identifier.trim() !== '' && confirmText === '削除する';
+  const forceValid = !forceMode || forceConfirmText === '強制削除';
+  const canSubmit = baseValid && forceValid && !isPending;
 
   const handleSubmit = () => {
     if (!canSubmit) return;
     setResult(null);
     startTransition(async () => {
-      const res = await deleteWorkerCompletely(identifier.trim());
+      const res = await deleteWorkerCompletely(identifier.trim(), { force: forceMode });
       setResult(res);
       if (res.success) {
         setIdentifier('');
         setConfirmText('');
+        setForceMode(false);
+        setForceConfirmText('');
       }
     });
   };
@@ -91,6 +97,45 @@ export default function DeleteWorkerPage() {
             />
           </div>
 
+          {/* 強制削除オプション */}
+          <div className="border border-orange-300 rounded-md bg-orange-50 p-4">
+            <label className="flex items-start gap-2 cursor-pointer">
+              <input
+                id="force-delete"
+                type="checkbox"
+                checked={forceMode}
+                onChange={(e) => setForceMode(e.target.checked)}
+                disabled={isPending}
+                className="mt-1 w-4 h-4 accent-orange-600"
+              />
+              <div className="flex-1">
+                <span className="font-semibold text-orange-900 text-sm">
+                  強制削除モード（進行中業務のブロックをバイパス）
+                </span>
+                <p className="text-xs text-orange-800 mt-1 leading-relaxed">
+                  APPLIED/SCHEDULED/WORKING/COMPLETED_PENDING の応募や未応答オファーがある場合でも削除を強行します。
+                  施設側の業務履歴からテストデータが消える可能性あり。
+                  <strong>未退勤の勤怠は強制モードでもブロックされます。</strong>
+                </p>
+              </div>
+            </label>
+            {forceMode && (
+              <div className="mt-3 pl-6">
+                <label className="block text-xs font-medium text-orange-900 mb-1">
+                  追加確認: 「<strong>強制削除</strong>」と入力
+                </label>
+                <input
+                  type="text"
+                  value={forceConfirmText}
+                  onChange={(e) => setForceConfirmText(e.target.value)}
+                  disabled={isPending}
+                  placeholder="強制削除"
+                  className="w-full px-3 py-2 border border-orange-400 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 text-sm"
+                />
+              </div>
+            )}
+          </div>
+
           <button
             type="button"
             onClick={handleSubmit}
@@ -105,7 +150,7 @@ export default function DeleteWorkerPage() {
             ) : (
               <>
                 <Trash2 className="w-5 h-5" />
-                完全削除を実行
+                {forceMode ? '強制削除を実行' : '完全削除を実行'}
               </>
             )}
           </button>
@@ -148,6 +193,9 @@ export default function DeleteWorkerPage() {
                         </li>
                         <li>
                           Facility 評価再計算: {result.counts.facilityRatingsRecalculated} 件
+                        </li>
+                        <li>
+                          労働条件通知書トークン削除: {result.counts.laborDocTokensDeleted} 件
                         </li>
                       </ul>
                     )}

--- a/src/lib/actions/dev-user-delete.ts
+++ b/src/lib/actions/dev-user-delete.ts
@@ -18,6 +18,7 @@ export interface DeleteWorkerResult {
     offeredJobsCleared: number;
     workDateCountersAdjusted: number;
     facilityRatingsRecalculated: number;
+    laborDocTokensDeleted: number;
   };
 }
 
@@ -34,8 +35,11 @@ export interface DeleteWorkerResult {
  * - UserActivityLog は FK 無しのため残存（履歴保持）
  */
 export async function deleteWorkerCompletely(
-  identifier: string
+  identifier: string,
+  options?: { force?: boolean }
 ): Promise<DeleteWorkerResult> {
+  const force = options?.force === true;
+
   let admin;
   try {
     admin = await requireSystemAdminAuth();
@@ -75,21 +79,52 @@ export async function deleteWorkerCompletely(
   }
 
   // --- 事前セーフガード: 施設業務に影響する状態があれば削除拒否 ---
+  // force=true が指定された場合、データ整合性に関わる critical check のみ残し他はバイパス
   const blockers: string[] = [];
 
-  // APPLIED も施設側で審査中なのでブロック対象に含める
-  const activeApps = await prisma.application.count({
-    where: {
-      user_id: user.id,
-      status: { in: ['APPLIED', 'SCHEDULED', 'WORKING', 'COMPLETED_PENDING'] },
-    },
-  });
-  if (activeApps > 0) {
-    blockers.push(
-      `審査中/進行中/完了待ちの応募が ${activeApps} 件あります（APPLIED / SCHEDULED / WORKING / COMPLETED_PENDING）。施設側の業務に影響するため削除できません。`
-    );
+  if (!force) {
+    // APPLIED も施設側で審査中なのでブロック対象に含める
+    const activeApps = await prisma.application.count({
+      where: {
+        user_id: user.id,
+        status: { in: ['APPLIED', 'SCHEDULED', 'WORKING', 'COMPLETED_PENDING'] },
+      },
+    });
+    if (activeApps > 0) {
+      blockers.push(
+        `審査中/進行中/完了待ちの応募が ${activeApps} 件あります（APPLIED / SCHEDULED / WORKING / COMPLETED_PENDING）。施設側の業務に影響するため削除できません。`
+      );
+    }
+
+    // オファー対象になっている未応答求人があれば拒否（施設が候補として保持している）
+    const offeredActive = await prisma.job.count({
+      where: {
+        target_worker_id: user.id,
+        status: { in: ['PUBLISHED', 'WORKING'] },
+      },
+    });
+    if (offeredActive > 0) {
+      blockers.push(
+        `施設から届いている未応答オファー求人が ${offeredActive} 件あります。施設側の候補者管理に影響するため削除できません。`
+      );
+    }
+
+    // 労働条件通知書のダウンロードトークン（施設が発行中）があれば拒否
+    // worker_id は FK 無しなので cascade 削除されず、削除後に dangling 化する
+    const pendingLaborDocTokens = await prisma.laborDocumentDownloadToken.count({
+      where: {
+        worker_id: user.id,
+        expires_at: { gt: new Date() },
+      },
+    });
+    if (pendingLaborDocTokens > 0) {
+      blockers.push(
+        `施設が発行中の労働条件通知書ダウンロードトークンが ${pendingLaborDocTokens} 件あります。期限切れまで待つかトークンを失効させてください。`
+      );
+    }
   }
 
+  // 未退勤 attendance は force でもブロック（データ整合性に関わる critical check）
   const activeAttendance = await prisma.attendance.count({
     where: {
       user_id: user.id,
@@ -98,34 +133,7 @@ export async function deleteWorkerCompletely(
   });
   if (activeAttendance > 0) {
     blockers.push(
-      `未退勤の勤怠レコードが ${activeAttendance} 件あります。退勤処理を完了してから削除してください。`
-    );
-  }
-
-  // オファー対象になっている未応答求人があれば拒否（施設が候補として保持している）
-  const offeredActive = await prisma.job.count({
-    where: {
-      target_worker_id: user.id,
-      status: { in: ['PUBLISHED', 'WORKING'] },
-    },
-  });
-  if (offeredActive > 0) {
-    blockers.push(
-      `施設から届いている未応答オファー求人が ${offeredActive} 件あります。施設側の候補者管理に影響するため削除できません。`
-    );
-  }
-
-  // 労働条件通知書のダウンロードトークン（施設が発行中）があれば拒否
-  // worker_id は FK 無しなので cascade 削除されず、削除後に dangling 化する
-  const pendingLaborDocTokens = await prisma.laborDocumentDownloadToken.count({
-    where: {
-      worker_id: user.id,
-      expires_at: { gt: new Date() },
-    },
-  });
-  if (pendingLaborDocTokens > 0) {
-    blockers.push(
-      `施設が発行中の労働条件通知書ダウンロードトークンが ${pendingLaborDocTokens} 件あります。期限切れまで待つかトークンを失効させてください。`
+      `未退勤の勤怠レコードが ${activeAttendance} 件あります。退勤処理を完了してから削除してください（強制削除でもバイパス不可）。`
     );
   }
 
@@ -148,6 +156,12 @@ export async function deleteWorkerCompletely(
       const offeredJobsCleared = await tx.job.updateMany({
         where: { target_worker_id: user.id },
         data: { target_worker_id: null },
+      });
+
+      // 1b. 労働条件通知書ダウンロードトークンも FK 無しのため手動削除
+      // （force モードでブロック外してきた場合は既に期限内のものが残っている可能性があるため必須）
+      const laborDocTokensDeleted = await tx.laborDocumentDownloadToken.deleteMany({
+        where: { worker_id: user.id },
       });
 
       // 2. 削除対象 Application（キャンセル済み・過去完了済み）を列挙し、
@@ -176,7 +190,9 @@ export async function deleteWorkerCompletely(
           current.applied += 1;
         }
         // マッチング成立済みの状態だけ matched を減らす
-        if (['WORKING', 'COMPLETED_PENDING', 'COMPLETED_RATED'].includes(app.status)) {
+        // 既存 apply/admin フローでは APPLIED→SCHEDULED 時点で matched_count +1 されるため
+        // SCHEDULED も対象に含める
+        if (['SCHEDULED', 'WORKING', 'COMPLETED_PENDING', 'COMPLETED_RATED'].includes(app.status)) {
           current.matched += 1;
         }
         wdCountMap.set(app.work_date_id, current);
@@ -254,6 +270,7 @@ export async function deleteWorkerCompletely(
         offeredJobsCleared: offeredJobsCleared.count,
         workDateCountersAdjusted,
         facilityRatingsRecalculated,
+        laborDocTokensDeleted: laborDocTokensDeleted.count,
       };
     });
 
@@ -261,10 +278,11 @@ export async function deleteWorkerCompletely(
       userType: 'SYSTEM_ADMIN',
       userId: admin.adminId,
       userEmail: admin.email,
-      action: 'DELETE_USER_TEST',
+      action: force ? 'DELETE_USER_TEST_FORCE' : 'DELETE_USER_TEST',
       targetType: 'User',
       targetId: user.id,
       requestData: {
+        force,
         deletedUserId: user.id,
         deletedUserEmail: user.email,
         deletedUserName: user.name,
@@ -290,9 +308,10 @@ export async function deleteWorkerCompletely(
       userType: 'SYSTEM_ADMIN',
       userId: admin.adminId,
       userEmail: admin.email,
-      action: 'DELETE_USER_TEST_FAILED',
+      action: force ? 'DELETE_USER_TEST_FORCE_FAILED' : 'DELETE_USER_TEST_FAILED',
       targetType: 'User',
       targetId: user.id,
+      requestData: { force },
       result: 'ERROR',
       errorMessage: message,
     }).catch(() => {});

--- a/src/lib/actions/dev-user-delete.ts
+++ b/src/lib/actions/dev-user-delete.ts
@@ -1,7 +1,11 @@
 'use server';
 
 import prisma from '@/lib/prisma';
-import { requireSystemAdminAuth } from '@/lib/system-admin-session-server';
+import { Prisma } from '@prisma/client';
+import {
+  requireSystemAdminAuth,
+  requireSuperAdminAuth,
+} from '@/lib/system-admin-session-server';
 import { logActivity } from '@/lib/logger';
 
 export interface DeleteWorkerResult {
@@ -42,9 +46,17 @@ export async function deleteWorkerCompletely(
 
   let admin;
   try {
-    admin = await requireSystemAdminAuth();
+    // 通常削除: system-admin 以上、force は super_admin に限定
+    admin = force
+      ? await requireSuperAdminAuth()
+      : await requireSystemAdminAuth();
   } catch {
-    return { success: false, message: 'システム管理者認証が必要です' };
+    return {
+      success: false,
+      message: force
+        ? '強制削除は super_admin 権限が必要です'
+        : 'システム管理者認証が必要です',
+    };
   }
 
   if (
@@ -78,91 +90,102 @@ export async function deleteWorkerCompletely(
     };
   }
 
-  // --- 事前セーフガード: 施設業務に影響する状態があれば削除拒否 ---
-  // force=true が指定された場合、データ整合性に関わる critical check のみ残し他はバイパス
-  const blockers: string[] = [];
-
-  if (!force) {
-    // APPLIED も施設側で審査中なのでブロック対象に含める
-    const activeApps = await prisma.application.count({
-      where: {
-        user_id: user.id,
-        status: { in: ['APPLIED', 'SCHEDULED', 'WORKING', 'COMPLETED_PENDING'] },
-      },
-    });
-    if (activeApps > 0) {
-      blockers.push(
-        `審査中/進行中/完了待ちの応募が ${activeApps} 件あります（APPLIED / SCHEDULED / WORKING / COMPLETED_PENDING）。施設側の業務に影響するため削除できません。`
-      );
-    }
-
-    // オファー対象になっている未応答求人があれば拒否（施設が候補として保持している）
-    const offeredActive = await prisma.job.count({
-      where: {
-        target_worker_id: user.id,
-        status: { in: ['PUBLISHED', 'WORKING'] },
-      },
-    });
-    if (offeredActive > 0) {
-      blockers.push(
-        `施設から届いている未応答オファー求人が ${offeredActive} 件あります。施設側の候補者管理に影響するため削除できません。`
-      );
-    }
-
-    // 労働条件通知書のダウンロードトークン（施設が発行中）があれば拒否
-    // worker_id は FK 無しなので cascade 削除されず、削除後に dangling 化する
-    const pendingLaborDocTokens = await prisma.laborDocumentDownloadToken.count({
-      where: {
-        worker_id: user.id,
-        expires_at: { gt: new Date() },
-      },
-    });
-    if (pendingLaborDocTokens > 0) {
-      blockers.push(
-        `施設が発行中の労働条件通知書ダウンロードトークンが ${pendingLaborDocTokens} 件あります。期限切れまで待つかトークンを失効させてください。`
-      );
-    }
-  }
-
-  // 未退勤 attendance は force でもブロック（データ整合性に関わる critical check）
-  const activeAttendance = await prisma.attendance.count({
-    where: {
-      user_id: user.id,
-      check_out_time: null,
-    },
-  });
-  if (activeAttendance > 0) {
-    blockers.push(
-      `未退勤の勤怠レコードが ${activeAttendance} 件あります。退勤処理を完了してから削除してください（強制削除でもバイパス不可）。`
-    );
-  }
-
-  if (blockers.length > 0) {
-    return {
-      success: false,
-      message: '削除前提条件を満たしていません',
-      blockers,
-    };
-  }
-
   // 監査ログ用: 影響を受けた主要エンティティのIDを収集
   let appIdsForLog: number[] = [];
   let facilityIdsForLog: number[] = [];
   let threadIdsForLog: number[] = [];
 
-  try {
-    const result = await prisma.$transaction(async (tx) => {
-      // 1. Job.target_worker_id を null 化（FK onDelete 無しのため必須）
-      const offeredJobsCleared = await tx.job.updateMany({
-        where: { target_worker_id: user.id },
-        data: { target_worker_id: null },
-      });
+  // blocker 情報をトランザクション外に伝えるための専用エラー
+  class BlockerError extends Error {
+    constructor(public readonly blockers: string[]) {
+      super('BLOCKERS');
+    }
+  }
 
-      // 1b. 労働条件通知書ダウンロードトークンも FK 無しのため手動削除
-      // （force モードでブロック外してきた場合は既に期限内のものが残っている可能性があるため必須）
-      const laborDocTokensDeleted = await tx.laborDocumentDownloadToken.deleteMany({
-        where: { worker_id: user.id },
-      });
+  try {
+    const result = await prisma.$transaction(
+      async (tx) => {
+        // 0. ユーザー ID に対する advisory xact lock + 行ロック
+        //    - advisory_xact_lock: 同じ削除コードの並行実行を直列化
+        //    - SELECT FOR UPDATE: PostgreSQL FK 制約により、子テーブル（Application,
+        //      Attendance, Bookmark, Message, Review, BankAccount, PushSubscription,
+        //      NearbyNotificationLog, MessageThread 等）への INSERT は親行に
+        //      FOR KEY SHARE を取得する。FOR UPDATE はこれと競合するため、
+        //      トランザクション commit まで新規 FK 子行の作成をブロックできる
+        const userLockKey = BigInt(user.id);
+        await tx.$queryRaw(
+          Prisma.sql`SELECT pg_advisory_xact_lock(${userLockKey}::bigint)`
+        );
+        await tx.$queryRaw(
+          Prisma.sql`SELECT id FROM users WHERE id = ${user.id} FOR UPDATE`
+        );
+        // 注: LaborDocumentDownloadToken は FK 無しのため FOR UPDATE で
+        // 新規発行をブロックできない。テストユーティリティとして race を受容
+        // （発行頻度は低く、テスト環境での競合確率は極めて低い）
+
+        // 0b. blocker チェック（トランザクション内で行うことで TOCTOU を防ぐ）
+        const txBlockers: string[] = [];
+
+        if (!force) {
+          const activeApps = await tx.application.count({
+            where: {
+              user_id: user.id,
+              status: { in: ['APPLIED', 'SCHEDULED', 'WORKING', 'COMPLETED_PENDING'] },
+            },
+          });
+          if (activeApps > 0) {
+            txBlockers.push(
+              `審査中/進行中/完了待ちの応募が ${activeApps} 件あります（APPLIED / SCHEDULED / WORKING / COMPLETED_PENDING）。施設側の業務に影響するため削除できません。`
+            );
+          }
+
+          const offeredActive = await tx.job.count({
+            where: {
+              target_worker_id: user.id,
+              status: { in: ['PUBLISHED', 'WORKING'] },
+            },
+          });
+          if (offeredActive > 0) {
+            txBlockers.push(
+              `施設から届いている未応答オファー求人が ${offeredActive} 件あります。施設側の候補者管理に影響するため削除できません。`
+            );
+          }
+
+          const pendingLaborDocTokens = await tx.laborDocumentDownloadToken.count({
+            where: {
+              worker_id: user.id,
+              expires_at: { gt: new Date() },
+            },
+          });
+          if (pendingLaborDocTokens > 0) {
+            txBlockers.push(
+              `施設が発行中の労働条件通知書ダウンロードトークンが ${pendingLaborDocTokens} 件あります。期限切れまで待つかトークンを失効させてください。`
+            );
+          }
+        }
+
+        // 未退勤 attendance は force でもブロック（critical check）
+        const activeAttendance = await tx.attendance.count({
+          where: {
+            user_id: user.id,
+            check_out_time: null,
+          },
+        });
+        if (activeAttendance > 0) {
+          txBlockers.push(
+            `未退勤の勤怠レコードが ${activeAttendance} 件あります。退勤処理を完了してから削除してください（強制削除でもバイパス不可）。`
+          );
+        }
+
+        if (txBlockers.length > 0) {
+          throw new BlockerError(txBlockers);
+        }
+
+        // 1. Job.target_worker_id を null 化（FK onDelete 無しのため必須）
+        const offeredJobsCleared = await tx.job.updateMany({
+          where: { target_worker_id: user.id },
+          data: { target_worker_id: null },
+        });
 
       // 2. 削除対象 Application（キャンセル済み・過去完了済み）を列挙し、
       //    JobWorkDate のカウンターを減算
@@ -236,6 +259,12 @@ export async function deleteWorkerCompletely(
         tx.attendance.count({ where: { user_id: user.id } }),
       ]);
 
+      // 3b. 労働条件通知書ダウンロードトークンを user.delete の直前に削除
+      // advisory lock 下なので新規トークン発行は直列化される
+      const laborDocTokensDeleted = await tx.laborDocumentDownloadToken.deleteMany({
+        where: { worker_id: user.id },
+      });
+
       // 4. User 削除（他の関連テーブルは onDelete: Cascade）
       await tx.user.delete({ where: { id: user.id } });
 
@@ -272,6 +301,11 @@ export async function deleteWorkerCompletely(
         facilityRatingsRecalculated,
         laborDocTokensDeleted: laborDocTokensDeleted.count,
       };
+    }, {
+      // 長時間ロックを避けるため timeout を設定
+      maxWait: 5000,
+      timeout: 30_000,
+      isolationLevel: Prisma.TransactionIsolationLevel.ReadCommitted,
     });
 
     logActivity({
@@ -301,6 +335,27 @@ export async function deleteWorkerCompletely(
       counts: result,
     };
   } catch (error) {
+    // BlockerError はトランザクション内で発生、ロールバック済み
+    if (error instanceof BlockerError) {
+      // ブロック時も監査ログを残す（force フラグ・試行ユーザー付き）
+      logActivity({
+        userType: 'SYSTEM_ADMIN',
+        userId: admin.adminId,
+        userEmail: admin.email,
+        action: force ? 'DELETE_USER_TEST_FORCE_BLOCKED' : 'DELETE_USER_TEST_BLOCKED',
+        targetType: 'User',
+        targetId: user.id,
+        requestData: { force, blockers: error.blockers },
+        result: 'ERROR',
+        errorMessage: 'BLOCKERS',
+      }).catch(() => {});
+      return {
+        success: false,
+        message: '削除前提条件を満たしていません',
+        blockers: error.blockers,
+      };
+    }
+
     const message = error instanceof Error ? error.message : String(error);
     console.error('[deleteWorkerCompletely] Error:', error);
 


### PR DESCRIPTION
## 概要
PR #535 で実装したワーカー削除機能が「自己応募でも APPLIED 状態があれば拒否」となっており、テストデータのクリーンアップが詰まるケースへの対応。強制削除モードを追加。

## 変更
### サーバー (\`src/lib/actions/dev-user-delete.ts\`)
- \`options.force\` フラグを追加
- force=true 時にスキップ:
  - APPLIED/SCHEDULED/WORKING/COMPLETED_PENDING 応募のブロック
  - 未応答オファー (target_worker_id + PUBLISHED/WORKING) のブロック
  - 期限内 LaborDocumentDownloadToken のブロック
- force でも残す critical check:
  - **未退勤 attendance**（データ整合性のためバイパス不可）
- LaborDocumentDownloadToken をトランザクション内で deleteMany（FK 無しなので手動削除）
- matched_count 減算対象に SCHEDULED も追加（既存 apply フローと整合）
- 監査ログ: 成功/失敗両方に force フラグ、action を分岐
  - 通常: DELETE_USER_TEST / DELETE_USER_TEST_FAILED
  - force: DELETE_USER_TEST_FORCE / DELETE_USER_TEST_FORCE_FAILED

### UI (\`app/system-admin/dev-portal/delete-worker/page.tsx\`)
- 「強制削除モード」チェックボックス（orange warning スタイル）
- チェック時、追加確認テキスト「強制削除」を入力させる（二重確認）
- ボタンラベルを「強制削除を実行」に動的切替
- counts 表示に laborDocTokensDeleted を追加

## Codex 指摘対応（2回の REQUEST CHANGES 後 APPROVE）
1. matched_count 減算対象から SCHEDULED が漏れていた → 追加
2. force で LaborDoc ブロックを外したが dangling トークンが残る → トランザクション内削除
3. 失敗時ログに force フラグが残らない → 記録

## 動作
1. 通常モード: 進行中業務あれば拒否
2. 強制モード: チェック + 「強制削除」入力 → APPLIED 等をバイパスして削除
3. 未退勤 attendance は強制モードでも拒否

🤖 Generated with [Claude Code](https://claude.com/claude-code)