### PR TITLE
機能追加: メール認証完了サンクスページ + 応募ページへの復帰フロー

### DIFF
--- a/app/api/auth/resend-verification/route.ts
+++ b/app/api/auth/resend-verification/route.ts
@@ -4,7 +4,7 @@ import { resendVerificationEmail } from '@/src/lib/auth/email-verification';
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const { email } = body;
+    const { email, returnUrl } = body;
 
     if (!email) {
       return NextResponse.json(
@@ -13,7 +13,9 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const result = await resendVerificationEmail(email);
+    // returnUrl: 認証完了後に戻す URL（相対パスのみ、サニタイズは sendVerificationEmail 内）
+    const safeReturnUrl = typeof returnUrl === 'string' ? returnUrl : null;
+    const result = await resendVerificationEmail(email, { returnUrl: safeReturnUrl });
 
     if (!result.success) {
       return NextResponse.json(

--- a/app/api/auth/verify/route.ts
+++ b/app/api/auth/verify/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { verifyEmailToken } from '@/src/lib/auth/email-verification';
+import { sanitizeReturnUrl } from '@/src/lib/auth/return-url';
 
 /**
  * メール認証エンドポイント（サーバーサイドリダイレクト方式）
@@ -22,11 +23,21 @@ function secureRedirect(url: URL): NextResponse {
 
 export async function GET(request: NextRequest) {
   const token = request.nextUrl.searchParams.get('token');
+  const returnUrlRaw = request.nextUrl.searchParams.get('returnUrl');
   const origin = request.nextUrl.origin;
+
+  // returnUrl の検証（相対パス + 長さ制限、オープンリダイレクト防止）
+  const safeReturnUrl = sanitizeReturnUrl(returnUrlRaw);
+  const returnUrlQuery = safeReturnUrl
+    ? `&returnUrl=${encodeURIComponent(safeReturnUrl)}`
+    : '';
 
   if (!token) {
     return secureRedirect(
-      new URL('/auth/verify?status=error&message=認証トークンが指定されていません', origin)
+      new URL(
+        `/auth/verify?status=error&message=認証トークンが指定されていません${returnUrlQuery}`,
+        origin
+      )
     );
   }
 
@@ -35,30 +46,38 @@ export async function GET(request: NextRequest) {
 
     if (!result.success) {
       // エラーの種類に応じてステータスを分ける
+      // returnUrl を引き継ぎ、再送フローでも戻り先を維持
       const status = result.error?.includes('期限') ? 'expired' : 'error';
       const message = encodeURIComponent(result.error || '認証に失敗しました');
       return secureRedirect(
-        new URL(`/auth/verify?status=${status}&message=${message}`, origin)
+        new URL(`/auth/verify?status=${status}&message=${message}${returnUrlQuery}`, origin)
       );
     }
 
     // 認証成功 → サーバーサイド自動ログインへリダイレクト
+    // リダイレクト先はメール認証完了サンクスページ（returnUrl を引き継ぐ）
     if (result.email && result.autoLoginToken) {
+      const emailVerifiedPath = safeReturnUrl
+        ? `/auth/email-verified?returnUrl=${encodeURIComponent(safeReturnUrl)}`
+        : '/auth/email-verified';
       const autoLoginUrl = new URL('/api/auth/auto-login', origin);
       autoLoginUrl.searchParams.set('token', result.autoLoginToken);
       autoLoginUrl.searchParams.set('email', result.email);
-      autoLoginUrl.searchParams.set('redirect', '/job-list');
+      autoLoginUrl.searchParams.set('redirect', emailVerifiedPath);
       return secureRedirect(autoLoginUrl);
     }
 
     // autoLoginTokenがない場合（通常起こらないが安全策）
     return secureRedirect(
-      new URL('/auth/verify?status=verified', origin)
+      new URL(`/auth/verify?status=verified${returnUrlQuery}`, origin)
     );
   } catch (error) {
     console.error('[Verify] Error:', error);
     return secureRedirect(
-      new URL('/auth/verify?status=error&message=システムエラーが発生しました', origin)
+      new URL(
+        `/auth/verify?status=error&message=システムエラーが発生しました${returnUrlQuery}`,
+        origin
+      )
     );
   }
 }

--- a/app/auth/email-verified/EmailVerifiedClient.tsx
+++ b/app/auth/email-verified/EmailVerifiedClient.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { trackGA4Event } from '@/src/lib/ga4-events';
+
+interface Props {
+  userName: string;
+  returnUrl: string | null;
+}
+
+export default function EmailVerifiedClient({ userName, returnUrl }: Props) {
+  useEffect(() => {
+    try {
+      trackGA4Event('email_verified_thanks_view', {
+        has_return_url: returnUrl ? 'true' : 'false',
+      });
+    } catch {
+      // noop
+    }
+  }, [returnUrl]);
+
+  return (
+    <div className="min-h-screen bg-[#F8FCFE]">
+      <div className="max-w-md mx-auto bg-white min-h-screen">
+        <div className="bg-gradient-to-br from-[#E8F7FB] via-[#D4F1F9] to-[#E8F0FE] px-5 pt-6 pb-8 text-center">
+          <div className="text-[#2AADCF] font-bold text-lg">タスタス</div>
+          <h1 className="text-xl font-bold text-gray-800 mt-1">メール認証完了</h1>
+        </div>
+
+        <div className="px-5 py-10 text-center">
+          <div className="mx-auto mb-5 w-20 h-20 rounded-full bg-gradient-to-br from-[#E8F7FB] to-[#D4F1F9] flex items-center justify-center text-3xl">
+            ✅
+          </div>
+          <h2 className="text-xl font-bold text-gray-800 mb-2">
+            メールアドレスの認証が完了しました
+          </h2>
+          <p className="text-sm text-gray-500 leading-relaxed mb-8">
+            {userName ? `${userName} さん、` : ''}
+            ご登録ありがとうございます。
+            <br />
+            求人へのご応募が可能になりました。
+          </p>
+
+          <div className="flex flex-col gap-3 max-w-xs mx-auto">
+            {returnUrl && (
+              <Link
+                href={returnUrl}
+                className="py-4 px-6 rounded-full bg-[#2AADCF] text-white text-base font-bold shadow-[0_6px_24px_rgba(42,173,207,0.3)]"
+                onClick={() => {
+                  try {
+                    trackGA4Event('email_verified_thanks_return_click', {});
+                  } catch {}
+                }}
+              >
+                応募ページへ戻る
+              </Link>
+            )}
+            <Link
+              href="/job-list"
+              className="py-3 px-6 rounded-full border border-gray-300 text-gray-700 text-sm font-medium bg-white"
+            >
+              求人一覧を見る
+            </Link>
+            <Link
+              href="/mypage"
+              className="py-3 px-6 rounded-full text-sm font-medium text-[#2AADCF] underline"
+            >
+              マイページへ移動
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/auth/email-verified/page.tsx
+++ b/app/auth/email-verified/page.tsx
@@ -1,0 +1,39 @@
+import { redirect } from 'next/navigation';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import prisma from '@/lib/prisma';
+import { sanitizeReturnUrl } from '@/src/lib/auth/return-url';
+import EmailVerifiedClient from './EmailVerifiedClient';
+
+export const dynamic = 'force-dynamic';
+
+interface Props {
+  searchParams: { returnUrl?: string };
+}
+
+export default async function EmailVerifiedPage({ searchParams }: Props) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    // 認証後は auto-login で Cookie 発行済みのはずだが、保険として /login に誘導
+    redirect('/login?verified=true');
+  }
+
+  // email_verified が実際に true になっているか DB で確認
+  // 未認証ユーザーが直打ちでこのページに到達できないようにする
+  const user = await prisma.user.findUnique({
+    where: { id: parseInt(session.user.id, 10) },
+    select: { email_verified: true },
+  });
+  if (!user?.email_verified) {
+    redirect('/auth/verify-pending');
+  }
+
+  const returnUrl = sanitizeReturnUrl(searchParams.returnUrl);
+
+  return (
+    <EmailVerifiedClient
+      userName={session.user.name ?? ''}
+      returnUrl={returnUrl}
+    />
+  );
+}

--- a/app/auth/resend-verification/page.tsx
+++ b/app/auth/resend-verification/page.tsx
@@ -8,6 +8,15 @@ import { Mail, CheckCircle, AlertCircle, ArrowLeft } from 'lucide-react';
 function ResendVerificationForm() {
   const searchParams = useSearchParams();
   const initialEmail = searchParams?.get('email') || '';
+  const returnUrlRaw = searchParams?.get('returnUrl') ?? null;
+  // クライアント側サニタイズ: 相対パス + 長さ制限
+  const returnUrl =
+    returnUrlRaw &&
+    returnUrlRaw.length <= 512 &&
+    returnUrlRaw.startsWith('/') &&
+    !returnUrlRaw.startsWith('//')
+      ? returnUrlRaw
+      : null;
 
   const [email, setEmail] = useState(initialEmail);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -30,7 +39,7 @@ function ResendVerificationForm() {
       const response = await fetch('/api/auth/resend-verification', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email }),
+        body: JSON.stringify({ email, returnUrl }),
       });
 
       const data = await response.json();

--- a/app/auth/verify/page.tsx
+++ b/app/auth/verify/page.tsx
@@ -19,6 +19,18 @@ export default function VerifyEmailPage() {
   const searchParams = useSearchParams();
   const status = searchParams?.get('status'); // 'verified' | 'error' | 'expired' | null
   const errorMessage = searchParams?.get('message');
+  const returnUrlRaw = searchParams?.get('returnUrl') ?? null;
+  // 相対パス + 長さ制限（クライアント側でも防御）
+  const returnUrl =
+    returnUrlRaw &&
+    returnUrlRaw.length <= 512 &&
+    returnUrlRaw.startsWith('/') &&
+    !returnUrlRaw.startsWith('//')
+      ? returnUrlRaw
+      : null;
+  const resendHref = returnUrl
+    ? `/auth/resend-verification?returnUrl=${encodeURIComponent(returnUrl)}`
+    : '/auth/resend-verification';
 
   // 認証成功だが自動ログイン失敗（手動ログインを促す）
   if (status === 'verified') {
@@ -59,7 +71,7 @@ export default function VerifyEmailPage() {
           </p>
           <div className="space-y-3">
             <Link
-              href="/auth/resend-verification"
+              href={resendHref}
               className="block w-full bg-blue-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-blue-700 transition"
             >
               認証メールを再送信
@@ -90,7 +102,7 @@ export default function VerifyEmailPage() {
           </p>
           <div className="space-y-3">
             <Link
-              href="/auth/resend-verification"
+              href={resendHref}
               className="block w-full bg-blue-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-blue-700 transition"
             >
               認証メールを再送信

--- a/components/auth/EmailVerificationRequiredModal.tsx
+++ b/components/auth/EmailVerificationRequiredModal.tsx
@@ -54,10 +54,16 @@ export function EmailVerificationRequiredModal({ open, email, onClose }: Props) 
     setIsSending(true);
     setErrorMessage(null);
     try {
+      // 現在のページを認証完了後の戻り先として送信
+      // （メールリンククリック後、このページに戻って応募を続けられる）
+      const returnUrl =
+        typeof window !== 'undefined'
+          ? window.location.pathname + window.location.search
+          : null;
       const res = await fetch('/api/auth/resend-verification', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email }),
+        body: JSON.stringify({ email, returnUrl }),
       });
       const data = await res.json();
       if (res.ok) {

--- a/src/lib/auth/email-verification.ts
+++ b/src/lib/auth/email-verification.ts
@@ -2,6 +2,7 @@ import { prisma } from '@/lib/prisma';
 import { Resend } from 'resend';
 import crypto from 'crypto';
 import { cacheResendQuotaHeader } from '@/src/lib/resend-quota';
+import { sanitizeReturnUrl } from '@/src/lib/auth/return-url';
 
 // Resend設定（遅延初期化 - APIキーがない場合はnull）
 let resend: Resend | null = null;
@@ -29,11 +30,14 @@ export function generateVerificationToken(): string {
 
 /**
  * ユーザーに認証トークンを設定し、認証メールを送信
+ * returnUrl: 認証完了後に戻す URL（相対パスのみ受理、応募中のページなど）
+ * サニタイズは `@/src/lib/auth/return-url` の sanitizeReturnUrl に委譲
  */
 export async function sendVerificationEmail(
   userId: number,
   email: string,
-  name: string
+  name: string,
+  options?: { returnUrl?: string | null }
 ): Promise<{ success: boolean; error?: string }> {
   try {
     // トークン生成
@@ -49,8 +53,11 @@ export async function sendVerificationEmail(
       },
     });
 
-    // 認証URL
-    const verificationUrl = `${APP_URL}/api/auth/verify?token=${token}`;
+    // 認証URL（returnUrl は相対パスのみ許可、query として付与）
+    const safeReturnUrl = sanitizeReturnUrl(options?.returnUrl);
+    const verificationUrl = safeReturnUrl
+      ? `${APP_URL}/api/auth/verify?token=${token}&returnUrl=${encodeURIComponent(safeReturnUrl)}`
+      : `${APP_URL}/api/auth/verify?token=${token}`;
 
     // メール送信が無効化されている場合はログのみ
     if (process.env.DISABLE_EMAIL_SENDING === 'true') {
@@ -153,7 +160,8 @@ export async function verifyEmailToken(
  * 認証メールを再送信
  */
 export async function resendVerificationEmail(
-  email: string
+  email: string,
+  options?: { returnUrl?: string | null }
 ): Promise<{ success: boolean; error?: string }> {
   try {
     // メールアドレスでユーザーを検索
@@ -192,7 +200,9 @@ export async function resendVerificationEmail(
     }
 
     // 再送信
-    return await sendVerificationEmail(user.id, user.email, user.name);
+    return await sendVerificationEmail(user.id, user.email, user.name, {
+      returnUrl: options?.returnUrl,
+    });
   } catch (error: any) {
     console.error('[Email Verification] Resend error:', error);
     return { success: false, error: error.message };

--- a/src/lib/auth/return-url.ts
+++ b/src/lib/auth/return-url.ts
@@ -1,0 +1,15 @@
+/**
+ * 認証メール等で使用する returnUrl の共通サニタイザ
+ *
+ * - 相対パス（"/" 始まり、"//" で始まらない）のみ許可
+ * - 最大長制限で URL 長制限や中継経路でのリンク破損を防止
+ * - null/undefined/不正値は null を返す
+ */
+const MAX_RETURN_URL_LENGTH = 512;
+
+export function sanitizeReturnUrl(raw: string | undefined | null): string | null {
+  if (!raw || typeof raw !== 'string') return null;
+  if (raw.length > MAX_RETURN_URL_LENGTH) return null;
+  if (!raw.startsWith('/') || raw.startsWith('//')) return null;
+  return raw;
+}


### PR DESCRIPTION
## 概要
応募モーダルからメール認証を開始したワーカーが、認証完了後に**元の求人ページに戻れる**ようにする。

## フロー
1. ワーカーが求人詳細で応募ボタン → 「メール認証が必要です」モーダル
2. 「認証メールを送信する」ボタン → 現在の URL を returnUrl として送信
3. メール内の認証リンク（returnUrl 付き）クリック
4. サーバー側で認証 → auto-login → **`/auth/email-verified?returnUrl=/jobs/123`**
5. 完了サンクスページに「応募ページへ戻る」ボタン表示
6. クリックで元の求人詳細ページへ

## 追加/変更
### 新規
- \`src/lib/auth/return-url.ts\` - 共通 sanitizeReturnUrl（相対パス + 512文字制限）
- \`app/auth/email-verified/page.tsx\` + \`EmailVerifiedClient.tsx\` - サンクスページ

### 変更
- \`sendVerificationEmail\` / \`resendVerificationEmail\` に options.returnUrl 追加
- \`/api/auth/verify\` の全分岐で returnUrl 引き継ぎ
- \`/api/auth/resend-verification\` で returnUrl 受付
- \`/auth/verify\` エラー画面 / \`/auth/resend-verification\` ページで returnUrl 維持
- \`EmailVerificationRequiredModal\` で \`window.location\` を returnUrl として送信

## セキュリティ
- 相対パスのみ許可（オープンリダイレクト防止）
- 最大長 512 文字（メール中継でのリンク破損防止）
- \`/auth/email-verified\` は **DB で email_verified=true を確認**（未認証者の直打ち防止）
- \`Referrer-Policy: no-referrer\` 維持

## Codex レビュー
3 回の REQUEST CHANGES を解消後 APPROVE
1. /auth/email-verified が session のみで email_verified=false でも表示できた → DB チェック追加
2. returnUrl の長さ制限なし → 512文字上限を共通化
3. verify エラー分岐で returnUrl が落ちていた → 全4分岐で引き継ぎ

🤖 Generated with [Claude Code](https://claude.com/claude-code)