### PR TITLE
デバッグ: TasLink 401時にAPIキーフィンガープリントをログ出力

### DIFF
--- a/src/lib/taslink.ts
+++ b/src/lib/taslink.ts
@@ -270,7 +270,24 @@ export async function syncWorkerToTasLink(
     }
 
     if (response.status === 401) {
-      console.error('[TasLink] Authentication failed: invalid API key');
+      // 診断情報: キー値の不可視文字/貼り間違いを特定するためのフィンガープリント
+      // 機密漏洩を避けるため先頭4/末尾4文字のみ出力。完全な値はログに残さない
+      const keyStr = API_KEY || '';
+      const hasWhitespace = /\s/.test(keyStr);
+      const hasQuotes = /["'`]/.test(keyStr);
+      const hasJsonChars = /[{}:]/.test(keyStr);
+      console.error('[TasLink] Authentication failed: invalid API key', {
+        userId,
+        apiUrl: API_URL,
+        keyPrefix: keyStr.slice(0, 4),
+        keySuffix: keyStr.slice(-4),
+        keyLength: keyStr.length,
+        suspicious: {
+          hasWhitespace,
+          hasQuotes,
+          hasJsonChars,
+        },
+      });
       return { success: false, error: 'Authentication failed (401)' };
     }
 


### PR DESCRIPTION
## Summary

TasLink連携で401（authentication failed）が継続発生している原因を特定するための診断ログを追加。

## 変更内容

\`src/lib/taslink.ts\` の401ハンドラに以下の情報をログ出力：
- \`keyPrefix\` / \`keySuffix\`（APIキーの先頭4・末尾4文字）
- \`keyLength\`（文字数）
- \`apiUrl\`（送信先URL）
- \`suspicious\` フラグ（空白・クォート・JSON記号の混入検出）
- \`userId\`（どのユーザーの同期で失敗したか）

完全なキー値はログに残さない（機密保護）。

## 背景

- tastas → TasLink 連携で全ユーザーの同期が401で失敗している状態が継続
- ヘッダ名（\`x-api-key\`）とURLは正しいとTasLink側から確認済み
- つまり **値そのものが不一致** で確定
- 原因候補: 空白/改行の混入、JSON形式でセットしてしまった、キーの環境違い（dev/prod）等

このPRで401発生時の詳細情報を取得し、TasLink側の期待値と突合することで確実に原因特定する。

## 使い方

1. このPRをdevelopにマージ → stgへ自動デプロイ
2. stgでプロフィール更新して発火
3. Vercel Logs で \`[TasLink] Authentication failed\` を検索
4. 出力された \`keyPrefix\` / \`keySuffix\` / \`keyLength\` を TasLink 管理者に共有
5. TasLink側の期待値と突合 → 原因特定

## 一時的な変更

診断が完了したら、401ログは元のシンプルな形式に戻すべき。一時的な診断用コード。

## Test plan

- [ ] stgへマージ後、既存ユーザーでプロフィール更新
- [ ] Vercel Logs で拡張ログが出ることを確認
- [ ] キー情報の突合でTasLink側と原因特定
- [ ] 原因判明後、ログを元の形式に戻すPRを別途作成

🤖 Generated with [Claude Code](https://claude.com/claude-code)