### PR TITLE
UI改善: 登録ボタンの文言を短縮（改行崩れ解消）

### DIFF
--- a/app/register/worker/page.tsx
+++ b/app/register/worker/page.tsx
@@ -716,7 +716,7 @@ function WorkerRegisterPageInner() {
             {isSubmitting
               ? '送信中...'
               : currentStep === '8'
-              ? '利用規約・プライバシーポリシーに同意して登録'
+              ? '同意して登録する'
               : '次へ'}
           </button>
         </div>


### PR DESCRIPTION
## 概要
モバイルで step 8 の送信ボタンの文言が1文字だけ次行に流れる見た目を改善。

## 変更
- 旧: 「利用規約・プライバシーポリシーに同意して登録」（長い）
- 新: 「同意して登録する」（簡潔）

直前のチェックボックス2つで同意対象（利用規約・プライバシーポリシー）は既に明示されているため、情報量は損なわれない。

## レビュー
Codex Code Reviewer: APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)