### PR TITLE
バグ修正: 登録フローの405エラー/パスワードform未配置/エラー表示UX改善

### DIFF
--- a/app/api/sms/send-code/route.ts
+++ b/app/api/sms/send-code/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { Prisma } from '@prisma/client';
+import { getServerSession } from 'next-auth';
+import prisma from '@/lib/prisma';
+import { authOptions } from '@/lib/auth';
 import { sendVerificationCode } from '@/src/lib/cpaasnow';
 import { isValidPhoneNumber } from '@/utils/inputValidation';
+import { normalizePhoneDigits } from '@/src/lib/auth/identifier';
 
 // インメモリレート制限: 電話番号あたり10分間で最大3回
 const rateLimitMap = new Map<string, { count: number; windowStart: number }>();
@@ -40,6 +45,39 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         { error: '有効な日本の電話番号を入力してください' },
         { status: 400 }
+      );
+    }
+
+    // 既に登録済みの電話番号には SMS を送信しない
+    // （SMS 配信コストの無駄、UX 悪化防止）
+    // DB 側も正規化比較（ハイフン・全角数字混在のレガシーデータ対応）
+    // ログイン済みの場合は自分自身の既存レコードを除外（プロフィール編集での再認証に対応）
+    const session = await getServerSession(authOptions);
+    const selfUserId = session?.user?.id ? parseInt(session.user.id, 10) : null;
+    const normalizedPhone = normalizePhoneDigits(phoneNumber);
+    const existingUser = selfUserId
+      ? await prisma.$queryRaw<{ id: number }[]>(
+          Prisma.sql`SELECT id FROM users
+            WHERE regexp_replace(translate(phone_number, '０１２３４５６７８９', '0123456789'), '[^0-9]', '', 'g') = ${normalizedPhone}
+            AND phone_verified = true
+            AND deleted_at IS NULL
+            AND id <> ${selfUserId}
+            LIMIT 1`
+        )
+      : await prisma.$queryRaw<{ id: number }[]>(
+          Prisma.sql`SELECT id FROM users
+            WHERE regexp_replace(translate(phone_number, '０１２３４５６７８９', '0123456789'), '[^0-9]', '', 'g') = ${normalizedPhone}
+            AND phone_verified = true
+            AND deleted_at IS NULL
+            LIMIT 1`
+        );
+    if (existingUser.length > 0) {
+      return NextResponse.json(
+        {
+          error: 'この電話番号は既に登録されています。ログインページからログインしてください。',
+          errorCode: 'PHONE_ALREADY_REGISTERED',
+        },
+        { status: 409 }
       );
     }
 

