### PR TITLE
バグ修正: サンクスページのLINE URLをLP設定（DB）から取得

### DIFF
--- a/app/register/worker/thanks/page.tsx
+++ b/app/register/worker/thanks/page.tsx
@@ -1,18 +1,44 @@
 import { redirect } from 'next/navigation';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
+import prisma from '@/lib/prisma';
 import ThanksClient from './ThanksClient';
 
 export const dynamic = 'force-dynamic';
 
+/**
+ * 登録 LP の cta_url を取得。ユーザーの registration_lp_id から
+ * LandingPage.cta_url を引く（環境変数に依存しない）
+ */
+async function resolveLineUrlForUser(userId: number): Promise<string> {
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { registration_lp_id: true },
+    });
+    if (!user?.registration_lp_id) return '';
+    const lpNum = parseInt(user.registration_lp_id, 10);
+    if (isNaN(lpNum)) return '';
+    const lp = await prisma.landingPage.findUnique({
+      where: { lp_number: lpNum },
+      select: { cta_url: true },
+    });
+    return lp?.cta_url ?? '';
+  } catch (e) {
+    console.error('[thanks] Failed to resolve LINE URL:', e);
+    return '';
+  }
+}
+
 export default async function RegisterThanksPage() {
   const session = await getServerSession(authOptions);
-  if (!session?.user) {
+  if (!session?.user?.id) {
     // 登録完了を経ずに直接アクセスされた場合のフォールバック
     redirect('/login');
   }
 
-  const lineUrl = process.env.NEXT_PUBLIC_REGISTER_LINE_URL || '';
+  const userId = parseInt(session.user.id, 10);
+  const lineUrl = await resolveLineUrlForUser(userId);
 
   return <ThanksClient userName={session.user.name ?? ''} lineUrl={lineUrl} />;
 }


### PR DESCRIPTION
## 症状
登録完了サンクスページに「公式LINEに登録」ボタンが表示されない。

## 原因
環境変数 \`NEXT_PUBLIC_REGISTER_LINE_URL\` が Vercel に未設定 → 空文字 → ボタン非表示。

## 修正
環境変数ではなく、既存の **LP 設定（LandingPage.cta_url）** から取得するよう変更。

- ユーザーの \`registration_lp_id\` から LP 番号を取得
- \`LandingPage.cta_url\` を引いて LINE ボタン URL に使用
- 未設定/エラー時は空文字（ボタン非表示）

## 利点
- Vercel 環境変数設定不要
- LP ごとに異なる LINE URL を設定可能（既存の \`/api/public/lp-line-url\` と同じデータソース）
- 既存の LP 管理画面から URL 更新可能

## レビュー
Codex Code Reviewer: APPROVE

🤖 Generated with [Claude Code](https://claude.com/claude-code)