### PR TITLE
UI改善: 登録完了サンクスページのボタン整理

### DIFF
--- a/app/register/worker/thanks/ThanksClient.tsx
+++ b/app/register/worker/thanks/ThanksClient.tsx
@@ -55,27 +55,20 @@ export default function ThanksClient({ userName, lineUrl }: Props) {
                   } catch {}
                 }}
               >
-                📲 LINEで相談する
+                📲 公式LINEに登録
               </a>
             ) : null}
 
             <Link
-              href="/job-list"
-              className="py-3 px-6 rounded-full text-sm font-medium text-gray-500 border border-gray-200 bg-white"
+              href="/"
+              className="py-3 px-6 rounded-full text-sm font-medium text-gray-700 border border-gray-200 bg-white"
               onClick={() => {
                 try {
                   trackGA4Event('worker_register_thanks_jobs_click', {});
                 } catch {}
               }}
             >
-              求人ページはこちら
-            </Link>
-
-            <Link
-              href="/mypage"
-              className="py-3 px-6 rounded-full text-sm font-medium text-[#2AADCF] underline"
-            >
-              マイページへ移動
+              お仕事一覧
             </Link>
           </div>
         </div>


### PR DESCRIPTION
## 変更
- LINE ボタンのラベル「LINEで相談する」→ **「公式LINEに登録」** に変更
- 下部のボタンを 2 個 (「求人ページはこちら」「マイページへ移動」) → 1 個 **「お仕事一覧」** に統合
- 「お仕事一覧」のリンク先: \`/\`（サイトトップ = ログイン後のホーム = 求人一覧ページ）

## 意図
CV 用ランディングページとして、主要 2 CTA（公式LINE登録 / 求人閲覧）に絞ってシンプルに。

## レビュー
Codex Code Reviewer: APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)