--- a/app/register/worker/page.tsx
+++ b/app/register/worker/page.tsx
@@ -79,6 +79,7 @@ function WorkerRegisterPageInner() {
   const [showPrivacyModal, setShowPrivacyModal] = useState(false);
   const [phoneVerificationToken, setPhoneVerificationToken] = useState<string | null>(null);
   const [isLoadingAddress, setIsLoadingAddress] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   // 利用規約・PP
   const [termsContent, setTermsContent] = useState<string>('');
@@ -229,6 +230,7 @@ function WorkerRegisterPageInner() {
     const nextIdx = stepIndex + 1;
     if (nextIdx < stepSequence.length) {
       setCurrentStep(stepSequence[nextIdx]);
+      setSubmitError(null);
       window.scrollTo({ top: 0, behavior: 'smooth' });
     }
   };
@@ -237,6 +239,7 @@ function WorkerRegisterPageInner() {
     const prevIdx = stepIndex - 1;
     if (prevIdx >= 0) {
       setCurrentStep(stepSequence[prevIdx]);
+      setSubmitError(null);
       window.scrollTo({ top: 0, behavior: 'smooth' });
     }
   };
@@ -268,6 +271,7 @@ function WorkerRegisterPageInner() {
   const handleSubmit = async () => {
     if (isSubmitting) return;
     setIsSubmitting(true);
+    setSubmitError(null);
 
     try {
       // 資格: mock ラベル → DB 値にマッピング、「その他」自由記述は追記
@@ -320,6 +324,8 @@ function WorkerRegisterPageInner() {
           details: data?.debug?.stack,
           context: { status: res.status, debug: data?.debug },
         });
+        // インライン永続表示（toast はすぐ消えるため）
+        setSubmitError(detailMessage);
         toast.error(detailMessage);
         setIsSubmitting(false);
         return;
@@ -343,6 +349,7 @@ function WorkerRegisterPageInner() {
         details: info.details,
         stack: info.stack,
       });
+      setSubmitError('登録中にエラーが発生しました。ネットワーク接続を確認して再度お試しください。');
       toast.error('登録中にエラーが発生しました');
       setIsSubmitting(false);
     }
@@ -350,7 +357,13 @@ function WorkerRegisterPageInner() {
 
   return (
     <div className="min-h-screen bg-[#F8FCFE]">
-      <div className="max-w-md mx-auto bg-white min-h-screen relative">
+      <form
+        className="max-w-md mx-auto bg-white min-h-screen relative"
+        onSubmit={(e) => {
+          e.preventDefault();
+          goNext();
+        }}
+      >
         {/* ヘッダー */}
         <div className="bg-gradient-to-br from-[#E8F7FB] via-[#D4F1F9] to-[#E8F0FE] px-5 pt-6 pb-8 text-center">
           <div className="text-[#2AADCF] font-bold text-lg">タスタス</div>
@@ -611,6 +624,15 @@ function WorkerRegisterPageInner() {
 
           {currentStep === '8' && (
             <StepContainer question="ご連絡先・パスワード">
+              {submitError && (
+                <div
+                  role="alert"
+                  aria-live="polite"
+                  className="mb-4 p-3 rounded-lg bg-red-50 border border-red-200 text-red-700 text-sm"
+                >
+                  {submitError}
+                </div>
+              )}
               <div className="mb-4">
                 <FieldLabel required>電話番号（SMS認証が必要です）</FieldLabel>
                 <SmsVerification
@@ -736,7 +758,7 @@ function WorkerRegisterPageInner() {
             onClose={() => setShowPrivacyModal(false)}
           />
         )}
-      </div>
+      </form>
     </div>
   );
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -38,6 +38,7 @@ const publicPaths = [
   '/register',
   '/admin/login',
   '/api/auth',
+  '/api/registration-tracking', // 登録ページ訪問トラッキング（未ログイン、BasicAuth は保持）
   '/auth', // メール認証関連（/auth/verify, /auth/verify-pending, /auth/resend-verification）
   '/dev-portal', // 開発用ポータル
   '/password-reset', // パスワードリセット


### PR DESCRIPTION
## 概要
ステージングで「同意して登録」押下後に何も起きない問題の原因調査と修正。

## 4つの修正

### 1. `/api/registration-tracking` の 405 エラー解消
- 原因: middleware で保護されていたため、未ログインの POST が `/login?callbackUrl=...` に 307 → ブラウザが /login に POST リトライ → 405
- 修正: `publicPaths` に追加（BasicAuth 保持、JWT チェックのみスキップ）

### 2. パスワード入力欄の form 未配置
- 原因: 新登録ページで `<form>` タグなし（div + onClick）
- 修正: 最外側を `<form onSubmit={(e) => { e.preventDefault(); goNext(); }}>` に

### 3. 登録失敗時の永続エラー表示
- 原因: DEBUG_MODE ガード付き banner + 消える toast → 本番では何も見えない
- 修正: submitError state + インライン alert 表示（role=alert, aria-live）、ステップ移動時クリア、catch 時にもセット

### 4. SMS送信前の電話番号重複チェック
- 原因: 既登録電話番号でも SMS が飛び、認証も通る → 最終 submit で 409。SMS 配信コストの無駄 & UX 悪化
- 修正: `/api/sms/send-code` で登録済み phone を事前検知（DB 側で正規化比較）。ログイン済みなら自分を除外
- セキュリティ: 既存のレート制限（10分3回）で列挙攻撃は抑制

## Codex レビュー
2回のREQUEST CHANGES（BasicAuth 不整合、エラーのクリア漏れ）を解消後 APPROVE。

🤖 Generated with [Claude Code](https://claude.com/claude-code)