### PR TITLE
バグ修正: 応募時のメール未認証モーダルが出ない問題

### DIFF
--- a/components/job/JobDetailClient.tsx
+++ b/components/job/JobDetailClient.tsx
@@ -375,10 +375,23 @@ export function JobDetailClient({ job, facility, relatedJobs: _relatedJobs, faci
       return;
     }
 
-    // プロフィール完了チェック（応募前に必須、失敗時も応募を阻止）
+    // メール認証・プロフィール完了チェック（応募前に必須）
+    // 優先順位: error → email_verified → profile complete
     setIsApplying(true);
     try {
       const profileResult = await getMissingProfileFields();
+      // API エラー時は汎用エラー表示（誤モーダル回避）
+      if (profileResult?.hasError) {
+        toast.error('プロフィールの確認に失敗しました。もう一度お試しください。');
+        setIsApplying(false);
+        return;
+      }
+      // メール未認証ならメール認証モーダルを表示して停止
+      if (profileResult && !profileResult.emailVerified) {
+        setEmailNotVerifiedModal({ open: true, email: profileResult.email });
+        setIsApplying(false);
+        return;
+      }
       if (profileResult && !profileResult.isComplete) {
         setProfileMissingFields(profileResult.missingFields);
         setShowProfileModal(true);

--- a/components/profile/ProfileIncompleteBanner.tsx
+++ b/components/profile/ProfileIncompleteBanner.tsx
@@ -28,8 +28,14 @@ export function ProfileIncompleteBanner() {
     const fetchProfile = async () => {
       try {
         const result = await getMissingProfileFields();
-        setMissingFields(result.missingFields);
-        setMissingCount(result.missingCount);
+        // hasError 時は未完了扱いしない（バナー非表示）
+        if (result.hasError) {
+          setMissingFields([]);
+          setMissingCount(0);
+        } else {
+          setMissingFields(result.missingFields);
+          setMissingCount(result.missingCount);
+        }
       } catch (error) {
         console.error('[ProfileIncompleteBanner] Error:', error);
       } finally {

--- a/contexts/BadgeContext.tsx
+++ b/contexts/BadgeContext.tsx
@@ -35,7 +35,10 @@ export function BadgeProvider({ children }: { children: ReactNode }) {
           setUnreadMessages(data.unreadMessages ?? 0);
           setUnreadAnnouncements(data.unreadAnnouncements ?? 0);
         }
-        setProfileMissingCount(profileData.missingCount);
+        // hasError 時は未完了扱いしない（前回値維持）
+        if (!profileData.hasError) {
+          setProfileMissingCount(profileData.missingCount);
+        }
       } catch (error) {
         console.error('[BadgeContext] Failed to refresh badges:', error);
       }

--- a/src/lib/actions/user-profile.ts
+++ b/src/lib/actions/user-profile.ts
@@ -159,11 +159,18 @@ export async function checkProfileComplete(userId: number) {
 /**
  * 現在ログインしているワーカーの未入力プロフィール項目を取得する
  * BadgeContextやバナー表示用
+ * メール認証状態も併せて返す（応募前チェックで使用）
+ *
+ * エラー時は hasError=true を返す。呼び出し側は hasError を先に確認すべき
+ * （hasError 時の emailVerified/email/isComplete/missingFields はダミー値）
  */
 export async function getMissingProfileFields(): Promise<{
     isComplete: boolean;
     missingFields: string[];
     missingCount: number;
+    emailVerified: boolean;
+    email: string;
+    hasError: boolean;
 }> {
     try {
         const user = await getAuthenticatedUser();
@@ -172,11 +179,22 @@ export async function getMissingProfileFields(): Promise<{
             isComplete: result.isComplete,
             missingFields: result.missingFields,
             missingCount: result.missingFields.length,
+            emailVerified: user.email_verified,
+            email: user.email,
+            hasError: false,
         };
     } catch (error) {
-        // エラーの場合は安全側に倒す（未完了として扱う）
+        // エラーの場合は hasError=true を返し、呼び出し側でエラー処理させる
         console.error('[getMissingProfileFields] Error:', error);
-        return { isComplete: false, missingFields: ['プロフィール確認に失敗しました'], missingCount: 1 };
+        return {
+            isComplete: false,
+            missingFields: ['プロフィール確認に失敗しました'],
+            missingCount: 1,
+            // エラー時のダミー値（呼び出し側は hasError を先に見るべき）
+            emailVerified: true,
+            email: '',
+            hasError: true,
+        };
     }
 }
 


### PR DESCRIPTION
## 症状
メール未認証のワーカーが求人に応募しようとした際、「メール認証が必要です」モーダルが出ず、代わりに「プロフィールを完成させてください」モーダルが表示されていた。

## 原因
クライアント側の事前チェック \`getMissingProfileFields()\` が**プロフィール完了のみ**を見ていたため、プロフィール未完了が先に検知されモーダル表示→サーバー側の \`email_verified\` チェック（applyForJob 等）に到達しなかった。

## 修正
1. \`getMissingProfileFields\` の戻り値に **emailVerified / email / hasError** を追加
2. \`JobDetailClient\` の応募前チェックで判定順を **hasError → emailVerified → isComplete** に変更
3. 既存 caller (\`BadgeContext\`, \`ProfileIncompleteBanner\`) も \`hasError\` 考慮に更新（エラー時に誤って「プロフィール未完了」バッジ/バナーを出さない）

## Codex レビュー
- 1回目: REQUEST CHANGES（フォールバック時に emailVerified=false で誤モーダル）→ hasError フィールド追加で解消
- 2回目: REQUEST CHANGES（他 caller に hasError 反映漏れ）→ 3 caller 全対応で解消
- 3回目: APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)