### PR TITLE
バグ修正: pg_advisory_xact_lockをexecuteRawに変更して登録500エラーを解消

### DIFF
--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -199,7 +199,9 @@ export async function POST(request: NextRequest) {
     try {
       user = await prisma.$transaction(async (tx) => {
         // 電話番号に対する advisory lock（トランザクション終了まで保持、他セッションは待機）
-        await tx.$queryRaw(
+        // pg_advisory_xact_lock は void を返すため $executeRaw を使用（$queryRaw だと
+        // 「Failed to deserialize column of type 'void'」エラーになる）
+        await tx.$executeRaw(
           Prisma.sql`SELECT pg_advisory_xact_lock(${lockKey}::bigint)`
         );
 

--- a/src/lib/actions/dev-user-delete.ts
+++ b/src/lib/actions/dev-user-delete.ts
@@ -113,9 +113,11 @@ export async function deleteWorkerCompletely(
         //      FOR KEY SHARE を取得する。FOR UPDATE はこれと競合するため、
         //      トランザクション commit まで新規 FK 子行の作成をブロックできる
         const userLockKey = BigInt(user.id);
-        await tx.$queryRaw(
+        // pg_advisory_xact_lock は void を返すため $executeRaw を使用
+        await tx.$executeRaw(
           Prisma.sql`SELECT pg_advisory_xact_lock(${userLockKey}::bigint)`
         );
+        // SELECT FOR UPDATE は行を返すため $queryRaw でよい
         await tx.$queryRaw(
           Prisma.sql`SELECT id FROM users WHERE id = ${user.id} FOR UPDATE`
         );

--- a/src/lib/actions/user-profile.ts
+++ b/src/lib/actions/user-profile.ts
@@ -32,7 +32,8 @@ export async function savePhoneVerification(phoneNumber: string, verificationTok
         const lockKey = computePhoneLockKey(normalizedPhone);
         try {
             await prisma.$transaction(async (tx) => {
-                await tx.$queryRaw(
+                // pg_advisory_xact_lock は void を返すため $executeRaw を使用
+                await tx.$executeRaw(
                     Prisma.sql`SELECT pg_advisory_xact_lock(${lockKey}::bigint)`
                 );
                 const dup = await tx.$queryRaw<{ id: number }[]>(
@@ -621,7 +622,8 @@ export async function updateUserProfile(formData: FormData) {
             const lockKey = computePhoneLockKey(normalizedPhone);
             try {
                 await prisma.$transaction(async (tx) => {
-                    await tx.$queryRaw(
+                    // pg_advisory_xact_lock は void を返すため $executeRaw を使用
+                    await tx.$executeRaw(
                         Prisma.sql`SELECT pg_advisory_xact_lock(${lockKey}::bigint)`
                     );
                     // ロック取得後、直前再チェック（正規化比較）


### PR DESCRIPTION
## 概要
登録時に以下のエラーで失敗していた問題を修正：
\`\`\`
Invalid prisma.\$queryRaw() invocation:
Raw query failed. Message: Failed to deserialize column of type 'void'.
\`\`\`

## 原因
\`pg_advisory_xact_lock()\` は PostgreSQL の \`void\` 型を返すため、Prisma の \`\$queryRaw\` は結果行の型デシリアライズに失敗していた。

## 修正
\`\$queryRaw\` → \`\$executeRaw\` に変更（void を返すクエリには \$executeRaw が適切）。

修正箇所（4箇所）:
- \`app/api/auth/register/route.ts\`
- \`src/lib/actions/user-profile.ts\` (savePhoneVerification, updateUserProfile の2箇所)
- \`src/lib/actions/dev-user-delete.ts\`

注: \`SELECT ... FOR UPDATE\` は行を返すため \`\$queryRaw\` のまま維持（dev-user-delete.ts の 1 箇所）。

## レビュー
Codex Code Reviewer: APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)