### PR TITLE
develop → main: 新登録フロー・削除機能・多数バグ修正

### DIFF
--- a/app/api/auth/auto-login/route.ts
+++ b/app/api/auth/auto-login/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { encode } from 'next-auth/jwt';
 import prisma from '@/lib/prisma';
 import { logActivity } from '@/lib/logger';
+import { issueSessionCookie } from '@/src/lib/auth/session-cookie';
 
 /**
  * サーバーサイド自動ログインエンドポイント
@@ -67,18 +67,6 @@ export async function GET(request: NextRequest) {
       },
     });
 
-    // NextAuth JWT トークンを生成
-    const jwtToken = await encode({
-      token: {
-        id: String(user.id),
-        email: user.email,
-        name: user.name,
-        sub: String(user.id),
-      },
-      secret: process.env.NEXTAUTH_SECRET!,
-      maxAge: 30 * 24 * 60 * 60, // 30日（lib/auth.tsのsession.maxAgeと同じ）
-    });
-
     // リダイレクト先のバリデーション（オープンリダイレクト防止）
     const isRelativeUrl = redirect.startsWith('/') && !redirect.startsWith('//');
     const safeRedirect = isRelativeUrl ? redirect : '/';
@@ -87,23 +75,11 @@ export async function GET(request: NextRequest) {
       new URL(safeRedirect, request.nextUrl.origin)
     );
 
-    // NextAuth セッションCookieを設定
-    const isProduction = process.env.NODE_ENV === 'production';
-    const cookieName = isProduction
-      ? '__Secure-next-auth.session-token'
-      : 'next-auth.session-token';
-
-    response.cookies.set(cookieName, jwtToken, {
-      httpOnly: true,
-      secure: isProduction,
-      sameSite: 'lax',
-      path: '/',
-      maxAge: 30 * 24 * 60 * 60, // 30日
+    await issueSessionCookie(response, {
+      id: user.id,
+      email: user.email,
+      name: user.name,
     });
-
-    // セキュリティヘッダー（トークン漏洩防止）
-    response.headers.set('Cache-Control', 'no-store');
-    response.headers.set('Referrer-Policy', 'no-referrer');
 
     console.log('[AutoLogin] Success for user:', user.id);
 

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -199,7 +199,9 @@ export async function POST(request: NextRequest) {
     try {
       user = await prisma.$transaction(async (tx) => {
         // 電話番号に対する advisory lock（トランザクション終了まで保持、他セッションは待機）
-        await tx.$queryRaw(
+        // pg_advisory_xact_lock は void を返すため $executeRaw を使用（$queryRaw だと
+        // 「Failed to deserialize column of type 'void'」エラーになる）
+        await tx.$executeRaw(
           Prisma.sql`SELECT pg_advisory_xact_lock(${lockKey}::bigint)`
         );
 

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -8,6 +8,7 @@ import { logActivity, getErrorMessage, getErrorStack } from '@/lib/logger';
 import { findLpByIpAddress } from '@/src/lib/lp-attribution';
 import { getClientIpAddress } from '@/src/lib/device-info';
 import { validatePhoneVerificationToken } from '@/src/lib/auth/phone-verification';
+import { syncWorkerToTasLink, mapUserToTasLinkPayload } from '@/src/lib/taslink';
 
 interface RegisterBody {
   email: string;
@@ -215,6 +216,16 @@ export async function POST(request: NextRequest) {
       );
     } catch (notifyErr) {
       console.error('Failed to notify admin:', getErrorMessage(notifyErr));
+    }
+
+    // TasLinkへワーカー情報を同期（同期完了を待つが、失敗しても登録は成功させる）
+    try {
+      const tasLinkPayload = mapUserToTasLinkPayload(user);
+      if (tasLinkPayload) {
+        await syncWorkerToTasLink(user.id, tasLinkPayload);
+      }
+    } catch (tasLinkErr) {
+      console.error('[TasLink] Registration sync failed:', getErrorMessage(tasLinkErr));
     }
 
     return NextResponse.json({

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -355,16 +355,21 @@ export async function POST(request: NextRequest) {
       url: '/api/auth/register',
     }).catch(logErr => console.error('Failed to log activity:', logErr));
 
-    // デバッグ用：エラー詳細を返す（本番運用開始後は削除）
+    // 本番環境では詳細情報を秘匿（開発・EXPOSE_DEBUG_ERRORS=true の場合のみ公開）
+    const exposeDebug =
+      process.env.NODE_ENV !== 'production' ||
+      process.env.EXPOSE_DEBUG_ERRORS === 'true';
     const errorMessage = error instanceof Error ? error.message : String(error);
     const errorStack = error instanceof Error ? error.stack : undefined;
     return NextResponse.json(
       {
         error: '登録中にエラーが発生しました',
-        debug: {
-          message: errorMessage,
-          stack: errorStack?.split('\n').slice(0, 5).join('\n'),
-        }
+        ...(exposeDebug ? {
+          debug: {
+            message: errorMessage,
+            stack: errorStack?.split('\n').slice(0, 5).join('\n'),
+          },
+        } : {}),
       },
       { status: 500 }
     );

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -9,6 +9,8 @@ import { findLpByIpAddress } from '@/src/lib/lp-attribution';
 import { getClientIpAddress } from '@/src/lib/device-info';
 import { validatePhoneVerificationToken } from '@/src/lib/auth/phone-verification';
 import { syncWorkerToTasLink, mapUserToTasLinkPayload } from '@/src/lib/taslink';
+import { issueSessionCookie } from '@/src/lib/auth/session-cookie';
+import { normalizePhoneDigits, phoneLockKey } from '@/src/lib/auth/identifier';
 
 interface RegisterBody {
   email: string;
@@ -31,6 +33,11 @@ interface RegisterBody {
   experienceFields?: Record<string, unknown>;
   workHistories?: string[];
   qualificationCertificates?: Record<string, unknown>;
+  // 新登録フロー（モック8ステップ）項目
+  desiredWorkStyle?: string[];     // 希望の働き方（複数選択）
+  workFrequency?: string;           // 週の頻度（step 2b）
+  jobTiming?: string;               // いつ頃探しているか
+  employmentStatus?: string;        // 現在の就業状況
   // LP経由登録情報
   registrationLpId?: string;
   registrationCampaignCode?: string;
@@ -39,6 +46,10 @@ interface RegisterBody {
   lpAttributionSource?: string;
   // 電話番号SMS認証トークン
   phoneVerificationToken?: string;
+}
+
+function normalizeEmail(input: string): string {
+  return input.trim().toLowerCase();
 }
 
 export async function POST(request: NextRequest) {
@@ -66,6 +77,10 @@ export async function POST(request: NextRequest) {
       experienceFields,
       workHistories,
       qualificationCertificates,
+      desiredWorkStyle,
+      workFrequency,
+      jobTiming,
+      employmentStatus,
       registrationLpId,
       registrationCampaignCode,
       registrationGenrePrefix,
@@ -110,6 +125,32 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // パスワード: 最低 8 文字
+    if (typeof password !== 'string' || password.length < 8) {
+      return NextResponse.json(
+        { error: 'パスワードは8文字以上で入力してください' },
+        { status: 400 }
+      );
+    }
+
+    // メール形式チェック
+    const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (typeof email !== 'string' || !EMAIL_RE.test(email.trim())) {
+      return NextResponse.json(
+        { error: 'メールアドレスの形式が正しくありません' },
+        { status: 400 }
+      );
+    }
+
+    const normalizedEmail = normalizeEmail(email);
+    const normalizedPhone = normalizePhoneDigits(phoneNumber);
+    if (normalizedPhone.length < 10 || normalizedPhone.length > 11) {
+      return NextResponse.json(
+        { error: '電話番号の形式が正しくありません' },
+        { status: 400 }
+      );
+    }
+
     // 電話番号SMS認証トークンの検証
     if (!phoneVerificationToken) {
       return NextResponse.json(
@@ -118,7 +159,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const isPhoneVerified = await validatePhoneVerificationToken(phoneVerificationToken, phoneNumber);
+    const isPhoneVerified = await validatePhoneVerificationToken(phoneVerificationToken, normalizedPhone);
     if (!isPhoneVerified) {
       return NextResponse.json(
         { error: '電話番号の認証トークンが無効または期限切れです。再度認証を行ってください。' },
@@ -126,15 +167,14 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // メールアドレスの重複チェック
-    const existingUser = await prisma.user.findUnique({
-      where: { email },
+    // メールアドレスの重複チェック（case-insensitive、既存レガシーデータ対応）
+    const existingEmailUser = await prisma.user.findFirst({
+      where: { email: { equals: normalizedEmail, mode: 'insensitive' } },
     });
-
-    if (existingUser) {
+    if (existingEmailUser) {
       return NextResponse.json(
         { error: 'このメールアドレスは既に登録されています' },
-        { status: 400 }
+        { status: 409 }
       );
     }
 
@@ -146,35 +186,89 @@ export async function POST(request: NextRequest) {
       ? workHistories.filter((h: string) => h && h.trim() !== '')
       : [];
 
-    // ユーザー作成（name は空文字許容）
-    const user = await prisma.user.create({
-      data: {
-        email,
-        password_hash: hashedPassword,
-        name: resolvedName,
-        phone_number: phoneNumber,
-        phone_verified: true,
-        phone_verified_at: new Date(),
-        birth_date: birthDate ? new Date(birthDate + 'T00:00:00+09:00') : null,
-        qualifications: qualifications || [],
-        last_name_kana: lastNameKana || null,
-        first_name_kana: firstNameKana || null,
-        gender: gender || null,
-        nationality: nationality || null,
-        postal_code: postalCode || null,
-        prefecture: prefecture || null,
-        city: city || null,
-        address_line: addressLine || null,
-        building: building || null,
-        experience_fields: experienceFields && Object.keys(experienceFields).length > 0 ? experienceFields as Prisma.InputJsonValue : Prisma.DbNull,
-        work_histories: workHistoriesArray,
-        qualification_certificates: qualificationCertificates && Object.keys(qualificationCertificates).length > 0 ? qualificationCertificates as Prisma.InputJsonValue : Prisma.DbNull,
-        // LP経由登録情報（フォールバックチェーン適用済み）
-        registration_lp_id: resolvedLpId,
-        registration_campaign_code: resolvedCampaignCode,
-        registration_genre_prefix: resolvedGenrePrefix,
-      },
-    });
+    // 希望の働き方（複数選択）は CSV で保存（既存 String? カラム踏襲）
+    const desiredWorkStyleCsv = Array.isArray(desiredWorkStyle) && desiredWorkStyle.length > 0
+      ? desiredWorkStyle.filter(s => s && s.trim() !== '').join(',')
+      : null;
+
+    // 電話番号の race 軽減: Postgres advisory xact lock で同一電話番号の同時登録を直列化
+    const lockKey = phoneLockKey(normalizedPhone);
+
+    // ユーザー作成（name は空文字許容）。P2002 (email unique 衝突) で email race を検出
+    let user;
+    try {
+      user = await prisma.$transaction(async (tx) => {
+        // 電話番号に対する advisory lock（トランザクション終了まで保持、他セッションは待機）
+        await tx.$queryRaw(
+          Prisma.sql`SELECT pg_advisory_xact_lock(${lockKey}::bigint)`
+        );
+
+        // ロック取得後の再チェック（race safe）
+        // 既存データにハイフンや全角数字が残っている可能性に備え、SQL 側で正規化比較
+        // translate で全角数字 → 半角数字、regexp_replace で非数字除去
+        const phoneExists = await tx.$queryRaw<{ id: number }[]>(
+          Prisma.sql`SELECT id FROM users
+            WHERE regexp_replace(translate(phone_number, '０１２３４５６７８９', '0123456789'), '[^0-9]', '', 'g') = ${normalizedPhone}
+            AND phone_verified = true
+            AND deleted_at IS NULL
+            LIMIT 1`
+        );
+        if (phoneExists.length > 0) {
+          throw new Error('PHONE_ALREADY_REGISTERED');
+        }
+
+        return tx.user.create({
+          data: {
+            email: normalizedEmail,
+            password_hash: hashedPassword,
+            name: resolvedName,
+            phone_number: normalizedPhone,
+            phone_verified: true,
+            phone_verified_at: new Date(),
+            birth_date: birthDate ? new Date(birthDate + 'T00:00:00+09:00') : null,
+            qualifications: qualifications || [],
+            last_name_kana: lastNameKana || null,
+            first_name_kana: firstNameKana || null,
+            gender: gender || null,
+            nationality: nationality || null,
+            postal_code: postalCode || null,
+            prefecture: prefecture || null,
+            city: city || null,
+            address_line: addressLine || null,
+            building: building || null,
+            experience_fields: experienceFields && Object.keys(experienceFields).length > 0 ? experienceFields as Prisma.InputJsonValue : Prisma.DbNull,
+            work_histories: workHistoriesArray,
+            qualification_certificates: qualificationCertificates && Object.keys(qualificationCertificates).length > 0 ? qualificationCertificates as Prisma.InputJsonValue : Prisma.DbNull,
+            // 新登録フロー項目（既存カラムに対応）
+            desired_work_style: desiredWorkStyleCsv,
+            desired_work_days_week: workFrequency || null,
+            job_change_desire: jobTiming || null,
+            current_work_style: employmentStatus || null,
+            // LP経由登録情報（フォールバックチェーン適用済み）
+            registration_lp_id: resolvedLpId,
+            registration_campaign_code: resolvedCampaignCode,
+            registration_genre_prefix: resolvedGenrePrefix,
+          },
+        });
+      });
+    } catch (e) {
+      if (e instanceof Error && e.message === 'PHONE_ALREADY_REGISTERED') {
+        return NextResponse.json(
+          { error: 'この電話番号は既に登録されています' },
+          { status: 409 }
+        );
+      }
+      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
+        const target = (e.meta?.target as string[] | undefined)?.join(',') || '';
+        if (target.includes('email')) {
+          return NextResponse.json(
+            { error: 'このメールアドレスは既に登録されています' },
+            { status: 409 }
+          );
+        }
+      }
+      throw e;
+    }
 
     // 操作ログを記録（ユーザー登録成功）
     await logActivity({
@@ -228,16 +322,23 @@ export async function POST(request: NextRequest) {
       console.error('[TasLink] Registration sync failed:', getErrorMessage(tasLinkErr));
     }
 
-    return NextResponse.json({
-      message: '登録が完了しました。確認メールをお送りしましたので、メール内のリンクをクリックして認証を完了してください。',
+    // 登録完了と同時に NextAuth セッション Cookie を発行（サンクスページ到達時点でログイン済みに）
+    const response = NextResponse.json({
+      message: '登録が完了しました。',
       user: {
         id: user.id,
         email: user.email,
         name: user.name,
       },
-      requiresVerification: true,
+      redirect: '/register/worker/thanks',
       emailSent: !emailError,
     });
+    await issueSessionCookie(response, {
+      id: user.id,
+      email: user.email,
+      name: user.name,
+    });
+    return response;
   } catch (error) {
     console.error('Registration error:', error);
 

--- a/app/api/auth/resend-verification/route.ts
+++ b/app/api/auth/resend-verification/route.ts
@@ -4,7 +4,7 @@ import { resendVerificationEmail } from '@/src/lib/auth/email-verification';
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const { email } = body;
+    const { email, returnUrl } = body;
 
     if (!email) {
       return NextResponse.json(
@@ -13,7 +13,9 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const result = await resendVerificationEmail(email);
+    // returnUrl: 認証完了後に戻す URL（相対パスのみ、サニタイズは sendVerificationEmail 内）
+    const safeReturnUrl = typeof returnUrl === 'string' ? returnUrl : null;
+    const result = await resendVerificationEmail(email, { returnUrl: safeReturnUrl });
 
     if (!result.success) {
       return NextResponse.json(

--- a/app/api/auth/verify/route.ts
+++ b/app/api/auth/verify/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { verifyEmailToken } from '@/src/lib/auth/email-verification';
+import { sanitizeReturnUrl } from '@/src/lib/auth/return-url';
 
 /**
  * メール認証エンドポイント（サーバーサイドリダイレクト方式）
@@ -22,11 +23,21 @@ function secureRedirect(url: URL): NextResponse {
 
 export async function GET(request: NextRequest) {
   const token = request.nextUrl.searchParams.get('token');
+  const returnUrlRaw = request.nextUrl.searchParams.get('returnUrl');
   const origin = request.nextUrl.origin;
+
+  // returnUrl の検証（相対パス + 長さ制限、オープンリダイレクト防止）
+  const safeReturnUrl = sanitizeReturnUrl(returnUrlRaw);
+  const returnUrlQuery = safeReturnUrl
+    ? `&returnUrl=${encodeURIComponent(safeReturnUrl)}`
+    : '';
 
   if (!token) {
     return secureRedirect(
-      new URL('/auth/verify?status=error&message=認証トークンが指定されていません', origin)
+      new URL(
+        `/auth/verify?status=error&message=認証トークンが指定されていません${returnUrlQuery}`,
+        origin
+      )
     );
   }
 
@@ -35,30 +46,38 @@ export async function GET(request: NextRequest) {
 
     if (!result.success) {
       // エラーの種類に応じてステータスを分ける
+      // returnUrl を引き継ぎ、再送フローでも戻り先を維持
       const status = result.error?.includes('期限') ? 'expired' : 'error';
       const message = encodeURIComponent(result.error || '認証に失敗しました');
       return secureRedirect(
-        new URL(`/auth/verify?status=${status}&message=${message}`, origin)
+        new URL(`/auth/verify?status=${status}&message=${message}${returnUrlQuery}`, origin)
       );
     }
 
     // 認証成功 → サーバーサイド自動ログインへリダイレクト
+    // リダイレクト先はメール認証完了サンクスページ（returnUrl を引き継ぐ）
     if (result.email && result.autoLoginToken) {
+      const emailVerifiedPath = safeReturnUrl
+        ? `/auth/email-verified?returnUrl=${encodeURIComponent(safeReturnUrl)}`
+        : '/auth/email-verified';
       const autoLoginUrl = new URL('/api/auth/auto-login', origin);
       autoLoginUrl.searchParams.set('token', result.autoLoginToken);
       autoLoginUrl.searchParams.set('email', result.email);
-      autoLoginUrl.searchParams.set('redirect', '/job-list');
+      autoLoginUrl.searchParams.set('redirect', emailVerifiedPath);
       return secureRedirect(autoLoginUrl);
     }
 
     // autoLoginTokenがない場合（通常起こらないが安全策）
     return secureRedirect(
-      new URL('/auth/verify?status=verified', origin)
+      new URL(`/auth/verify?status=verified${returnUrlQuery}`, origin)
     );
   } catch (error) {
     console.error('[Verify] Error:', error);
     return secureRedirect(
-      new URL('/auth/verify?status=error&message=システムエラーが発生しました', origin)
+      new URL(
+        `/auth/verify?status=error&message=システムエラーが発生しました${returnUrlQuery}`,
+        origin
+      )
     );
   }
 }

--- a/app/api/sms/send-code/route.ts
+++ b/app/api/sms/send-code/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { Prisma } from '@prisma/client';
+import { getServerSession } from 'next-auth';
+import prisma from '@/lib/prisma';
+import { authOptions } from '@/lib/auth';
 import { sendVerificationCode } from '@/src/lib/cpaasnow';
 import { isValidPhoneNumber } from '@/utils/inputValidation';
+import { normalizePhoneDigits } from '@/src/lib/auth/identifier';
 
 // インメモリレート制限: 電話番号あたり10分間で最大3回
 const rateLimitMap = new Map<string, { count: number; windowStart: number }>();
@@ -40,6 +45,39 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         { error: '有効な日本の電話番号を入力してください' },
         { status: 400 }
+      );
+    }
+
+    // 既に登録済みの電話番号には SMS を送信しない
+    // （SMS 配信コストの無駄、UX 悪化防止）
+    // DB 側も正規化比較（ハイフン・全角数字混在のレガシーデータ対応）
+    // ログイン済みの場合は自分自身の既存レコードを除外（プロフィール編集での再認証に対応）
+    const session = await getServerSession(authOptions);
+    const selfUserId = session?.user?.id ? parseInt(session.user.id, 10) : null;
+    const normalizedPhone = normalizePhoneDigits(phoneNumber);
+    const existingUser = selfUserId
+      ? await prisma.$queryRaw<{ id: number }[]>(
+          Prisma.sql`SELECT id FROM users
+            WHERE regexp_replace(translate(phone_number, '０１２３４５６７８９', '0123456789'), '[^0-9]', '', 'g') = ${normalizedPhone}
+            AND phone_verified = true
+            AND deleted_at IS NULL
+            AND id <> ${selfUserId}
+            LIMIT 1`
+        )
+      : await prisma.$queryRaw<{ id: number }[]>(
+          Prisma.sql`SELECT id FROM users
+            WHERE regexp_replace(translate(phone_number, '０１２３４５６７８９', '0123456789'), '[^0-9]', '', 'g') = ${normalizedPhone}
+            AND phone_verified = true
+            AND deleted_at IS NULL
+            LIMIT 1`
+        );
+    if (existingUser.length > 0) {
+      return NextResponse.json(
+        {
+          error: 'この電話番号は既に登録されています。ログインページからログインしてください。',
+          errorCode: 'PHONE_ALREADY_REGISTERED',
+        },
+        { status: 409 }
       );
     }
 

--- a/app/auth/email-verified/EmailVerifiedClient.tsx
+++ b/app/auth/email-verified/EmailVerifiedClient.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { trackGA4Event } from '@/src/lib/ga4-events';
+
+interface Props {
+  userName: string;
+  returnUrl: string | null;
+}
+
+export default function EmailVerifiedClient({ userName, returnUrl }: Props) {
+  useEffect(() => {
+    try {
+      trackGA4Event('email_verified_thanks_view', {
+        has_return_url: returnUrl ? 'true' : 'false',
+      });
+    } catch {
+      // noop
+    }
+  }, [returnUrl]);
+
+  return (
+    <div className="min-h-screen bg-[#F8FCFE]">
+      <div className="max-w-md mx-auto bg-white min-h-screen">
+        <div className="bg-gradient-to-br from-[#E8F7FB] via-[#D4F1F9] to-[#E8F0FE] px-5 pt-6 pb-8 text-center">
+          <div className="text-[#2AADCF] font-bold text-lg">タスタス</div>
+          <h1 className="text-xl font-bold text-gray-800 mt-1">メール認証完了</h1>
+        </div>
+
+        <div className="px-5 py-10 text-center">
+          <div className="mx-auto mb-5 w-20 h-20 rounded-full bg-gradient-to-br from-[#E8F7FB] to-[#D4F1F9] flex items-center justify-center text-3xl">
+            ✅
+          </div>
+          <h2 className="text-xl font-bold text-gray-800 mb-2">
+            メールアドレスの認証が完了しました
+          </h2>
+          <p className="text-sm text-gray-500 leading-relaxed mb-8">
+            {userName ? `${userName} さん、` : ''}
+            ご登録ありがとうございます。
+            <br />
+            求人へのご応募が可能になりました。
+          </p>
+
+          <div className="flex flex-col gap-3 max-w-xs mx-auto">
+            {returnUrl && (
+              <Link
+                href={returnUrl}
+                className="py-4 px-6 rounded-full bg-[#2AADCF] text-white text-base font-bold shadow-[0_6px_24px_rgba(42,173,207,0.3)]"
+                onClick={() => {
+                  try {
+                    trackGA4Event('email_verified_thanks_return_click', {});
+                  } catch {}
+                }}
+              >
+                応募ページへ戻る
+              </Link>
+            )}
+            <Link
+              href="/job-list"
+              className="py-3 px-6 rounded-full border border-gray-300 text-gray-700 text-sm font-medium bg-white"
+            >
+              求人一覧を見る
+            </Link>
+            <Link
+              href="/mypage"
+              className="py-3 px-6 rounded-full text-sm font-medium text-[#2AADCF] underline"
+            >
+              マイページへ移動
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/auth/email-verified/page.tsx
+++ b/app/auth/email-verified/page.tsx
@@ -1,0 +1,39 @@
+import { redirect } from 'next/navigation';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import prisma from '@/lib/prisma';
+import { sanitizeReturnUrl } from '@/src/lib/auth/return-url';
+import EmailVerifiedClient from './EmailVerifiedClient';
+
+export const dynamic = 'force-dynamic';
+
+interface Props {
+  searchParams: { returnUrl?: string };
+}
+
+export default async function EmailVerifiedPage({ searchParams }: Props) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    // 認証後は auto-login で Cookie 発行済みのはずだが、保険として /login に誘導
+    redirect('/login?verified=true');
+  }
+
+  // email_verified が実際に true になっているか DB で確認
+  // 未認証ユーザーが直打ちでこのページに到達できないようにする
+  const user = await prisma.user.findUnique({
+    where: { id: parseInt(session.user.id, 10) },
+    select: { email_verified: true },
+  });
+  if (!user?.email_verified) {
+    redirect('/auth/verify-pending');
+  }
+
+  const returnUrl = sanitizeReturnUrl(searchParams.returnUrl);
+
+  return (
+    <EmailVerifiedClient
+      userName={session.user.name ?? ''}
+      returnUrl={returnUrl}
+    />
+  );
+}

--- a/app/auth/resend-verification/page.tsx
+++ b/app/auth/resend-verification/page.tsx
@@ -8,6 +8,15 @@ import { Mail, CheckCircle, AlertCircle, ArrowLeft } from 'lucide-react';
 function ResendVerificationForm() {
   const searchParams = useSearchParams();
   const initialEmail = searchParams?.get('email') || '';
+  const returnUrlRaw = searchParams?.get('returnUrl') ?? null;
+  // クライアント側サニタイズ: 相対パス + 長さ制限
+  const returnUrl =
+    returnUrlRaw &&
+    returnUrlRaw.length <= 512 &&
+    returnUrlRaw.startsWith('/') &&
+    !returnUrlRaw.startsWith('//')
+      ? returnUrlRaw
+      : null;
 
   const [email, setEmail] = useState(initialEmail);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -30,7 +39,7 @@ function ResendVerificationForm() {
       const response = await fetch('/api/auth/resend-verification', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email }),
+        body: JSON.stringify({ email, returnUrl }),
       });
 
       const data = await response.json();

--- a/app/auth/verify/page.tsx
+++ b/app/auth/verify/page.tsx
@@ -19,6 +19,18 @@ export default function VerifyEmailPage() {
   const searchParams = useSearchParams();
   const status = searchParams?.get('status'); // 'verified' | 'error' | 'expired' | null
   const errorMessage = searchParams?.get('message');
+  const returnUrlRaw = searchParams?.get('returnUrl') ?? null;
+  // 相対パス + 長さ制限（クライアント側でも防御）
+  const returnUrl =
+    returnUrlRaw &&
+    returnUrlRaw.length <= 512 &&
+    returnUrlRaw.startsWith('/') &&
+    !returnUrlRaw.startsWith('//')
+      ? returnUrlRaw
+      : null;
+  const resendHref = returnUrl
+    ? `/auth/resend-verification?returnUrl=${encodeURIComponent(returnUrl)}`
+    : '/auth/resend-verification';
 
   // 認証成功だが自動ログイン失敗（手動ログインを促す）
   if (status === 'verified') {
@@ -59,7 +71,7 @@ export default function VerifyEmailPage() {
           </p>
           <div className="space-y-3">
             <Link
-              href="/auth/resend-verification"
+              href={resendHref}
               className="block w-full bg-blue-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-blue-700 transition"
             >
               認証メールを再送信
@@ -90,7 +102,7 @@ export default function VerifyEmailPage() {
           </p>
           <div className="space-y-3">
             <Link
-              href="/auth/resend-verification"
+              href={resendHref}
               className="block w-full bg-blue-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-blue-700 transition"
             >
               認証メールを再送信

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -3,12 +3,13 @@
 import { useState, useEffect, Suspense } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Link from 'next/link';
-import { Mail, Lock, Eye, EyeOff } from 'lucide-react';
+import { User, Lock, Eye, EyeOff } from 'lucide-react';
 import { useAuth } from '@/contexts/AuthContext';
 import { getCsrfToken } from 'next-auth/react';
 import toast from 'react-hot-toast';
 import { useDebugError, extractDebugInfo } from '@/components/debug/DebugErrorBanner';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
+import { parseLoginIdentifier } from '@/src/lib/auth/identifier';
 
 export default function WorkerLogin() {
   return (
@@ -23,11 +24,10 @@ function WorkerLoginInner() {
   const searchParams = useSearchParams();
   const { login, isLoading: authLoading } = useAuth();
   const { showDebugError } = useDebugError();
-  const [email, setEmail] = useState('');
+  const [identifier, setIdentifier] = useState('');
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState('');
-  const [isEmailNotVerified, setIsEmailNotVerified] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [csrfReady, setCsrfReady] = useState(false);
 
@@ -42,36 +42,35 @@ function WorkerLoginInner() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
-    setIsEmailNotVerified(false);
 
-    if (!email || !password) {
-      setError('メールアドレスとパスワードを入力してください');
+    if (!identifier || !password) {
+      setError('メールアドレスまたは電話番号とパスワードを入力してください');
+      return;
+    }
+
+    const parsed = parseLoginIdentifier(identifier);
+    if (parsed.type === 'invalid') {
+      setError('メールアドレスまたは電話番号の形式が正しくありません');
       return;
     }
 
     setIsSubmitting(true);
 
     try {
-      const result = await login(email, password);
+      const result = await login(identifier, password);
 
       if (result.success) {
         toast.success('ログインしました');
         // セッションCookieが確実に反映されるようフルページナビゲーション
         window.location.href = '/';
       } else {
-        // メール未認証エラーの場合
-        if (result.error?.includes('EMAIL_NOT_VERIFIED')) {
-          setIsEmailNotVerified(true);
-          setError('メールアドレスが認証されていません。登録時に送信された確認メールのリンクをクリックしてください。');
-        } else {
-          showDebugError({
-            type: 'other',
-            operation: 'ログイン',
-            message: result.error || 'ログインに失敗しました',
-            context: { email }
-          });
-          setError(result.error || 'ログインに失敗しました');
-        }
+        showDebugError({
+          type: 'other',
+          operation: 'ログイン',
+          message: result.error || 'ログインに失敗しました',
+          context: { identifier }
+        });
+        setError(result.error || 'ログインに失敗しました');
       }
     } catch (err) {
       const debugInfo = extractDebugInfo(err);
@@ -81,7 +80,7 @@ function WorkerLoginInner() {
         message: debugInfo.message,
         details: debugInfo.details,
         stack: debugInfo.stack,
-        context: { email }
+        context: { identifier }
       });
       setError('ログイン中にエラーが発生しました');
     } finally {
@@ -113,34 +112,26 @@ function WorkerLoginInner() {
           {error && (
             <div className="mb-4 p-3 bg-white/90 border border-red-200 rounded-lg text-red-700 text-sm">
               <p>{error}</p>
-              {isEmailNotVerified && (
-                <Link
-                  href={`/auth/resend-verification?email=${encodeURIComponent(email)}`}
-                  className="mt-2 block text-primary font-medium hover:underline"
-                >
-                  確認メールを再送信する
-                </Link>
-              )}
             </div>
           )}
 
           <form onSubmit={handleSubmit} className="space-y-4">
-            {/* メールアドレス */}
+            {/* メールアドレス or 電話番号 */}
             <div>
               <label className="block text-sm font-medium mb-2 text-white">
-                メールアドレス
+                メールアドレス または 電話番号
               </label>
               <div className="relative">
-                <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
+                <User className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
                 <input
-                  type="email"
-                  id="login-email"
-                  name="email"
+                  type="text"
+                  id="login-identifier"
+                  name="identifier"
                   autoComplete="username"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
+                  value={identifier}
+                  onChange={(e) => setIdentifier(e.target.value)}
                   className="w-full pl-10 pr-4 py-3 border-0 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 bg-white"
-                  placeholder="yamada.taro@example.com"
+                  placeholder="メールアドレス または 電話番号"
                 />
               </div>
             </div>

--- a/app/my-jobs/MyJobsContent.tsx
+++ b/app/my-jobs/MyJobsContent.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 import { getMyApplications, cancelApplicationByWorker, cancelAppliedApplication } from '@/src/lib/actions';
 import toast from 'react-hot-toast';
 import { useDebugError, extractDebugInfo } from '@/components/debug/DebugErrorBanner';
+import { EmailVerificationRequiredModal } from '@/components/auth/EmailVerificationRequiredModal';
 
 type ApplicationStatus = 'APPLIED' | 'SCHEDULED' | 'WORKING' | 'COMPLETED_PENDING' | 'COMPLETED_RATED' | 'CANCELLED';
 type JobType = 'NORMAL' | 'LIMITED_WORKED' | 'LIMITED_FAVORITE' | 'ORIENTATION' | 'OFFER';
@@ -65,6 +66,7 @@ export function MyJobsContent({ initialTab }: MyJobsContentProps) {
   // SCHEDULED/WORKINGキャンセル用モーダル
   const [scheduledCancelModalApp, setScheduledCancelModalApp] = useState<Application | null>(null);
   const [scheduledCancelling, setScheduledCancelling] = useState(false);
+  const [emailNotVerifiedModal, setEmailNotVerifiedModal] = useState<{ open: boolean; email: string }>({ open: false, email: '' });
 
   // URLパラメータの変更を監視してタブを更新（Linkでの遷移時）
   useEffect(() => {
@@ -194,6 +196,9 @@ export function MyJobsContent({ initialTab }: MyJobsContentProps) {
         setApplications(prev =>
           prev.map(a => a.id === scheduledCancelModalApp.id ? { ...a, status: 'CANCELLED' as ApplicationStatus } : a)
         );
+      } else if ('errorCode' in result && result.errorCode === 'EMAIL_NOT_VERIFIED') {
+        const email = ('email' in result && typeof result.email === 'string') ? result.email : '';
+        setEmailNotVerifiedModal({ open: true, email });
       } else {
         showDebugError({
           type: 'delete',
@@ -234,6 +239,13 @@ export function MyJobsContent({ initialTab }: MyJobsContentProps) {
 
   return (
     <>
+      {/* メール未認証モーダル */}
+      <EmailVerificationRequiredModal
+        open={emailNotVerifiedModal.open}
+        email={emailNotVerifiedModal.email}
+        onClose={() => setEmailNotVerifiedModal({ open: false, email: '' })}
+      />
+
       {/* 求人カード一覧 */}
       <div className="p-3 space-y-2">
         {filteredApplications.length === 0 ? (

--- a/app/mypage/profile/ProfileEditClient.tsx
+++ b/app/mypage/profile/ProfileEditClient.tsx
@@ -195,7 +195,8 @@ export default function ProfileEditClient({ userProfile }: ProfileEditClientProp
 
     // 2. 働き方と希望
     currentWorkStyle: userProfile.current_work_style || '',
-    desiredWorkStyle: userProfile.desired_work_style || '',
+    // desired_work_style は CSV 形式の可能性があるため、最初の値をドロップダウン初期値として取り出す
+    desiredWorkStyle: (userProfile.desired_work_style || '').split(',')[0] || '',
     jobChangeDesire: userProfile.job_change_desire || '',
     desiredWorkDaysPerWeek: userProfile.desired_work_days_week || '',
     desiredWorkPeriod: userProfile.desired_work_period || '',

--- a/app/register/worker/page.tsx
+++ b/app/register/worker/page.tsx
@@ -716,7 +716,7 @@ function WorkerRegisterPageInner() {
             {isSubmitting
               ? '送信中...'
               : currentStep === '8'
-              ? '利用規約・プライバシーポリシーに同意して登録'
+              ? '同意して登録する'
               : '次へ'}
           </button>
         </div>

--- a/app/register/worker/page.tsx
+++ b/app/register/worker/page.tsx
@@ -309,13 +309,18 @@ function WorkerRegisterPageInner() {
       });
       const data = await res.json();
       if (!res.ok) {
+        // debug.message があれば詳細な原因も表示（ステージング診断用）
+        const detailMessage = data?.debug?.message
+          ? `${data.error || '登録に失敗しました'}（原因: ${data.debug.message}）`
+          : (data.error || '登録に失敗しました');
         showDebugError({
           type: 'other',
           operation: '会員登録',
-          message: data.error || '登録に失敗しました',
-          context: { status: res.status },
+          message: detailMessage,
+          details: data?.debug?.stack,
+          context: { status: res.status, debug: data?.debug },
         });
-        toast.error(data.error || '登録に失敗しました');
+        toast.error(detailMessage);
         setIsSubmitting(false);
         return;
       }
@@ -638,43 +643,45 @@ function WorkerRegisterPageInner() {
                   className="w-full px-4 py-3 border-2 border-gray-200 rounded-[10px] focus:border-[#2AADCF] focus:outline-none"
                 />
               </div>
-              <div className="space-y-2 mt-6">
-                <label className="flex items-start gap-2 text-sm cursor-pointer">
+              <div className="space-y-1 mt-6">
+                <div className="flex items-start gap-3 py-2 px-1 min-h-[44px] select-none">
                   <input
+                    id="agree-terms"
                     type="checkbox"
                     checked={agreedToTerms}
                     onChange={e => setAgreedToTerms(e.target.checked)}
-                    className="mt-0.5"
+                    className="mt-1 w-5 h-5 flex-shrink-0 accent-[#2AADCF] cursor-pointer"
                   />
-                  <span>
+                  <div className="leading-relaxed text-sm flex-1">
                     <button
                       type="button"
                       onClick={() => setShowTermsModal(true)}
-                      className="text-[#2AADCF] underline"
+                      className="text-[#2AADCF] underline font-medium"
                     >
                       利用規約
                     </button>
-                    に同意する
-                  </span>
-                </label>
-                <label className="flex items-start gap-2 text-sm cursor-pointer">
+                    <label htmlFor="agree-terms" className="cursor-pointer">に同意する</label>
+                  </div>
+                </div>
+                <div className="flex items-start gap-3 py-2 px-1 min-h-[44px] select-none">
                   <input
+                    id="agree-privacy"
                     type="checkbox"
                     checked={agreedToPrivacy}
                     onChange={e => setAgreedToPrivacy(e.target.checked)}
-                    className="mt-0.5"
+                    className="mt-1 w-5 h-5 flex-shrink-0 accent-[#2AADCF] cursor-pointer"
                   />
-                  <span>
+                  <div className="leading-relaxed text-sm flex-1">
                     <button
                       type="button"
                       onClick={() => setShowPrivacyModal(true)}
-                      className="text-[#2AADCF] underline"
+                      className="text-[#2AADCF] underline font-medium"
                     >
                       プライバシーポリシー
                     </button>
-                    に同意する
-                  </span>
-                </label>
+                    <label htmlFor="agree-privacy" className="cursor-pointer">に同意する</label>
+                  </div>
+                </div>
               </div>
               <div className="flex justify-center gap-4 mt-6 text-xs text-gray-500">
                 <span>🔒 SSL暗号化通信</span>

--- a/app/register/worker/page.tsx
+++ b/app/register/worker/page.tsx
@@ -3,14 +3,17 @@
 import { useState, useEffect, Suspense, useMemo } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import toast from 'react-hot-toast';
-import { SmsVerification } from '@/components/ui/SmsVerification';
 import { useDebugError, extractDebugInfo } from '@/components/debug/DebugErrorBanner';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
+import { PhoneNumberInput } from '@/components/ui/PhoneNumberInput';
 import { getLegalDocument } from '@/src/lib/content-actions';
 import { trackGA4Event } from '@/src/lib/ga4-events';
 import RegistrationPageTracker from '@/components/tracking/RegistrationPageTracker';
+import { isValidPhoneNumber } from '@/utils/inputValidation';
 
-type StepId = '1' | '2' | '2b' | '3' | '4' | '5' | '6' | '7' | '8';
+// フォーム入力ステップ (1〜8) + SMS認証ステップ (sms)
+// PP 同意後に SMS を送信するため、認証は step 8 の後に別画面で行う
+type StepId = '1' | '2' | '2b' | '3' | '4' | '5' | '6' | '7' | '8' | 'sms';
 
 // 資格オプション：表示ラベルとDB保存値のマッピング
 const QUALIFICATION_OPTIONS: { label: string; value: string }[] = [
@@ -39,6 +42,14 @@ const EMPLOYMENT_STATUS_OPTIONS = [
   '離職中',
   '学生',
 ];
+
+// SMS ステップで電話番号を見やすく表示（090-1234-5678）
+function formatPhoneForDisplay(phoneNumber: string): string {
+  const digits = phoneNumber.replace(/[^0-9]/g, '');
+  if (digits.length === 11) return `${digits.slice(0, 3)}-${digits.slice(3, 7)}-${digits.slice(7)}`;
+  if (digits.length === 10) return `${digits.slice(0, 2)}-${digits.slice(2, 6)}-${digits.slice(6)}`;
+  return phoneNumber;
+}
 
 // step2 で「どのくらい働きたいですか？」を見せる条件
 function shouldShowStep2b(desiredWorkStyle: string[]): boolean {
@@ -80,6 +91,13 @@ function WorkerRegisterPageInner() {
   const [phoneVerificationToken, setPhoneVerificationToken] = useState<string | null>(null);
   const [isLoadingAddress, setIsLoadingAddress] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // SMS認証ステップ用
+  const [smsCode, setSmsCode] = useState('');
+  const [smsError, setSmsError] = useState<string | null>(null);
+  const [smsCooldownSeconds, setSmsCooldownSeconds] = useState(0);
+  const [isSendingSms, setIsSendingSms] = useState(false);
+  const [isVerifyingSms, setIsVerifyingSms] = useState(false);
 
   // 利用規約・PP
   const [termsContent, setTermsContent] = useState<string>('');
@@ -161,10 +179,11 @@ function WorkerRegisterPageInner() {
   }, []);
 
   // ステップ順序（条件付きで 2b を挿入）
+  // sms ステップは step 8 の後に続く「認証コード入力」画面（利用規約同意後に SMS 送信）
   const stepSequence = useMemo<StepId[]>(() => {
     const base: StepId[] = ['1', '2'];
     if (shouldShowStep2b(form.desiredWorkStyle)) base.push('2b');
-    base.push('3', '4', '5', '6', '7', '8');
+    base.push('3', '4', '5', '6', '7', '8', 'sms');
     return base;
   }, [form.desiredWorkStyle]);
 
@@ -210,7 +229,7 @@ function WorkerRegisterPageInner() {
       case '8':
         return (
           !!form.phoneNumber &&
-          !!phoneVerificationToken &&
+          isValidPhoneNumber(form.phoneNumber) &&
           !!form.email &&
           /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email) &&
           !!form.password &&
@@ -218,13 +237,21 @@ function WorkerRegisterPageInner() {
           agreedToTerms &&
           agreedToPrivacy
         );
+      case 'sms':
+        return smsCode.length >= 4 && smsCode.length <= 6;
     }
   };
 
   const goNext = () => {
     if (!isStepValid()) return;
+    // step 8: 利用規約・PP 同意後に SMS 送信 → sms ステップへ
     if (currentStep === '8') {
-      handleSubmit();
+      handleSendSmsAndAdvance();
+      return;
+    }
+    // sms ステップ: コード検証 → 登録API 実行
+    if (currentStep === 'sms') {
+      handleVerifyAndSubmit();
       return;
     }
     const nextIdx = stepIndex + 1;
@@ -268,19 +295,121 @@ function WorkerRegisterPageInner() {
     }
   };
 
-  const handleSubmit = async () => {
-    if (isSubmitting) return;
-    setIsSubmitting(true);
+  // クールダウン秒カウントダウン
+  useEffect(() => {
+    if (smsCooldownSeconds <= 0) return;
+    const t = setTimeout(() => setSmsCooldownSeconds(s => s - 1), 1000);
+    return () => clearTimeout(t);
+  }, [smsCooldownSeconds]);
+
+  // step 8 (利用規約同意後) → SMS 送信 → sms ステップへ
+  const handleSendSmsAndAdvance = async () => {
+    if (isSendingSms) return;
+    setIsSendingSms(true);
+    setSmsError(null);
     setSubmitError(null);
+    try {
+      const res = await fetch('/api/sms/send-code', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ phoneNumber: form.phoneNumber }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        const msg = data.error || 'SMS送信に失敗しました';
+        setSubmitError(msg);
+        toast.error(msg);
+        return;
+      }
+      // SMS 送信成功 → sms ステップへ遷移
+      setCurrentStep('sms');
+      setSmsCooldownSeconds(60);
+      setSmsCode('');
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+      toast.success('認証コードを送信しました');
+    } catch (err) {
+      const info = extractDebugInfo(err);
+      showDebugError({
+        type: 'other',
+        operation: 'SMS送信',
+        message: info.message,
+        details: info.details,
+        stack: info.stack,
+      });
+      setSubmitError('SMS送信中にエラーが発生しました');
+      toast.error('SMS送信中にエラーが発生しました');
+    } finally {
+      setIsSendingSms(false);
+    }
+  };
+
+  // SMS コード再送信
+  const handleResendSms = async () => {
+    if (isSendingSms || smsCooldownSeconds > 0) return;
+    setIsSendingSms(true);
+    setSmsError(null);
+    try {
+      const res = await fetch('/api/sms/send-code', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ phoneNumber: form.phoneNumber }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setSmsError(data.error || '再送信に失敗しました');
+        return;
+      }
+      setSmsCooldownSeconds(60);
+      setSmsCode('');
+      toast.success('認証コードを再送信しました');
+    } catch {
+      setSmsError('再送信中にエラーが発生しました');
+    } finally {
+      setIsSendingSms(false);
+    }
+  };
+
+  // step sms (コード入力) → 認証 → 登録API
+  const handleVerifyAndSubmit = async () => {
+    if (isVerifyingSms || isSubmitting) return;
+
+    // 既に検証成功した token を保持していれば再利用（登録API失敗→再試行 UX 対応）
+    // CPaaS のコードは一度使うと AlreadyVerified で弾かれるため
+    let token = phoneVerificationToken;
+
+    if (!token) {
+      setIsVerifyingSms(true);
+      setSmsError(null);
+      try {
+        const verifyRes = await fetch('/api/sms/verify-code', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ phoneNumber: form.phoneNumber, code: smsCode }),
+        });
+        const verifyData = await verifyRes.json();
+        if (!verifyData.success) {
+          setSmsError(verifyData.error || '認証に失敗しました');
+          return;
+        }
+        token = verifyData.verificationToken as string;
+        setPhoneVerificationToken(token);
+      } catch (err) {
+        setSmsError('認証処理中にエラーが発生しました。ネットワーク接続を確認してください。');
+        return;
+      } finally {
+        setIsVerifyingSms(false);
+      }
+    }
 
     try {
-      // 資格: mock ラベル → DB 値にマッピング、「その他」自由記述は追記
+      // 2. 登録 API 実行
+      setIsSubmitting(true);
+      setSubmitError(null);
+
       const qualificationsToSave = [...form.qualifications];
       if (form.qualifications.includes('その他') && form.qualificationOther.trim()) {
         qualificationsToSave.push(form.qualificationOther.trim());
       }
-
-      // 生年月日 YYYY-MM-DD
       const birthDate = `${form.birthYear}-${String(form.birthMonth).padStart(2, '0')}-${String(form.birthDay).padStart(2, '0')}`;
 
       const res = await fetch('/api/auth/register', {
@@ -292,7 +421,7 @@ function WorkerRegisterPageInner() {
           lastName: form.lastName,
           firstName: form.firstName,
           phoneNumber: form.phoneNumber,
-          phoneVerificationToken,
+          phoneVerificationToken: token,
           birthDate,
           qualifications: qualificationsToSave,
           lastNameKana: form.lastNameKana,
@@ -313,7 +442,6 @@ function WorkerRegisterPageInner() {
       });
       const data = await res.json();
       if (!res.ok) {
-        // debug.message があれば詳細な原因も表示（ステージング診断用）
         const detailMessage = data?.debug?.message
           ? `${data.error || '登録に失敗しました'}（原因: ${data.debug.message}）`
           : (data.error || '登録に失敗しました');
@@ -324,14 +452,12 @@ function WorkerRegisterPageInner() {
           details: data?.debug?.stack,
           context: { status: res.status, debug: data?.debug },
         });
-        // インライン永続表示（toast はすぐ消えるため）
         setSubmitError(detailMessage);
         toast.error(detailMessage);
         setIsSubmitting(false);
         return;
       }
 
-      // GA4 登録完了イベント
       try {
         trackGA4Event('worker_register_complete', {
           lp_id: lpInfo.lpId || '',
@@ -352,6 +478,7 @@ function WorkerRegisterPageInner() {
       setSubmitError('登録中にエラーが発生しました。ネットワーク接続を確認して再度お試しください。');
       toast.error('登録中にエラーが発生しました');
       setIsSubmitting(false);
+      setIsVerifyingSms(false);
     }
   };
 
@@ -634,16 +761,19 @@ function WorkerRegisterPageInner() {
                 </div>
               )}
               <div className="mb-4">
-                <FieldLabel required>電話番号（SMS認証が必要です）</FieldLabel>
-                <SmsVerification
-                  phoneNumber={form.phoneNumber}
-                  onPhoneNumberChange={v => {
-                    // 電話番号を変更したら既存の認証トークンを破棄（未認証状態に戻す）
+                <FieldLabel required>電話番号</FieldLabel>
+                <PhoneNumberInput
+                  value={form.phoneNumber}
+                  onChange={v => {
                     setField('phoneNumber', v);
                     setPhoneVerificationToken(null);
                   }}
-                  onVerified={token => setPhoneVerificationToken(token)}
+                  placeholder="例：09012345678"
+                  className="w-full px-4 py-3 border-2 border-gray-200 rounded-[10px] focus:border-[#2AADCF] focus:outline-none"
                 />
+                <p className="text-xs text-gray-500 mt-1">
+                  ※ 同意して登録を押すと、SMSで認証コードをお送りします
+                </p>
               </div>
               <div className="mb-4">
                 <FieldLabel required>メールアドレス</FieldLabel>
@@ -711,6 +841,78 @@ function WorkerRegisterPageInner() {
               </div>
             </StepContainer>
           )}
+
+          {currentStep === 'sms' && (
+            <StepContainer question="認証コードを入力してください">
+              <div className="text-center mb-6">
+                <div className="text-3xl mb-3">📱</div>
+                <p className="text-sm text-gray-700 mb-1">以下の番号宛にSMSを送信しました</p>
+                <p className="text-lg font-bold text-[#1A8FAD] tracking-wider">
+                  {formatPhoneForDisplay(form.phoneNumber)}
+                </p>
+              </div>
+
+              {submitError && (
+                <div
+                  role="alert"
+                  aria-live="polite"
+                  className="mb-4 p-3 rounded-lg bg-red-50 border border-red-200 text-red-700 text-sm"
+                >
+                  {submitError}
+                </div>
+              )}
+              {smsError && (
+                <div
+                  id="sms-code-error"
+                  role="alert"
+                  aria-live="polite"
+                  className="mb-4 p-3 rounded-lg bg-red-50 border border-red-200 text-red-700 text-sm"
+                >
+                  {smsError}
+                </div>
+              )}
+
+              <div className="mb-4">
+                <label htmlFor="sms-code-input" className="block text-sm font-semibold text-gray-800 mb-2">
+                  認証コード
+                  <span className="ml-2 text-[10px] bg-[#FF6B8A] text-white px-2 py-0.5 rounded font-semibold">
+                    必須
+                  </span>
+                </label>
+                <input
+                  id="sms-code-input"
+                  type="tel"
+                  inputMode="numeric"
+                  maxLength={6}
+                  autoComplete="one-time-code"
+                  autoFocus
+                  value={smsCode}
+                  onChange={e => {
+                    setSmsCode(e.target.value.replace(/[^0-9]/g, ''));
+                    setSmsError(null);
+                  }}
+                  placeholder="4桁または6桁のコード"
+                  className="w-full px-4 py-4 border-2 border-gray-200 rounded-[10px] focus:border-[#2AADCF] focus:outline-none text-center text-2xl tracking-[0.5em] font-bold"
+                  aria-describedby={smsError ? 'sms-code-error' : undefined}
+                />
+              </div>
+
+              <div className="text-center">
+                <button
+                  type="button"
+                  onClick={handleResendSms}
+                  disabled={smsCooldownSeconds > 0 || isSendingSms}
+                  className="text-sm text-[#2AADCF] underline disabled:text-gray-400 disabled:no-underline"
+                >
+                  {isSendingSms
+                    ? '送信中...'
+                    : smsCooldownSeconds > 0
+                    ? `再送信まで ${smsCooldownSeconds} 秒`
+                    : '認証コードが届かない方はこちら（再送信）'}
+                </button>
+              </div>
+            </StepContainer>
+          )}
         </div>
 
         {/* フッターナビ */}
@@ -719,8 +921,8 @@ function WorkerRegisterPageInner() {
             <button
               type="button"
               onClick={goBack}
-              className="w-14 h-14 flex-shrink-0 rounded-full border-2 border-[#2AADCF] text-[#2AADCF] bg-white flex items-center justify-center text-xl"
-              disabled={isSubmitting}
+              className="w-14 h-14 flex-shrink-0 rounded-full border-2 border-[#2AADCF] text-[#2AADCF] bg-white flex items-center justify-center text-xl disabled:opacity-50 disabled:cursor-not-allowed"
+              disabled={isSubmitting || isSendingSms || isVerifyingSms}
             >
               ←
             </button>
@@ -728,17 +930,23 @@ function WorkerRegisterPageInner() {
           <button
             type="button"
             onClick={goNext}
-            disabled={!isStepValid() || isSubmitting}
+            disabled={!isStepValid() || isSubmitting || isSendingSms || isVerifyingSms}
             className={`flex-1 py-4 rounded-full font-semibold text-white shadow-[0_4px_16px_rgba(42,173,207,0.3)] transition-all ${
-              isStepValid() && !isSubmitting
+              isStepValid() && !isSubmitting && !isSendingSms && !isVerifyingSms
                 ? 'bg-[#2AADCF] hover:bg-[#1A8FAD]'
                 : 'bg-[#C8E4ED] cursor-not-allowed'
             }`}
           >
             {isSubmitting
-              ? '送信中...'
+              ? '登録中...'
+              : isSendingSms
+              ? 'SMS送信中...'
+              : isVerifyingSms
+              ? '認証中...'
               : currentStep === '8'
               ? '同意して登録する'
+              : currentStep === 'sms'
+              ? '認証して登録完了'
               : '次へ'}
           </button>
         </div>

--- a/app/register/worker/page.tsx
+++ b/app/register/worker/page.tsx
@@ -79,6 +79,7 @@ function WorkerRegisterPageInner() {
   const [showPrivacyModal, setShowPrivacyModal] = useState(false);
   const [phoneVerificationToken, setPhoneVerificationToken] = useState<string | null>(null);
   const [isLoadingAddress, setIsLoadingAddress] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   // 利用規約・PP
   const [termsContent, setTermsContent] = useState<string>('');
@@ -229,6 +230,7 @@ function WorkerRegisterPageInner() {
     const nextIdx = stepIndex + 1;
     if (nextIdx < stepSequence.length) {
       setCurrentStep(stepSequence[nextIdx]);
+      setSubmitError(null);
       window.scrollTo({ top: 0, behavior: 'smooth' });
     }
   };
@@ -237,6 +239,7 @@ function WorkerRegisterPageInner() {
     const prevIdx = stepIndex - 1;
     if (prevIdx >= 0) {
       setCurrentStep(stepSequence[prevIdx]);
+      setSubmitError(null);
       window.scrollTo({ top: 0, behavior: 'smooth' });
     }
   };
@@ -268,6 +271,7 @@ function WorkerRegisterPageInner() {
   const handleSubmit = async () => {
     if (isSubmitting) return;
     setIsSubmitting(true);
+    setSubmitError(null);
 
     try {
       // 資格: mock ラベル → DB 値にマッピング、「その他」自由記述は追記
@@ -320,6 +324,8 @@ function WorkerRegisterPageInner() {
           details: data?.debug?.stack,
           context: { status: res.status, debug: data?.debug },
         });
+        // インライン永続表示（toast はすぐ消えるため）
+        setSubmitError(detailMessage);
         toast.error(detailMessage);
         setIsSubmitting(false);
         return;
@@ -343,6 +349,7 @@ function WorkerRegisterPageInner() {
         details: info.details,
         stack: info.stack,
       });
+      setSubmitError('登録中にエラーが発生しました。ネットワーク接続を確認して再度お試しください。');
       toast.error('登録中にエラーが発生しました');
       setIsSubmitting(false);
     }
@@ -350,7 +357,13 @@ function WorkerRegisterPageInner() {
 
   return (
     <div className="min-h-screen bg-[#F8FCFE]">
-      <div className="max-w-md mx-auto bg-white min-h-screen relative">
+      <form
+        className="max-w-md mx-auto bg-white min-h-screen relative"
+        onSubmit={(e) => {
+          e.preventDefault();
+          goNext();
+        }}
+      >
         {/* ヘッダー */}
         <div className="bg-gradient-to-br from-[#E8F7FB] via-[#D4F1F9] to-[#E8F0FE] px-5 pt-6 pb-8 text-center">
           <div className="text-[#2AADCF] font-bold text-lg">タスタス</div>
@@ -611,6 +624,15 @@ function WorkerRegisterPageInner() {
 
           {currentStep === '8' && (
             <StepContainer question="ご連絡先・パスワード">
+              {submitError && (
+                <div
+                  role="alert"
+                  aria-live="polite"
+                  className="mb-4 p-3 rounded-lg bg-red-50 border border-red-200 text-red-700 text-sm"
+                >
+                  {submitError}
+                </div>
+              )}
               <div className="mb-4">
                 <FieldLabel required>電話番号（SMS認証が必要です）</FieldLabel>
                 <SmsVerification
@@ -736,7 +758,7 @@ function WorkerRegisterPageInner() {
             onClose={() => setShowPrivacyModal(false)}
           />
         )}
-      </div>
+      </form>
     </div>
   );
 }

--- a/app/register/worker/page.tsx
+++ b/app/register/worker/page.tsx
@@ -1,26 +1,65 @@
 'use client';
 
-import { useState, useEffect, Suspense } from 'react';
+import { useState, useEffect, Suspense, useMemo } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { ArrowLeft, Check } from 'lucide-react';
-import Link from 'next/link';
 import toast from 'react-hot-toast';
-import { isValidEmail, isValidPhoneNumber } from '@/utils/inputValidation';
-import { isKatakanaOnly } from '@/utils/inputValidation';
 import { SmsVerification } from '@/components/ui/SmsVerification';
-import { KatakanaInput } from '@/components/ui/KatakanaInput';
-import { NameWithKanaInput } from '@/components/ui/NameWithKanaInput';
-import AddressSelector from '@/components/ui/AddressSelector';
 import { useDebugError, extractDebugInfo } from '@/components/debug/DebugErrorBanner';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
-import { trackGA4Event } from '@/src/lib/ga4-events';
 import { getLegalDocument } from '@/src/lib/content-actions';
-import { QUALIFICATION_GROUPS } from '@/constants/qualifications';
+import { trackGA4Event } from '@/src/lib/ga4-events';
 import RegistrationPageTracker from '@/components/tracking/RegistrationPageTracker';
+
+type StepId = '1' | '2' | '2b' | '3' | '4' | '5' | '6' | '7' | '8';
+
+// 資格オプション：表示ラベルとDB保存値のマッピング
+const QUALIFICATION_OPTIONS: { label: string; value: string }[] = [
+  { label: '正看護師', value: '看護師' },
+  { label: '准看護師', value: '准看護師' },
+  { label: '介護福祉士', value: '介護福祉士' },
+  { label: '実務者研修（ヘルパー1級）', value: '実務者研修' },
+  { label: '初任者研修（ヘルパー2級）', value: '初任者研修' },
+  { label: 'その他', value: 'その他' },
+];
+
+const DESIRED_WORK_STYLE_OPTIONS = [
+  '単発・スポット',
+  '常勤・正社員',
+  '非常勤・パート（扶養内）',
+  '非常勤・パート（扶養外）',
+  '派遣',
+  'こだわらない',
+];
+
+const WORK_FREQUENCY_OPTIONS = ['週1回', '週2〜3回', '週4〜5回', '週5回'];
+const JOB_TIMING_OPTIONS = ['いますぐ', '1ヶ月以内', '3ヶ月以内', 'いまは情報収集のみ'];
+const EMPLOYMENT_STATUS_OPTIONS = [
+  '就業中（常勤・正社員）',
+  '就業中（非常勤・パート）',
+  '離職中',
+  '学生',
+];
+
+// step2 で「どのくらい働きたいですか？」を見せる条件
+function shouldShowStep2b(desiredWorkStyle: string[]): boolean {
+  return desiredWorkStyle.some(v =>
+    v === '単発・スポット' ||
+    v === '非常勤・パート（扶養内）' ||
+    v === '非常勤・パート（扶養外）' ||
+    v === '派遣' ||
+    v === 'こだわらない'
+  );
+}
 
 export default function WorkerRegisterPage() {
   return (
-    <Suspense fallback={<div className="min-h-screen bg-gray-50 py-8"><div className="max-w-xl mx-auto px-4 text-center text-gray-500">読み込み中...</div></div>}>
+    <Suspense
+      fallback={
+        <div className="min-h-screen bg-white flex items-center justify-center">
+          <LoadingSpinner size="lg" />
+        </div>
+      }
+    >
       <RegistrationPageTracker />
       <WorkerRegisterPageInner />
     </Suspense>
@@ -31,870 +70,780 @@ function WorkerRegisterPageInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { showDebugError } = useDebugError();
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [showErrors, setShowErrors] = useState(false);
-  const [currentStep, setCurrentStep] = useState(1);
-  const [agreedToTerms, setAgreedToTerms] = useState(false);
-  const [showTermsModal, setShowTermsModal] = useState(false);
-  const [agreedToPrivacy, setAgreedToPrivacy] = useState(false);
-  const [phoneVerificationToken, setPhoneVerificationToken] = useState<string | null>(null);
-  const [showPrivacyModal, setShowPrivacyModal] = useState(false);
 
-  // 利用規約・PPのDB取得
+  const [currentStep, setCurrentStep] = useState<StepId>('1');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [agreedToTerms, setAgreedToTerms] = useState(false);
+  const [agreedToPrivacy, setAgreedToPrivacy] = useState(false);
+  const [showTermsModal, setShowTermsModal] = useState(false);
+  const [showPrivacyModal, setShowPrivacyModal] = useState(false);
+  const [phoneVerificationToken, setPhoneVerificationToken] = useState<string | null>(null);
+  const [isLoadingAddress, setIsLoadingAddress] = useState(false);
+
+  // 利用規約・PP
   const [termsContent, setTermsContent] = useState<string>('');
   const [privacyContent, setPrivacyContent] = useState<string>('');
-  const [termsLastUpdated, setTermsLastUpdated] = useState<string>('');
-  const [privacyLastUpdated, setPrivacyLastUpdated] = useState<string>('');
-  const [isLoadingLegal, setIsLoadingLegal] = useState(true);
 
-  const [formData, setFormData] = useState({
-    // ステップ1: アカウント情報・基本情報
-    email: '',
-    emailConfirm: '',
-    phoneNumber: '',
-    password: '',
-    passwordConfirm: '',
+  // フォームデータ
+  const [form, setForm] = useState({
+    qualifications: [] as string[],       // DB 保存値の配列
+    qualificationOther: '',                // その他自由記述
+    desiredWorkStyle: [] as string[],     // 複数選択
+    workFrequency: '',                     // step 2b（条件付き）
+    jobTiming: '',
+    employmentStatus: '',
+    postalCode: '',
+    prefecture: '',
+    city: '',
+    gender: '',
+    birthYear: '',
+    birthMonth: '',
+    birthDay: '',
     lastName: '',
     firstName: '',
     lastNameKana: '',
     firstNameKana: '',
-    birthDate: '',
-    // ステップ2: 住所・資格
-    postalCode: '',
-    prefecture: '',
-    city: '',
-    addressLine: '',
-    building: '',
-    qualifications: [] as string[],
+    phoneNumber: '',
+    email: '',
+    password: '',
   });
 
-  // LP経由登録情報（localStorage → URLパラメータ のフォールバックチェーン）
-  const [lpInfo, setLpInfo] = useState<{ lpId: string | null; campaignCode: string | null; genrePrefix: string | null }>({
-    lpId: null,
-    campaignCode: null,
-    genrePrefix: null,
-  });
-  const [lpSource, setLpSource] = useState<'localStorage' | 'urlParams' | 'none'>('none');
+  // LP 情報（localStorage / URL params）
+  const [lpInfo, setLpInfo] = useState<{
+    lpId: string | null;
+    campaignCode: string | null;
+    genrePrefix: string | null;
+    source: 'localStorage' | 'urlParams' | 'none';
+  }>({ lpId: null, campaignCode: null, genrePrefix: null, source: 'none' });
 
-  // ページロード時にLP情報を取得（localStorage優先、URLパラメータフォールバック）
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      let fromLocalStorage = false;
-
-      try {
-        // 第1優先: localStorage（lp_tracking_data）
-        const trackingDataStr = localStorage.getItem('lp_tracking_data');
-        if (trackingDataStr) {
-          const trackingData = JSON.parse(trackingDataStr);
-          if (trackingData.expiry && Date.now() <= trackingData.expiry) {
-            setLpInfo({
-              lpId: trackingData.lpId || null,
-              campaignCode: trackingData.campaignCode || null,
-              genrePrefix: trackingData.genrePrefix || null,
-            });
-            fromLocalStorage = true;
-          }
+    // localStorage 優先、次に URL パラメータ
+    try {
+      const stored = typeof window !== 'undefined' ? localStorage.getItem('lpInfo') : null;
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        if (parsed?.lpId) {
+          setLpInfo({
+            lpId: parsed.lpId,
+            campaignCode: parsed.campaignCode ?? null,
+            genrePrefix: parsed.genrePrefix ?? null,
+            source: 'localStorage',
+          });
+          return;
         }
-        // 第1優先: localStorage（個別キー）
-        if (!fromLocalStorage) {
-          const storedLpId = localStorage.getItem('lp_id');
-          const storedCampaignCode = localStorage.getItem('lp_campaign_code');
-          if (storedLpId) {
-            let genrePrefix = null;
-            if (storedCampaignCode) {
-              const match = storedCampaignCode.match(/^([A-Z]{3})-/);
-              if (match) {
-                genrePrefix = match[1];
-              }
-            }
-            setLpInfo({
-              lpId: storedLpId,
-              campaignCode: storedCampaignCode,
-              genrePrefix,
-            });
-            fromLocalStorage = true;
-          }
-        }
-      } catch (e) {
-        console.error('Failed to get LP info from localStorage:', e);
       }
-
-      if (fromLocalStorage) {
-        setLpSource('localStorage');
-        return;
-      }
-
-      // 第2優先: URLクエリパラメータ（CTAリンク経由で引き継がれた情報）
-      const urlLp = searchParams?.get('lp');
-      if (urlLp) {
-        setLpInfo({
-          lpId: urlLp,
-          campaignCode: searchParams?.get('c') || null,
-          genrePrefix: searchParams?.get('g') || null,
-        });
-        setLpSource('urlParams');
-      }
+    } catch {
+      // noop
+    }
+    const lp = searchParams?.get('lp') ?? null;
+    const c = searchParams?.get('c') ?? null;
+    const g = searchParams?.get('g') ?? null;
+    if (lp) {
+      setLpInfo({ lpId: lp, campaignCode: c, genrePrefix: g, source: 'urlParams' });
     }
   }, [searchParams]);
 
-  // 利用規約・PPをDBから取得
+  // 利用規約・PP取得（表示時）
   useEffect(() => {
-    const fetchLegalDocs = async () => {
+    (async () => {
       try {
-        const [termsDoc, privacyDoc] = await Promise.all([
+        const [terms, privacy] = await Promise.all([
           getLegalDocument('TERMS', 'WORKER'),
           getLegalDocument('PRIVACY', 'WORKER'),
         ]);
-        if (termsDoc) {
-          setTermsContent(termsDoc.content);
-          setTermsLastUpdated(
-            termsDoc.published_at
-              ? new Date(termsDoc.published_at).toLocaleDateString('ja-JP', { year: 'numeric', month: 'long', day: 'numeric' })
-              : ''
-          );
-        }
-        if (privacyDoc) {
-          setPrivacyContent(privacyDoc.content);
-          setPrivacyLastUpdated(
-            privacyDoc.published_at
-              ? new Date(privacyDoc.published_at).toLocaleDateString('ja-JP', { year: 'numeric', month: 'long', day: 'numeric' })
-              : ''
-          );
-        }
-      } catch (error) {
-        console.error('Failed to fetch legal documents:', error);
-      } finally {
-        setIsLoadingLegal(false);
+        if (terms?.content) setTermsContent(terms.content);
+        if (privacy?.content) setPrivacyContent(privacy.content);
+      } catch {
+        // 取得失敗しても登録は継続可能
       }
-    };
-    fetchLegalDocs();
+    })();
   }, []);
 
-  // 資格チェックボックスのトグル
-  const handleQualificationToggle = (qualification: string) => {
-    setFormData(prev => ({
-      ...prev,
-      qualifications: prev.qualifications.includes(qualification)
-        ? prev.qualifications.filter(q => q !== qualification)
-        : [...prev.qualifications, qualification],
-    }));
+  // ステップ順序（条件付きで 2b を挿入）
+  const stepSequence = useMemo<StepId[]>(() => {
+    const base: StepId[] = ['1', '2'];
+    if (shouldShowStep2b(form.desiredWorkStyle)) base.push('2b');
+    base.push('3', '4', '5', '6', '7', '8');
+    return base;
+  }, [form.desiredWorkStyle]);
+
+  const stepIndex = stepSequence.indexOf(currentStep);
+  const totalSteps = stepSequence.length;
+
+  const setField = <K extends keyof typeof form>(k: K, v: (typeof form)[K]) => {
+    setForm(prev => ({ ...prev, [k]: v }));
   };
 
-  // ステップ1のバリデーション
-  const validateStep1 = (): boolean => {
-    const errors: string[] = [];
-
-    if (!formData.email) errors.push('メールアドレス');
-    if (!formData.emailConfirm) errors.push('メールアドレス（確認）');
-    if (!formData.phoneNumber) errors.push('電話番号');
-    if (!formData.password) errors.push('パスワード');
-    if (!formData.passwordConfirm) errors.push('パスワード（確認）');
-    if (!formData.lastName) errors.push('姓');
-    if (!formData.firstName) errors.push('名');
-    if (!formData.lastNameKana) errors.push('姓（カナ）');
-    if (!formData.firstNameKana) errors.push('名（カナ）');
-    if (!formData.birthDate) errors.push('生年月日');
-
-    if (errors.length > 0) {
-      toast.error(`以下の項目を入力してください: ${errors.join('、')}`);
-      return false;
-    }
-
-    if (!isValidEmail(formData.email)) {
-      toast.error('メールアドレスの形式が正しくありません');
-      return false;
-    }
-
-    if (formData.email !== formData.emailConfirm) {
-      toast.error('メールアドレスが一致しません');
-      return false;
-    }
-
-    if (!isValidPhoneNumber(formData.phoneNumber)) {
-      toast.error('有効な日本の電話番号を入力してください（例: 09012345678）');
-      return false;
-    }
-
-    if (!phoneVerificationToken) {
-      toast.error('電話番号のSMS認証を完了してください');
-      return false;
-    }
-
-    if (formData.password.length < 8) {
-      toast.error('パスワードは8文字以上で入力してください');
-      return false;
-    }
-
-    if (formData.password !== formData.passwordConfirm) {
-      toast.error('パスワードが一致しません');
-      return false;
-    }
-
-    if (formData.lastNameKana && !isKatakanaOnly(formData.lastNameKana)) {
-      toast.error('姓（カナ）はカタカナで入力してください');
-      return false;
-    }
-
-    if (formData.firstNameKana && !isKatakanaOnly(formData.firstNameKana)) {
-      toast.error('名（カナ）はカタカナで入力してください');
-      return false;
-    }
-
-    return true;
+  const toggleArrayValue = (field: 'qualifications' | 'desiredWorkStyle', value: string) => {
+    setForm(prev => {
+      const curr = prev[field];
+      return {
+        ...prev,
+        [field]: curr.includes(value) ? curr.filter(v => v !== value) : [...curr, value],
+      };
+    });
   };
 
-  // ステップ1→2への遷移
-  const handleNextStep = () => {
-    setShowErrors(true);
-    if (validateStep1()) {
-      setShowErrors(false);
-      setCurrentStep(2);
-      window.scrollTo(0, 0);
-    }
-  };
-
-  // ステップ2→1への戻り
-  const handlePrevStep = () => {
-    setShowErrors(false);
-    setCurrentStep(1);
-    window.scrollTo(0, 0);
-  };
-
-  // 登録送信
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setShowErrors(true);
-
-    // ステップ2のバリデーション
-    const errors: string[] = [];
-    if (!formData.prefecture) errors.push('都道府県');
-    if (!formData.city) errors.push('市区町村');
-    if (!formData.addressLine) errors.push('番地');
-    if (formData.qualifications.length === 0) errors.push('保有資格');
-
-    if (errors.length > 0) {
-      toast.error(`以下の項目を入力してください: ${errors.join('、')}`);
-      return;
-    }
-
-    if (!agreedToTerms) {
-      toast.error('利用規約に同意してください');
-      const termsSection = document.getElementById('terms-section');
-      if (termsSection) {
-        termsSection.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  // 各ステップのバリデーション
+  const isStepValid = (): boolean => {
+    switch (currentStep) {
+      case '1': {
+        if (form.qualifications.length === 0) return false;
+        if (form.qualifications.includes('その他') && !form.qualificationOther.trim()) return false;
+        return true;
       }
+      case '2':
+        return form.desiredWorkStyle.length > 0;
+      case '2b':
+        return !!form.workFrequency;
+      case '3':
+        return !!form.jobTiming;
+      case '4':
+        return !!form.employmentStatus;
+      case '5':
+        return !!form.postalCode && form.postalCode.replace(/[^0-9]/g, '').length === 7;
+      case '6':
+        return !!form.gender && !!form.birthYear && !!form.birthMonth && !!form.birthDay;
+      case '7':
+        return !!form.lastName.trim() && !!form.firstName.trim() && !!form.lastNameKana.trim() && !!form.firstNameKana.trim();
+      case '8':
+        return (
+          !!form.phoneNumber &&
+          !!phoneVerificationToken &&
+          !!form.email &&
+          /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(form.email) &&
+          !!form.password &&
+          form.password.length >= 8 &&
+          agreedToTerms &&
+          agreedToPrivacy
+        );
+    }
+  };
+
+  const goNext = () => {
+    if (!isStepValid()) return;
+    if (currentStep === '8') {
+      handleSubmit();
       return;
     }
+    const nextIdx = stepIndex + 1;
+    if (nextIdx < stepSequence.length) {
+      setCurrentStep(stepSequence[nextIdx]);
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  };
 
-    if (!agreedToPrivacy) {
-      toast.error('プライバシーポリシーに同意してください');
-      const termsSection = document.getElementById('terms-section');
-      if (termsSection) {
-        termsSection.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  const goBack = () => {
+    const prevIdx = stepIndex - 1;
+    if (prevIdx >= 0) {
+      setCurrentStep(stepSequence[prevIdx]);
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  };
+
+  // 郵便番号 → 住所自動入力（zipcloud）
+  const handlePostalLookup = async (code: string) => {
+    const digits = code.replace(/[^0-9]/g, '');
+    if (digits.length !== 7) return;
+    setIsLoadingAddress(true);
+    try {
+      const res = await fetch(`https://zipcloud.ibsnet.co.jp/api/search?zipcode=${digits}`);
+      const data = await res.json();
+      if (data.results?.length > 0) {
+        const r = data.results[0];
+        setForm(prev => ({
+          ...prev,
+          postalCode: digits,
+          prefecture: r.address1 || '',
+          city: `${r.address2 || ''}${r.address3 || ''}`,
+        }));
       }
-      return;
+    } catch {
+      // ignore
+    } finally {
+      setIsLoadingAddress(false);
     }
+  };
 
+  const handleSubmit = async () => {
+    if (isSubmitting) return;
     setIsSubmitting(true);
 
     try {
-      const response = await fetch('/api/auth/register', {
+      // 資格: mock ラベル → DB 値にマッピング、「その他」自由記述は追記
+      const qualificationsToSave = [...form.qualifications];
+      if (form.qualifications.includes('その他') && form.qualificationOther.trim()) {
+        qualificationsToSave.push(form.qualificationOther.trim());
+      }
+
+      // 生年月日 YYYY-MM-DD
+      const birthDate = `${form.birthYear}-${String(form.birthMonth).padStart(2, '0')}-${String(form.birthDay).padStart(2, '0')}`;
+
+      const res = await fetch('/api/auth/register', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          email: formData.email,
-          password: formData.password,
-          phoneNumber: formData.phoneNumber,
+          email: form.email,
+          password: form.password,
+          lastName: form.lastName,
+          firstName: form.firstName,
+          phoneNumber: form.phoneNumber,
           phoneVerificationToken,
-          // 新規追加フィールド
-          lastName: formData.lastName,
-          firstName: formData.firstName,
-          lastNameKana: formData.lastNameKana,
-          firstNameKana: formData.firstNameKana,
-          birthDate: formData.birthDate,
-          postalCode: formData.postalCode,
-          prefecture: formData.prefecture,
-          city: formData.city,
-          addressLine: formData.addressLine,
-          building: formData.building,
-          qualifications: formData.qualifications,
-          // LP経由登録情報（フォールバックチェーン: localStorage → URLパラメータ → サーバーサイドIP照合）
+          birthDate,
+          qualifications: qualificationsToSave,
+          lastNameKana: form.lastNameKana,
+          firstNameKana: form.firstNameKana,
+          gender: form.gender,
+          postalCode: form.postalCode,
+          prefecture: form.prefecture,
+          city: form.city,
+          desiredWorkStyle: form.desiredWorkStyle,
+          workFrequency: form.workFrequency || undefined,
+          jobTiming: form.jobTiming,
+          employmentStatus: form.employmentStatus,
           registrationLpId: lpInfo.lpId,
           registrationCampaignCode: lpInfo.campaignCode,
           registrationGenrePrefix: lpInfo.genrePrefix,
-          lpAttributionSource: lpSource,
+          lpAttributionSource: lpInfo.source,
         }),
       });
-
-      const data = await response.json();
-
-      if (!response.ok) {
-        throw new Error(data.error || '登録に失敗しました');
+      const data = await res.json();
+      if (!res.ok) {
+        showDebugError({
+          type: 'other',
+          operation: '会員登録',
+          message: data.error || '登録に失敗しました',
+          context: { status: res.status },
+        });
+        toast.error(data.error || '登録に失敗しました');
+        setIsSubmitting(false);
+        return;
       }
 
-      toast.success('登録が完了しました。メールをご確認ください。');
-      trackGA4Event('sign_up', {
-        method: 'email',
-        lp_id: lpInfo.lpId || undefined,
-        campaign_code: lpInfo.campaignCode || undefined,
-      });
+      // GA4 登録完了イベント
+      try {
+        trackGA4Event('worker_register_complete', {
+          lp_id: lpInfo.lpId || '',
+          genre: lpInfo.genrePrefix || '',
+        });
+      } catch {}
 
-      // メール認証待ちページへリダイレクト
-      router.push(`/auth/verify-pending?email=${encodeURIComponent(formData.email)}`);
-      return;
-    } catch (error) {
-      const debugInfo = extractDebugInfo(error);
+      router.replace(data.redirect || '/register/worker/thanks');
+    } catch (err) {
+      const info = extractDebugInfo(err);
       showDebugError({
-        type: 'save',
-        operation: 'ワーカー新規登録',
-        message: debugInfo.message,
-        details: debugInfo.details,
-        stack: debugInfo.stack,
-        context: {
-          email: formData.email,
-        }
+        type: 'other',
+        operation: '会員登録（例外）',
+        message: info.message,
+        details: info.details,
+        stack: info.stack,
       });
-      toast.error(error instanceof Error ? error.message : '登録中にエラーが発生しました');
-    } finally {
+      toast.error('登録中にエラーが発生しました');
       setIsSubmitting(false);
     }
   };
 
-  const handleCancel = () => {
-    if (confirm('入力内容が失われますが、よろしいですか？')) {
-      window.history.back();
-    }
-  };
-
   return (
-    <div className="min-h-screen bg-gray-50 py-8">
-      <div className="max-w-xl mx-auto px-4">
-        <div className="mb-6">
-          <Link href="/job-list" className="inline-flex items-center gap-2 text-primary hover:underline">
-            <ArrowLeft className="w-4 h-4" />
-            戻る
-          </Link>
+    <div className="min-h-screen bg-[#F8FCFE]">
+      <div className="max-w-md mx-auto bg-white min-h-screen relative">
+        {/* ヘッダー */}
+        <div className="bg-gradient-to-br from-[#E8F7FB] via-[#D4F1F9] to-[#E8F0FE] px-5 pt-6 pb-8 text-center">
+          <div className="text-[#2AADCF] font-bold text-lg">タスタス</div>
+          <h1 className="text-xl font-bold text-gray-800 mt-1">あなたの現状を教えてください</h1>
         </div>
 
-        {/* ステップインジケーター */}
-        <div className="flex items-center justify-center mb-8">
-          <div className="flex items-center gap-0">
-            {/* ステップ1 */}
-            <div className="flex items-center">
-              <div className={`w-10 h-10 rounded-full flex items-center justify-center text-sm font-bold ${
-                currentStep === 1 ? 'bg-primary text-white' : currentStep > 1 ? 'bg-green-500 text-white' : 'bg-gray-200 text-gray-500'
-              }`}>
-                {currentStep > 1 ? <Check className="w-5 h-5" /> : '1'}
-              </div>
-              <span className={`ml-2 text-sm font-medium ${currentStep === 1 ? 'text-primary' : 'text-gray-500'}`}>
-                アカウント・基本情報
-              </span>
-            </div>
-            {/* 接続線 */}
-            <div className={`w-12 h-0.5 mx-2 ${currentStep > 1 ? 'bg-green-500' : 'bg-gray-200'}`} />
-            {/* ステップ2 */}
-            <div className="flex items-center">
-              <div className={`w-10 h-10 rounded-full flex items-center justify-center text-sm font-bold ${
-                currentStep === 2 ? 'bg-primary text-white' : 'bg-gray-200 text-gray-500'
-              }`}>
-                2
-              </div>
-              <span className={`ml-2 text-sm font-medium ${currentStep === 2 ? 'text-primary' : 'text-gray-500'}`}>
-                住所・資格
-              </span>
-            </div>
-          </div>
+        {/* プログレスバー */}
+        <div className="flex items-center justify-center gap-2 py-5">
+          {stepSequence.map((_, i) => (
+            <div
+              key={i}
+              className={`w-3 h-3 rounded-full transition-all ${
+                i === stepIndex
+                  ? 'bg-[#2AADCF] scale-125 shadow-[0_2px_8px_rgba(42,173,207,0.3)]'
+                  : i < stepIndex
+                  ? 'bg-[#2AADCF]'
+                  : 'bg-gray-300'
+              }`}
+            />
+          ))}
         </div>
 
-        <div className="bg-white rounded-lg shadow-lg p-8">
-          <h1 className="text-2xl font-bold text-gray-900 mb-2">新規ワーカー登録</h1>
-          <p className="text-gray-600 mb-6">
-            {currentStep === 1
-              ? 'アカウント情報と基本情報を入力してください。'
-              : '住所と保有資格を入力してください。'}
-          </p>
-
-          <form onSubmit={handleSubmit} noValidate>
-            {/* ============ ステップ1: アカウント・基本情報 ============ */}
-            {currentStep === 1 && (
-              <div className="space-y-6">
-                {/* アカウント情報セクション */}
-                <div>
-                  <h2 className="text-lg font-bold text-gray-800 mb-4 pb-2 border-b">アカウント情報</h2>
-                  <div className="space-y-4">
-                    {/* メールアドレス */}
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">
-                        メールアドレス <span className="text-red-500">*</span>
-                      </label>
-                      <input
-                        type="email"
-                        value={formData.email}
-                        onChange={(e) => setFormData({ ...formData, email: e.target.value })}
-                        className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary ${showErrors && !formData.email ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
-                        placeholder="example@email.com"
-                      />
-                      {showErrors && !formData.email && (
-                        <p className="text-red-500 text-xs mt-1">メールアドレスを入力してください</p>
-                      )}
-                    </div>
-                    {/* メールアドレス（確認） */}
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">
-                        メールアドレス（確認） <span className="text-red-500">*</span>
-                      </label>
-                      <input
-                        type="email"
-                        value={formData.emailConfirm}
-                        onChange={(e) => setFormData({ ...formData, emailConfirm: e.target.value })}
-                        className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary ${showErrors && !formData.emailConfirm ? 'border-red-500 bg-red-50' : formData.emailConfirm && formData.email !== formData.emailConfirm ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
-                        placeholder="確認のため再入力"
-                      />
-                      {showErrors && !formData.emailConfirm && (
-                        <p className="text-red-500 text-xs mt-1">メールアドレス（確認）を入力してください</p>
-                      )}
-                      {formData.emailConfirm && formData.email !== formData.emailConfirm && (
-                        <p className="text-red-500 text-xs mt-1">メールアドレスが一致しません</p>
-                      )}
-                      {formData.emailConfirm && formData.email === formData.emailConfirm && (
-                        <p className="text-green-600 text-xs mt-1">✓ 一致しています</p>
-                      )}
-                    </div>
-                    {/* 電話番号（SMS認証） */}
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">
-                        電話番号 <span className="text-red-500">*</span>
-                      </label>
-                      <SmsVerification
-                        phoneNumber={formData.phoneNumber}
-                        onPhoneNumberChange={(value) => {
-                          setFormData({ ...formData, phoneNumber: value });
-                          setPhoneVerificationToken(null);
-                        }}
-                        onVerified={(token) => setPhoneVerificationToken(token)}
-                        showError={showErrors && !formData.phoneNumber}
-                        errorMessage="電話番号を入力してください"
-                        inputClassName={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary ${showErrors && !formData.phoneNumber ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
-                      />
-                    </div>
-                    {/* パスワード */}
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">
-                        パスワード <span className="text-red-500">*</span>
-                      </label>
-                      <input
-                        type="password"
-                        value={formData.password}
-                        onChange={(e) => setFormData({ ...formData, password: e.target.value })}
-                        className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary ${showErrors && !formData.password ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
-                        placeholder="8文字以上"
-                        minLength={8}
-                      />
-                      <p className="text-xs text-gray-500 mt-1">8文字以上で入力してください</p>
-                      {showErrors && !formData.password && (
-                        <p className="text-red-500 text-xs mt-1">パスワードを入力してください</p>
-                      )}
-                    </div>
-                    {/* パスワード（確認） */}
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">
-                        パスワード（確認） <span className="text-red-500">*</span>
-                      </label>
-                      <input
-                        type="password"
-                        value={formData.passwordConfirm}
-                        onChange={(e) => setFormData({ ...formData, passwordConfirm: e.target.value })}
-                        className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary ${showErrors && !formData.passwordConfirm ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
-                        placeholder="パスワードを再入力"
-                        minLength={8}
-                      />
-                      {showErrors && !formData.passwordConfirm && (
-                        <p className="text-red-500 text-xs mt-1">パスワード（確認）を入力してください</p>
-                      )}
-                    </div>
-                  </div>
-                </div>
-
-                {/* 基本情報セクション */}
-                <div>
-                  <h2 className="text-lg font-bold text-gray-800 mb-4 pb-2 border-b">基本情報</h2>
-                  <div className="space-y-4">
-                    {/* 氏名 */}
-                    <div className="grid grid-cols-2 gap-4">
-                      <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-1">
-                          姓 <span className="text-red-500">*</span>
-                        </label>
-                        <NameWithKanaInput
-                          value={formData.lastName}
-                          onChange={(value) => setFormData(prev => ({ ...prev, lastName: value }))}
-                          onKanaChange={(kana) => setFormData(prev => ({ ...prev, lastNameKana: kana }))}
-                          kanaValue={formData.lastNameKana}
-                          className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary ${showErrors && !formData.lastName ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
-                          placeholder="山田"
-                        />
-                        {showErrors && !formData.lastName && (
-                          <p className="text-red-500 text-xs mt-1">姓を入力してください</p>
-                        )}
-                      </div>
-                      <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-1">
-                          名 <span className="text-red-500">*</span>
-                        </label>
-                        <NameWithKanaInput
-                          value={formData.firstName}
-                          onChange={(value) => setFormData(prev => ({ ...prev, firstName: value }))}
-                          onKanaChange={(kana) => setFormData(prev => ({ ...prev, firstNameKana: kana }))}
-                          kanaValue={formData.firstNameKana}
-                          className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary ${showErrors && !formData.firstName ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
-                          placeholder="太郎"
-                        />
-                        {showErrors && !formData.firstName && (
-                          <p className="text-red-500 text-xs mt-1">名を入力してください</p>
-                        )}
-                      </div>
-                    </div>
-                    {/* 氏名カナ */}
-                    <div className="grid grid-cols-2 gap-4">
-                      <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-1">
-                          姓（カナ） <span className="text-red-500">*</span>
-                        </label>
-                        <KatakanaInput
-                          value={formData.lastNameKana}
-                          onChange={(value) => setFormData({ ...formData, lastNameKana: value })}
-                          className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary ${showErrors && !formData.lastNameKana ? 'border-red-500 bg-red-50' : formData.lastNameKana && !isKatakanaOnly(formData.lastNameKana) ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
-                          placeholder="ヤマダ"
-                        />
-                        {showErrors && !formData.lastNameKana && (
-                          <p className="text-red-500 text-xs mt-1">姓（カナ）を入力してください</p>
-                        )}
-                        {formData.lastNameKana && !isKatakanaOnly(formData.lastNameKana) && (
-                          <p className="text-red-500 text-xs mt-1">カタカナで入力してください</p>
-                        )}
-                        <p className="text-xs text-gray-500 mt-1">※漢字入力で自動変換・ひらがなも変換可</p>
-                      </div>
-                      <div>
-                        <label className="block text-sm font-medium text-gray-700 mb-1">
-                          名（カナ） <span className="text-red-500">*</span>
-                        </label>
-                        <KatakanaInput
-                          value={formData.firstNameKana}
-                          onChange={(value) => setFormData({ ...formData, firstNameKana: value })}
-                          className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary ${showErrors && !formData.firstNameKana ? 'border-red-500 bg-red-50' : formData.firstNameKana && !isKatakanaOnly(formData.firstNameKana) ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
-                          placeholder="タロウ"
-                        />
-                        {showErrors && !formData.firstNameKana && (
-                          <p className="text-red-500 text-xs mt-1">名（カナ）を入力してください</p>
-                        )}
-                        {formData.firstNameKana && !isKatakanaOnly(formData.firstNameKana) && (
-                          <p className="text-red-500 text-xs mt-1">カタカナで入力してください</p>
-                        )}
-                        <p className="text-xs text-gray-500 mt-1">※漢字入力で自動変換・ひらがなも変換可</p>
-                      </div>
-                    </div>
-                    {/* 生年月日 */}
-                    <div>
-                      <label className="block text-sm font-medium text-gray-700 mb-1">
-                        生年月日 <span className="text-red-500">*</span>
-                      </label>
-                      <input
-                        type="date"
-                        value={formData.birthDate}
-                        onChange={(e) => setFormData({ ...formData, birthDate: e.target.value })}
-                        className={`w-full px-3 py-2 border rounded-md focus:outline-none focus:ring-2 focus:ring-primary ${showErrors && !formData.birthDate ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
-                      />
-                      {showErrors && !formData.birthDate && (
-                        <p className="text-red-500 text-xs mt-1">生年月日を入力してください</p>
-                      )}
-                    </div>
-                  </div>
-                </div>
-
-                {/* ステップ1ボタン */}
-                <div className="flex justify-end gap-3 pt-4 border-t">
-                  <button
-                    type="button"
-                    onClick={handleCancel}
-                    className="px-6 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 transition-colors"
-                  >
-                    キャンセル
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleNextStep}
-                    className="px-6 py-2 bg-primary hover:bg-primary-dark text-white rounded-md transition-colors font-bold"
-                  >
-                    次へ
-                  </button>
-                </div>
+        {/* ステップコンテンツ */}
+        <div className="px-5 pb-32">
+          {currentStep === '1' && (
+            <StepContainer question="どんな資格をお持ちですか？" hint="複数選択できます">
+              <div className="grid grid-cols-2 gap-2.5">
+                {QUALIFICATION_OPTIONS.map(opt => (
+                  <CardOption
+                    key={opt.value}
+                    label={opt.label}
+                    selected={form.qualifications.includes(opt.value)}
+                    onClick={() => toggleArrayValue('qualifications', opt.value)}
+                  />
+                ))}
               </div>
-            )}
-
-            {/* ============ ステップ2: 住所・資格・同意 ============ */}
-            {currentStep === 2 && (
-              <div className="space-y-6">
-                {/* 住所セクション */}
-                <div>
-                  <h2 className="text-lg font-bold text-gray-800 mb-4 pb-2 border-b">住所</h2>
-                  <AddressSelector
-                    prefecture={formData.prefecture}
-                    city={formData.city}
-                    addressLine={formData.addressLine}
-                    building={formData.building}
-                    postalCode={formData.postalCode}
-                    onChange={(data) => {
-                      setFormData(prev => ({
-                        ...prev,
-                        prefecture: data.prefecture,
-                        city: data.city,
-                        addressLine: data.addressLine || '',
-                        building: data.building || '',
-                        postalCode: data.postalCode || '',
-                      }));
-                    }}
-                    required={true}
-                    showErrors={showErrors}
+              {form.qualifications.includes('その他') && (
+                <div className="mt-3">
+                  <input
+                    type="text"
+                    value={form.qualificationOther}
+                    onChange={e => setField('qualificationOther', e.target.value)}
+                    placeholder="資格名を入力してください"
+                    className="w-full px-4 py-3 border-2 border-gray-200 rounded-[10px] focus:border-[#2AADCF] focus:outline-none"
                   />
                 </div>
+              )}
+            </StepContainer>
+          )}
 
-                {/* 保有資格セクション */}
-                <div>
-                  <h2 className="text-lg font-bold text-gray-800 mb-4 pb-2 border-b">保有資格</h2>
-                  <p className="text-sm text-gray-600 mb-2">
-                    保有している資格にチェックを入れてください。
-                  </p>
-                  <p className="text-sm text-red-600 font-medium mb-4">
-                    ※応募するには会員登録後、資格証明書の写真の提出が必要です
-                  </p>
-                  {showErrors && formData.qualifications.length === 0 && (
-                    <p className="text-red-500 text-xs mb-3">少なくとも1つの資格を選択してください</p>
-                  )}
-                  <div className={`space-y-4 ${showErrors && formData.qualifications.length === 0 ? 'ring-2 ring-red-500 rounded-lg p-3' : ''}`}>
-                    {QUALIFICATION_GROUPS.map((group) => (
-                      <div key={group.name}>
-                        <h4 className="text-sm font-semibold text-gray-700 mb-2">{group.name}</h4>
-                        <div className="grid grid-cols-2 gap-2">
-                          {group.qualifications.map((qual) => (
-                            <label key={qual} className="flex items-center gap-2 cursor-pointer text-sm">
-                              <input
-                                type="checkbox"
-                                checked={formData.qualifications.includes(qual)}
-                                onChange={() => handleQualificationToggle(qual)}
-                                className="w-4 h-4 text-primary border-gray-300 rounded focus:ring-primary"
-                              />
-                              <span>{qual}</span>
-                            </label>
-                          ))}
-                        </div>
-                      </div>
-                    ))}
+          {currentStep === '2' && (
+            <StepContainer question="希望の働き方" hint="複数選択できます">
+              <div className="grid grid-cols-2 gap-2.5">
+                {DESIRED_WORK_STYLE_OPTIONS.map(opt => (
+                  <CardOption
+                    key={opt}
+                    label={opt}
+                    selected={form.desiredWorkStyle.includes(opt)}
+                    onClick={() => toggleArrayValue('desiredWorkStyle', opt)}
+                  />
+                ))}
+              </div>
+            </StepContainer>
+          )}
+
+          {currentStep === '2b' && (
+            <StepContainer question="どのくらい働きたいですか？">
+              <div className="grid grid-cols-2 gap-2.5">
+                {WORK_FREQUENCY_OPTIONS.map(opt => (
+                  <CardOption
+                    key={opt}
+                    label={opt}
+                    selected={form.workFrequency === opt}
+                    onClick={() => setField('workFrequency', opt)}
+                  />
+                ))}
+                {form.desiredWorkStyle.includes('単発・スポット') && (
+                  <CardOption
+                    label="不定期/決まっていない"
+                    fullWidth
+                    selected={form.workFrequency === '不定期/決まっていない'}
+                    onClick={() => setField('workFrequency', '不定期/決まっていない')}
+                  />
+                )}
+              </div>
+            </StepContainer>
+          )}
+
+          {currentStep === '3' && (
+            <StepContainer question="いつ頃の求人をお探しですか？">
+              <div className="grid grid-cols-2 gap-2.5">
+                {JOB_TIMING_OPTIONS.map(opt => (
+                  <CardOption
+                    key={opt}
+                    label={opt}
+                    selected={form.jobTiming === opt}
+                    onClick={() => setField('jobTiming', opt)}
+                  />
+                ))}
+              </div>
+            </StepContainer>
+          )}
+
+          {currentStep === '4' && (
+            <StepContainer question="お仕事のご状況">
+              <div className="grid grid-cols-2 gap-2.5">
+                {EMPLOYMENT_STATUS_OPTIONS.map(opt => (
+                  <CardOption
+                    key={opt}
+                    label={opt}
+                    selected={form.employmentStatus === opt}
+                    onClick={() => setField('employmentStatus', opt)}
+                  />
+                ))}
+              </div>
+            </StepContainer>
+          )}
+
+          {currentStep === '5' && (
+            <StepContainer question="お住まいの地域">
+              <FieldLabel required>郵便番号</FieldLabel>
+              <input
+                type="tel"
+                inputMode="numeric"
+                maxLength={8}
+                value={form.postalCode}
+                onChange={e => {
+                  const v = e.target.value;
+                  setField('postalCode', v);
+                  if (v.replace(/[^0-9]/g, '').length === 7) {
+                    handlePostalLookup(v);
+                  }
+                }}
+                placeholder="例：1500022"
+                className="w-full px-4 py-3 border-2 border-gray-200 rounded-[10px] focus:border-[#2AADCF] focus:outline-none"
+              />
+              {isLoadingAddress && <p className="text-xs text-gray-500 mt-1">住所を取得中...</p>}
+              {form.prefecture && (
+                <div className="mt-4 space-y-3">
+                  <div>
+                    <FieldLabel>都道府県</FieldLabel>
+                    <input
+                      type="text"
+                      readOnly
+                      value={form.prefecture}
+                      className="w-full px-4 py-3 border-2 border-gray-200 rounded-[10px] bg-gray-50"
+                    />
+                  </div>
+                  <div>
+                    <FieldLabel>市区町村</FieldLabel>
+                    <input
+                      type="text"
+                      readOnly
+                      value={form.city}
+                      className="w-full px-4 py-3 border-2 border-gray-200 rounded-[10px] bg-gray-50"
+                    />
                   </div>
                 </div>
+              )}
+            </StepContainer>
+          )}
 
-                {/* 利用規約・プライバシーポリシー同意 */}
-                <div id="terms-section" className={`p-4 bg-gray-50 rounded-lg border ${showErrors && (!agreedToTerms || !agreedToPrivacy) ? 'border-red-500' : 'border-gray-200'}`}>
-                  <div className="space-y-4">
-                    {/* 利用規約 */}
-                    <div className="space-y-2">
-                      <button
-                        type="button"
-                        onClick={() => setShowTermsModal(true)}
-                        className="text-primary hover:underline text-sm font-medium"
-                      >
-                        利用規約を確認する
-                      </button>
-                      <label className="flex items-start gap-3 cursor-pointer p-3 bg-white rounded-lg border border-gray-200">
-                        <input
-                          type="checkbox"
-                          checked={agreedToTerms}
-                          onChange={(e) => setAgreedToTerms(e.target.checked)}
-                          className="w-5 h-5 text-primary border-gray-300 rounded focus:ring-primary mt-0.5"
-                        />
-                        <span className="text-sm">
-                          <span className="font-medium">利用規約に同意します</span>
-                          <span className="text-red-500 ml-1">*</span>
-                          {termsLastUpdated && (
-                          <span className="text-gray-500 block text-xs mt-1">
-                            （最終更新日: {termsLastUpdated}）
-                          </span>
-                        )}
-                        </span>
-                      </label>
-                      {showErrors && !agreedToTerms && (
-                        <p className="text-red-500 text-xs">利用規約に同意してください</p>
-                      )}
-                    </div>
-
-                    {/* プライバシーポリシー */}
-                    <div className="space-y-2">
-                      <button
-                        type="button"
-                        onClick={() => setShowPrivacyModal(true)}
-                        className="text-primary hover:underline text-sm font-medium"
-                      >
-                        プライバシーポリシーを確認する
-                      </button>
-                      <label className="flex items-start gap-3 cursor-pointer p-3 bg-white rounded-lg border border-gray-200">
-                        <input
-                          type="checkbox"
-                          checked={agreedToPrivacy}
-                          onChange={(e) => setAgreedToPrivacy(e.target.checked)}
-                          className="w-5 h-5 text-primary border-gray-300 rounded focus:ring-primary mt-0.5"
-                        />
-                        <span className="text-sm">
-                          <span className="font-medium">プライバシーポリシーに同意します</span>
-                          <span className="text-red-500 ml-1">*</span>
-                          {privacyLastUpdated && (
-                          <span className="text-gray-500 block text-xs mt-1">
-                            （最終更新日: {privacyLastUpdated}）
-                          </span>
-                        )}
-                        </span>
-                      </label>
-                      {showErrors && !agreedToPrivacy && (
-                        <p className="text-red-500 text-xs">プライバシーポリシーに同意してください</p>
-                      )}
-                    </div>
-                  </div>
-                </div>
-
-                {/* 案内文 */}
-                <div className="p-4 bg-blue-50 rounded-lg border border-blue-200">
-                  <p className="text-sm text-blue-800">
-                    登録後、求人に応募する際には追加の情報（緊急連絡先、銀行口座、身分証明書、資格証明書など）が必要です。マイページからいつでも入力できます。
-                  </p>
-                </div>
-
-                {/* ステップ2ボタン */}
-                <div className="flex justify-end gap-3 pt-4 border-t">
-                  <button
-                    type="button"
-                    onClick={handlePrevStep}
-                    className="px-6 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 transition-colors"
-                  >
-                    戻る
-                  </button>
-                  <button
-                    type="submit"
-                    disabled={isSubmitting}
-                    className="px-6 py-2 bg-primary hover:bg-primary-dark text-white rounded-md transition-colors font-bold disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2 min-w-[100px]"
-                  >
-                    {isSubmitting && <LoadingSpinner size="sm" color="white" />}
-                    {isSubmitting ? '登録中...' : '登録する'}
-                  </button>
+          {currentStep === '6' && (
+            <StepContainer question="性別・生年月日">
+              <div className="mb-5">
+                <FieldLabel required>性別</FieldLabel>
+                <div className="grid grid-cols-2 gap-2.5">
+                  {['男性', '女性'].map(g => (
+                    <CardOption
+                      key={g}
+                      label={g}
+                      selected={form.gender === g}
+                      onClick={() => setField('gender', g)}
+                    />
+                  ))}
                 </div>
               </div>
-            )}
-          </form>
+              <FieldLabel required>生年月日</FieldLabel>
+              <div className="flex gap-2">
+                <select
+                  value={form.birthYear}
+                  onChange={e => setField('birthYear', e.target.value)}
+                  className="flex-1 px-3 py-3 border-2 border-gray-200 rounded-[10px] focus:border-[#2AADCF] focus:outline-none"
+                >
+                  <option value="">年</option>
+                  {Array.from({ length: 2008 - 1950 + 1 }, (_, i) => 2008 - i).map(y => (
+                    <option key={y} value={y}>{y}年</option>
+                  ))}
+                </select>
+                <select
+                  value={form.birthMonth}
+                  onChange={e => setField('birthMonth', e.target.value)}
+                  className="flex-1 px-3 py-3 border-2 border-gray-200 rounded-[10px] focus:border-[#2AADCF] focus:outline-none"
+                >
+                  <option value="">月</option>
+                  {Array.from({ length: 12 }, (_, i) => i + 1).map(m => (
+                    <option key={m} value={m}>{m}月</option>
+                  ))}
+                </select>
+                <select
+                  value={form.birthDay}
+                  onChange={e => setField('birthDay', e.target.value)}
+                  className="flex-1 px-3 py-3 border-2 border-gray-200 rounded-[10px] focus:border-[#2AADCF] focus:outline-none"
+                >
+                  <option value="">日</option>
+                  {Array.from({ length: 31 }, (_, i) => i + 1).map(d => (
+                    <option key={d} value={d}>{d}日</option>
+                  ))}
+                </select>
+              </div>
+            </StepContainer>
+          )}
+
+          {currentStep === '7' && (
+            <StepContainer question="おなまえ">
+              <div className="mb-4">
+                <FieldLabel required>姓</FieldLabel>
+                <input
+                  type="text"
+                  value={form.lastName}
+                  onChange={e => setField('lastName', e.target.value)}
+                  placeholder="例：山田"
+                  className="w-full px-4 py-3 border-2 border-gray-200 rounded-[10px] focus:border-[#2AADCF] focus:outline-none"
+                />
+              </div>
+              <div className="mb-4">
+                <FieldLabel required>名</FieldLabel>
+                <input
+                  type="text"
+                  value={form.firstName}
+                  onChange={e => setField('firstName', e.target.value)}
+                  placeholder="例：花子"
+                  className="w-full px-4 py-3 border-2 border-gray-200 rounded-[10px] focus:border-[#2AADCF] focus:outline-none"
+                />
+              </div>
+              <div className="mb-4">
+                <FieldLabel required>せい（カナ）</FieldLabel>
+                <input
+                  type="text"
+                  value={form.lastNameKana}
+                  onChange={e => setField('lastNameKana', e.target.value)}
+                  placeholder="例：ヤマダ"
+                  className="w-full px-4 py-3 border-2 border-gray-200 rounded-[10px] focus:border-[#2AADCF] focus:outline-none"
+                />
+              </div>
+              <div>
+                <FieldLabel required>めい（カナ）</FieldLabel>
+                <input
+                  type="text"
+                  value={form.firstNameKana}
+                  onChange={e => setField('firstNameKana', e.target.value)}
+                  placeholder="例：ハナコ"
+                  className="w-full px-4 py-3 border-2 border-gray-200 rounded-[10px] focus:border-[#2AADCF] focus:outline-none"
+                />
+              </div>
+            </StepContainer>
+          )}
+
+          {currentStep === '8' && (
+            <StepContainer question="ご連絡先・パスワード">
+              <div className="mb-4">
+                <FieldLabel required>電話番号（SMS認証が必要です）</FieldLabel>
+                <SmsVerification
+                  phoneNumber={form.phoneNumber}
+                  onPhoneNumberChange={v => {
+                    // 電話番号を変更したら既存の認証トークンを破棄（未認証状態に戻す）
+                    setField('phoneNumber', v);
+                    setPhoneVerificationToken(null);
+                  }}
+                  onVerified={token => setPhoneVerificationToken(token)}
+                />
+              </div>
+              <div className="mb-4">
+                <FieldLabel required>メールアドレス</FieldLabel>
+                <input
+                  type="email"
+                  value={form.email}
+                  onChange={e => setField('email', e.target.value)}
+                  placeholder="例：example@mail.com"
+                  className="w-full px-4 py-3 border-2 border-gray-200 rounded-[10px] focus:border-[#2AADCF] focus:outline-none"
+                />
+              </div>
+              <div className="mb-4">
+                <FieldLabel required>パスワード（8文字以上）</FieldLabel>
+                <input
+                  type="password"
+                  value={form.password}
+                  onChange={e => setField('password', e.target.value)}
+                  placeholder="8文字以上"
+                  className="w-full px-4 py-3 border-2 border-gray-200 rounded-[10px] focus:border-[#2AADCF] focus:outline-none"
+                />
+              </div>
+              <div className="space-y-2 mt-6">
+                <label className="flex items-start gap-2 text-sm cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={agreedToTerms}
+                    onChange={e => setAgreedToTerms(e.target.checked)}
+                    className="mt-0.5"
+                  />
+                  <span>
+                    <button
+                      type="button"
+                      onClick={() => setShowTermsModal(true)}
+                      className="text-[#2AADCF] underline"
+                    >
+                      利用規約
+                    </button>
+                    に同意する
+                  </span>
+                </label>
+                <label className="flex items-start gap-2 text-sm cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={agreedToPrivacy}
+                    onChange={e => setAgreedToPrivacy(e.target.checked)}
+                    className="mt-0.5"
+                  />
+                  <span>
+                    <button
+                      type="button"
+                      onClick={() => setShowPrivacyModal(true)}
+                      className="text-[#2AADCF] underline"
+                    >
+                      プライバシーポリシー
+                    </button>
+                    に同意する
+                  </span>
+                </label>
+              </div>
+              <div className="flex justify-center gap-4 mt-6 text-xs text-gray-500">
+                <span>🔒 SSL暗号化通信</span>
+                <span>🛡️ 個人情報保護</span>
+              </div>
+            </StepContainer>
+          )}
         </div>
+
+        {/* フッターナビ */}
+        <div className="fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-md bg-[#F0F3F5] p-4 flex gap-3 items-center z-50" style={{ paddingBottom: 'max(16px, env(safe-area-inset-bottom))' }}>
+          {currentStep !== '1' && (
+            <button
+              type="button"
+              onClick={goBack}
+              className="w-14 h-14 flex-shrink-0 rounded-full border-2 border-[#2AADCF] text-[#2AADCF] bg-white flex items-center justify-center text-xl"
+              disabled={isSubmitting}
+            >
+              ←
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={goNext}
+            disabled={!isStepValid() || isSubmitting}
+            className={`flex-1 py-4 rounded-full font-semibold text-white shadow-[0_4px_16px_rgba(42,173,207,0.3)] transition-all ${
+              isStepValid() && !isSubmitting
+                ? 'bg-[#2AADCF] hover:bg-[#1A8FAD]'
+                : 'bg-[#C8E4ED] cursor-not-allowed'
+            }`}
+          >
+            {isSubmitting
+              ? '送信中...'
+              : currentStep === '8'
+              ? '利用規約・プライバシーポリシーに同意して登録'
+              : '次へ'}
+          </button>
+        </div>
+
+        {/* 利用規約モーダル */}
+        {showTermsModal && (
+          <LegalModal
+            title="利用規約"
+            content={termsContent}
+            onClose={() => setShowTermsModal(false)}
+          />
+        )}
+        {showPrivacyModal && (
+          <LegalModal
+            title="プライバシーポリシー"
+            content={privacyContent}
+            onClose={() => setShowPrivacyModal(false)}
+          />
+        )}
       </div>
+    </div>
+  );
+}
 
-      {/* 利用規約モーダル */}
-      {showTermsModal && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-lg max-w-2xl w-full max-h-[80vh] flex flex-col">
-            <div className="flex items-center justify-between p-4 border-b">
-              <h2 className="text-lg font-bold">利用規約</h2>
-              <button
-                type="button"
-                onClick={() => setShowTermsModal(false)}
-                className="p-2 hover:bg-gray-100 rounded-full transition-colors"
-                aria-label="閉じる"
-              >
-                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                </svg>
-              </button>
-            </div>
-            <div className="flex-1 overflow-y-auto p-4">
-              {termsLastUpdated && <p className="text-xs text-gray-500 mb-4">最終更新日: {termsLastUpdated}</p>}
-              {isLoadingLegal ? (
-                <p className="text-sm text-gray-500">読み込み中...</p>
-              ) : termsContent ? (
-                <div
-                  className="prose prose-sm max-w-none prose-h2:text-base prose-h2:font-bold prose-h2:text-gray-900 prose-h2:mt-6 prose-h2:mb-3 prose-p:text-gray-700 prose-p:leading-relaxed prose-p:my-2 prose-ul:my-2 prose-li:text-gray-700"
-                  dangerouslySetInnerHTML={{ __html: termsContent }}
-                />
-              ) : (
-                <p className="text-sm text-gray-500">利用規約を読み込めませんでした。</p>
-              )}
-            </div>
-            <div className="p-4 border-t flex justify-end gap-3">
-              <button
-                type="button"
-                onClick={() => setShowTermsModal(false)}
-                className="px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 transition-colors"
-              >
-                閉じる
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  setAgreedToTerms(true);
-                  setShowTermsModal(false);
-                }}
-                className="px-4 py-2 bg-primary text-white rounded-md hover:bg-primary-dark transition-colors"
-              >
-                同意して閉じる
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+// --- 共通コンポーネント ---
 
-      {/* プライバシーポリシーモーダル */}
-      {showPrivacyModal && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-lg max-w-2xl w-full max-h-[80vh] flex flex-col">
-            <div className="flex items-center justify-between p-4 border-b">
-              <h2 className="text-lg font-bold">プライバシーポリシー</h2>
-              <button
-                type="button"
-                onClick={() => setShowPrivacyModal(false)}
-                className="p-2 hover:bg-gray-100 rounded-full transition-colors"
-                aria-label="閉じる"
-              >
-                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                </svg>
-              </button>
-            </div>
-            <div className="flex-1 overflow-y-auto p-4">
-              {privacyLastUpdated && <p className="text-xs text-gray-500 mb-4">最終更新日: {privacyLastUpdated}</p>}
-              {isLoadingLegal ? (
-                <p className="text-sm text-gray-500">読み込み中...</p>
-              ) : privacyContent ? (
-                <div
-                  className="prose prose-sm max-w-none prose-h2:text-base prose-h2:font-bold prose-h2:text-gray-900 prose-h2:mt-6 prose-h2:mb-3 prose-p:text-gray-700 prose-p:leading-relaxed prose-p:my-2 prose-ul:my-2 prose-li:text-gray-700"
-                  dangerouslySetInnerHTML={{ __html: privacyContent }}
-                />
-              ) : (
-                <p className="text-sm text-gray-500">プライバシーポリシーを読み込めませんでした。</p>
-              )}
-            </div>
-            <div className="p-4 border-t flex justify-end gap-3">
-              <button
-                type="button"
-                onClick={() => setShowPrivacyModal(false)}
-                className="px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 transition-colors"
-              >
-                閉じる
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  setAgreedToPrivacy(true);
-                  setShowPrivacyModal(false);
-                }}
-                className="px-4 py-2 bg-primary text-white rounded-md hover:bg-primary-dark transition-colors"
-              >
-                同意して閉じる
-              </button>
-            </div>
-          </div>
-        </div>
+function StepContainer({
+  question,
+  hint,
+  children,
+}: {
+  question: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <h2 className="text-lg font-bold text-gray-800 mb-5 text-center leading-relaxed">{question}</h2>
+      {hint && <p className="text-xs text-gray-500 text-center mb-4">{hint}</p>}
+      {children}
+    </div>
+  );
+}
+
+function CardOption({
+  label,
+  selected,
+  onClick,
+  fullWidth = false,
+}: {
+  label: string;
+  selected: boolean;
+  onClick: () => void;
+  fullWidth?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex items-center justify-center text-center p-4 min-h-[72px] rounded-2xl transition-all select-none ${
+        fullWidth ? 'col-span-2' : ''
+      } ${
+        selected
+          ? 'bg-[#2AADCF] text-white shadow-[0_4px_16px_rgba(42,173,207,0.35)]'
+          : 'bg-gray-100 text-gray-800'
+      } active:scale-95`}
+    >
+      <span className="text-sm font-semibold leading-snug whitespace-pre-line">{label}</span>
+    </button>
+  );
+}
+
+function FieldLabel({
+  children,
+  required = false,
+}: {
+  children: React.ReactNode;
+  required?: boolean;
+}) {
+  return (
+    <div className="text-sm font-semibold text-gray-800 mb-2 flex items-center gap-2">
+      {children}
+      {required && (
+        <span className="text-[10px] bg-[#FF6B8A] text-white px-2 py-0.5 rounded font-semibold">必須</span>
       )}
+    </div>
+  );
+}
+
+function LegalModal({
+  title,
+  content,
+  onClose,
+}: {
+  title: string;
+  content: string;
+  onClose: () => void;
+}) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 z-[100] flex items-end justify-center"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="legal-modal-title"
+    >
+      <div
+        className="bg-white w-full max-w-md rounded-t-3xl p-6 max-h-[80vh] overflow-y-auto"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <h3 id="legal-modal-title" className="text-lg font-bold">{title}</h3>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-gray-400 text-2xl leading-none px-2"
+            aria-label="閉じる"
+          >
+            ×
+          </button>
+        </div>
+        <div
+          className="prose prose-sm max-w-none"
+          dangerouslySetInnerHTML={{ __html: content || '<p>読み込み中...</p>' }}
+        />
+      </div>
     </div>
   );
 }

--- a/app/register/worker/thanks/ThanksClient.tsx
+++ b/app/register/worker/thanks/ThanksClient.tsx
@@ -55,27 +55,20 @@ export default function ThanksClient({ userName, lineUrl }: Props) {
                   } catch {}
                 }}
               >
-                📲 LINEで相談する
+                📲 公式LINEに登録
               </a>
             ) : null}
 
             <Link
-              href="/job-list"
-              className="py-3 px-6 rounded-full text-sm font-medium text-gray-500 border border-gray-200 bg-white"
+              href="/"
+              className="py-3 px-6 rounded-full text-sm font-medium text-gray-700 border border-gray-200 bg-white"
               onClick={() => {
                 try {
                   trackGA4Event('worker_register_thanks_jobs_click', {});
                 } catch {}
               }}
             >
-              求人ページはこちら
-            </Link>
-
-            <Link
-              href="/mypage"
-              className="py-3 px-6 rounded-full text-sm font-medium text-[#2AADCF] underline"
-            >
-              マイページへ移動
+              お仕事一覧
             </Link>
           </div>
         </div>

--- a/app/register/worker/thanks/ThanksClient.tsx
+++ b/app/register/worker/thanks/ThanksClient.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { useEffect } from 'react';
+import Link from 'next/link';
+import { trackGA4Event } from '@/src/lib/ga4-events';
+
+interface Props {
+  userName: string;
+  lineUrl: string;
+}
+
+export default function ThanksClient({ userName, lineUrl }: Props) {
+  useEffect(() => {
+    try {
+      trackGA4Event('worker_register_thanks_view', {});
+    } catch {
+      // noop
+    }
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-[#F8FCFE]">
+      <div className="max-w-md mx-auto bg-white min-h-screen">
+        <div className="bg-gradient-to-br from-[#E8F7FB] via-[#D4F1F9] to-[#E8F0FE] px-5 pt-6 pb-8 text-center">
+          <div className="text-[#2AADCF] font-bold text-lg">タスタス</div>
+          <h1 className="text-xl font-bold text-gray-800 mt-1">登録完了</h1>
+        </div>
+
+        <div className="px-5 py-10 text-center">
+          <div className="mx-auto mb-5 w-20 h-20 rounded-full bg-gradient-to-br from-[#E8F7FB] to-[#D4F1F9] flex items-center justify-center text-3xl">
+            🎉
+          </div>
+          <h2 className="text-xl font-bold text-gray-800 mb-2">
+            会員登録が完了しました！
+          </h2>
+          <p className="text-sm text-gray-500 leading-relaxed mb-8">
+            {userName ? `${userName} さん、ありがとうございます。` : ''}
+            <br />
+            LINE登録者限定で、
+            <br />
+            ご希望に合った施設をお探しいたします！
+          </p>
+
+          <div className="flex flex-col gap-3 max-w-xs mx-auto">
+            {lineUrl ? (
+              <a
+                href={lineUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="py-4 px-6 rounded-full text-lg font-bold text-white shadow-[0_6px_24px_rgba(6,199,85,0.35)]"
+                style={{ background: 'linear-gradient(135deg,#06C755 0%,#05B34C 100%)' }}
+                onClick={() => {
+                  try {
+                    trackGA4Event('worker_register_thanks_line_click', {});
+                  } catch {}
+                }}
+              >
+                📲 LINEで相談する
+              </a>
+            ) : null}
+
+            <Link
+              href="/job-list"
+              className="py-3 px-6 rounded-full text-sm font-medium text-gray-500 border border-gray-200 bg-white"
+              onClick={() => {
+                try {
+                  trackGA4Event('worker_register_thanks_jobs_click', {});
+                } catch {}
+              }}
+            >
+              求人ページはこちら
+            </Link>
+
+            <Link
+              href="/mypage"
+              className="py-3 px-6 rounded-full text-sm font-medium text-[#2AADCF] underline"
+            >
+              マイページへ移動
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/register/worker/thanks/page.tsx
+++ b/app/register/worker/thanks/page.tsx
@@ -7,23 +7,37 @@ import ThanksClient from './ThanksClient';
 export const dynamic = 'force-dynamic';
 
 /**
- * 登録 LP の cta_url を取得。ユーザーの registration_lp_id から
- * LandingPage.cta_url を引く（環境変数に依存しない）
+ * LINE 友だち追加 URL を取得。優先順位:
+ * 1. 登録時の LP (user.registration_lp_id) の LandingPage.cta_url
+ * 2. LpLineTag の is_default=true のエントリの URL
+ * 3. 空文字（LINE ボタン非表示）
+ * 環境変数に依存しない。DB 側は LP 管理画面 / LINE タグ管理画面から設定可能
  */
 async function resolveLineUrlForUser(userId: number): Promise<string> {
   try {
+    // 1. 登録 LP の cta_url
     const user = await prisma.user.findUnique({
       where: { id: userId },
       select: { registration_lp_id: true },
     });
-    if (!user?.registration_lp_id) return '';
-    const lpNum = parseInt(user.registration_lp_id, 10);
-    if (isNaN(lpNum)) return '';
-    const lp = await prisma.landingPage.findUnique({
-      where: { lp_number: lpNum },
-      select: { cta_url: true },
+    if (user?.registration_lp_id) {
+      const lpNum = parseInt(user.registration_lp_id, 10);
+      if (!isNaN(lpNum)) {
+        const lp = await prisma.landingPage.findUnique({
+          where: { lp_number: lpNum },
+          select: { cta_url: true },
+        });
+        if (lp?.cta_url) return lp.cta_url;
+      }
+    }
+
+    // 2. フォールバック: デフォルト LINE タグ（複数 is_default=true があっても安定選択）
+    const defaultTag = await prisma.lpLineTag.findFirst({
+      where: { is_default: true },
+      orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
+      select: { url: true },
     });
-    return lp?.cta_url ?? '';
+    return defaultTag?.url ?? '';
   } catch (e) {
     console.error('[thanks] Failed to resolve LINE URL:', e);
     return '';

--- a/app/register/worker/thanks/page.tsx
+++ b/app/register/worker/thanks/page.tsx
@@ -1,0 +1,18 @@
+import { redirect } from 'next/navigation';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import ThanksClient from './ThanksClient';
+
+export const dynamic = 'force-dynamic';
+
+export default async function RegisterThanksPage() {
+  const session = await getServerSession(authOptions);
+  if (!session?.user) {
+    // 登録完了を経ずに直接アクセスされた場合のフォールバック
+    redirect('/login');
+  }
+
+  const lineUrl = process.env.NEXT_PUBLIC_REGISTER_LINE_URL || '';
+
+  return <ThanksClient userName={session.user.name ?? ''} lineUrl={lineUrl} />;
+}

--- a/app/register/worker/thanks/page.tsx
+++ b/app/register/worker/thanks/page.tsx
@@ -1,18 +1,44 @@
 import { redirect } from 'next/navigation';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
+import prisma from '@/lib/prisma';
 import ThanksClient from './ThanksClient';
 
 export const dynamic = 'force-dynamic';
 
+/**
+ * 登録 LP の cta_url を取得。ユーザーの registration_lp_id から
+ * LandingPage.cta_url を引く（環境変数に依存しない）
+ */
+async function resolveLineUrlForUser(userId: number): Promise<string> {
+  try {
+    const user = await prisma.user.findUnique({
+      where: { id: userId },
+      select: { registration_lp_id: true },
+    });
+    if (!user?.registration_lp_id) return '';
+    const lpNum = parseInt(user.registration_lp_id, 10);
+    if (isNaN(lpNum)) return '';
+    const lp = await prisma.landingPage.findUnique({
+      where: { lp_number: lpNum },
+      select: { cta_url: true },
+    });
+    return lp?.cta_url ?? '';
+  } catch (e) {
+    console.error('[thanks] Failed to resolve LINE URL:', e);
+    return '';
+  }
+}
+
 export default async function RegisterThanksPage() {
   const session = await getServerSession(authOptions);
-  if (!session?.user) {
+  if (!session?.user?.id) {
     // 登録完了を経ずに直接アクセスされた場合のフォールバック
     redirect('/login');
   }
 
-  const lineUrl = process.env.NEXT_PUBLIC_REGISTER_LINE_URL || '';
+  const userId = parseInt(session.user.id, 10);
+  const lineUrl = await resolveLineUrlForUser(userId);
 
   return <ThanksClient userName={session.user.name ?? ''} lineUrl={lineUrl} />;
 }

--- a/app/system-admin/dev-portal/delete-worker/page.tsx
+++ b/app/system-admin/dev-portal/delete-worker/page.tsx
@@ -8,20 +8,26 @@ import { deleteWorkerCompletely, DeleteWorkerResult } from '@/src/lib/actions/de
 export default function DeleteWorkerPage() {
   const [identifier, setIdentifier] = useState('');
   const [confirmText, setConfirmText] = useState('');
+  const [forceMode, setForceMode] = useState(false);
+  const [forceConfirmText, setForceConfirmText] = useState('');
   const [result, setResult] = useState<DeleteWorkerResult | null>(null);
   const [isPending, startTransition] = useTransition();
 
-  const canSubmit = identifier.trim() !== '' && confirmText === '削除する' && !isPending;
+  const baseValid = identifier.trim() !== '' && confirmText === '削除する';
+  const forceValid = !forceMode || forceConfirmText === '強制削除';
+  const canSubmit = baseValid && forceValid && !isPending;
 
   const handleSubmit = () => {
     if (!canSubmit) return;
     setResult(null);
     startTransition(async () => {
-      const res = await deleteWorkerCompletely(identifier.trim());
+      const res = await deleteWorkerCompletely(identifier.trim(), { force: forceMode });
       setResult(res);
       if (res.success) {
         setIdentifier('');
         setConfirmText('');
+        setForceMode(false);
+        setForceConfirmText('');
       }
     });
   };
@@ -91,6 +97,45 @@ export default function DeleteWorkerPage() {
             />
           </div>
 
+          {/* 強制削除オプション */}
+          <div className="border border-orange-300 rounded-md bg-orange-50 p-4">
+            <label className="flex items-start gap-2 cursor-pointer">
+              <input
+                id="force-delete"
+                type="checkbox"
+                checked={forceMode}
+                onChange={(e) => setForceMode(e.target.checked)}
+                disabled={isPending}
+                className="mt-1 w-4 h-4 accent-orange-600"
+              />
+              <div className="flex-1">
+                <span className="font-semibold text-orange-900 text-sm">
+                  強制削除モード（進行中業務のブロックをバイパス）
+                </span>
+                <p className="text-xs text-orange-800 mt-1 leading-relaxed">
+                  APPLIED/SCHEDULED/WORKING/COMPLETED_PENDING の応募や未応答オファーがある場合でも削除を強行します。
+                  施設側の業務履歴からテストデータが消える可能性あり。
+                  <strong>未退勤の勤怠は強制モードでもブロックされます。</strong>
+                </p>
+              </div>
+            </label>
+            {forceMode && (
+              <div className="mt-3 pl-6">
+                <label className="block text-xs font-medium text-orange-900 mb-1">
+                  追加確認: 「<strong>強制削除</strong>」と入力
+                </label>
+                <input
+                  type="text"
+                  value={forceConfirmText}
+                  onChange={(e) => setForceConfirmText(e.target.value)}
+                  disabled={isPending}
+                  placeholder="強制削除"
+                  className="w-full px-3 py-2 border border-orange-400 rounded-md focus:outline-none focus:ring-2 focus:ring-orange-500 text-sm"
+                />
+              </div>
+            )}
+          </div>
+
           <button
             type="button"
             onClick={handleSubmit}
@@ -105,7 +150,7 @@ export default function DeleteWorkerPage() {
             ) : (
               <>
                 <Trash2 className="w-5 h-5" />
-                完全削除を実行
+                {forceMode ? '強制削除を実行' : '完全削除を実行'}
               </>
             )}
           </button>
@@ -148,6 +193,9 @@ export default function DeleteWorkerPage() {
                         </li>
                         <li>
                           Facility 評価再計算: {result.counts.facilityRatingsRecalculated} 件
+                        </li>
+                        <li>
+                          労働条件通知書トークン削除: {result.counts.laborDocTokensDeleted} 件
                         </li>
                       </ul>
                     )}

--- a/app/system-admin/dev-portal/delete-worker/page.tsx
+++ b/app/system-admin/dev-portal/delete-worker/page.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import { useState, useTransition } from 'react';
+import Link from 'next/link';
+import { ArrowLeft, AlertTriangle, Loader2, Trash2, CheckCircle2 } from 'lucide-react';
+import { deleteWorkerCompletely, DeleteWorkerResult } from '@/src/lib/actions/dev-user-delete';
+
+export default function DeleteWorkerPage() {
+  const [identifier, setIdentifier] = useState('');
+  const [confirmText, setConfirmText] = useState('');
+  const [result, setResult] = useState<DeleteWorkerResult | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const canSubmit = identifier.trim() !== '' && confirmText === '削除する' && !isPending;
+
+  const handleSubmit = () => {
+    if (!canSubmit) return;
+    setResult(null);
+    startTransition(async () => {
+      const res = await deleteWorkerCompletely(identifier.trim());
+      setResult(res);
+      if (res.success) {
+        setIdentifier('');
+        setConfirmText('');
+      }
+    });
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto p-6">
+      <div className="mb-6">
+        <Link
+          href="/system-admin/dev-portal"
+          className="inline-flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          開発者ポータルに戻る
+        </Link>
+      </div>
+
+      <div className="bg-white rounded-lg shadow p-6">
+        <div className="flex items-center gap-2 mb-2">
+          <Trash2 className="w-6 h-6 text-red-600" />
+          <h1 className="text-2xl font-bold">ワーカー完全削除（開発・テスト用）</h1>
+        </div>
+        <p className="text-sm text-gray-600 mb-6">
+          指定したワーカーユーザーと、それに紐付く応募・ブックマーク・メッセージ・プッシュ通知登録・出退勤・銀行口座などのデータを<strong>完全に削除</strong>します。
+        </p>
+
+        <div className="bg-red-50 border border-red-200 rounded-md p-4 mb-6">
+          <div className="flex gap-3">
+            <AlertTriangle className="w-5 h-5 text-red-600 flex-shrink-0 mt-0.5" />
+            <div className="text-sm text-red-800">
+              <p className="font-bold mb-2">⚠️ 重要な注意事項</p>
+              <ul className="list-disc pl-5 space-y-1">
+                <li>この操作は<strong>不可逆</strong>です。削除後の復元はできません。</li>
+                <li>対象ユーザーのオファー求人の <code className="bg-red-100 px-1 rounded">target_worker_id</code> は null にリセットされます（求人自体は削除されません）。</li>
+                <li>操作ログ（UserActivityLog）は履歴保持のため残存します。</li>
+                <li>本番環境では <code className="bg-red-100 px-1 rounded">ALLOW_DEV_USER_DELETE=true</code> が設定されていないと実行できません。</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium mb-1">
+              対象ユーザー（メールアドレス または ユーザーID）
+            </label>
+            <input
+              type="text"
+              value={identifier}
+              onChange={(e) => setIdentifier(e.target.value)}
+              disabled={isPending}
+              placeholder="例: test@example.com または 123"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium mb-1">
+              確認のため「<strong>削除する</strong>」と入力してください
+            </label>
+            <input
+              type="text"
+              value={confirmText}
+              onChange={(e) => setConfirmText(e.target.value)}
+              disabled={isPending}
+              placeholder="削除する"
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-red-500"
+            />
+          </div>
+
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            className="w-full px-4 py-3 bg-red-600 text-white font-semibold rounded-md hover:bg-red-700 disabled:bg-gray-300 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+          >
+            {isPending ? (
+              <>
+                <Loader2 className="w-5 h-5 animate-spin" />
+                削除中...
+              </>
+            ) : (
+              <>
+                <Trash2 className="w-5 h-5" />
+                完全削除を実行
+              </>
+            )}
+          </button>
+        </div>
+
+        {result && (
+          <div
+            className={`mt-6 p-4 rounded-md border ${
+              result.success
+                ? 'bg-green-50 border-green-200'
+                : 'bg-red-50 border-red-200'
+            }`}
+          >
+            {result.success ? (
+              <>
+                <div className="flex items-center gap-2 mb-2">
+                  <CheckCircle2 className="w-5 h-5 text-green-600" />
+                  <p className="font-semibold text-green-800">削除完了</p>
+                </div>
+                {result.deletedUser && (
+                  <div className="text-sm text-green-800 space-y-1">
+                    <p>
+                      ユーザー: ID={result.deletedUser.id}, {result.deletedUser.name}（
+                      {result.deletedUser.email}）
+                    </p>
+                    {result.counts && (
+                      <ul className="list-disc pl-5 mt-2">
+                        <li>応募レコード: {result.counts.applications} 件（cascade 削除）</li>
+                        <li>ブックマーク: {result.counts.bookmarks} 件（cascade 削除）</li>
+                        <li>メッセージ: {result.counts.messages} 件（cascade 削除）</li>
+                        <li>レビュー: {result.counts.reviews} 件（cascade 削除）</li>
+                        <li>勤怠: {result.counts.attendances} 件（cascade 削除）</li>
+                        <li>
+                          オファー求人の target_worker_id クリア:{' '}
+                          {result.counts.offeredJobsCleared} 件
+                        </li>
+                        <li>
+                          JobWorkDate カウンター調整:{' '}
+                          {result.counts.workDateCountersAdjusted} 件
+                        </li>
+                        <li>
+                          Facility 評価再計算: {result.counts.facilityRatingsRecalculated} 件
+                        </li>
+                      </ul>
+                    )}
+                  </div>
+                )}
+              </>
+            ) : (
+              <>
+                <div className="flex items-center gap-2 mb-2">
+                  <AlertTriangle className="w-5 h-5 text-red-600" />
+                  <p className="font-semibold text-red-800">
+                    {result.blockers ? '削除不可（進行中業務あり）' : 'エラー'}
+                  </p>
+                </div>
+                <p className="text-sm text-red-800">{result.message}</p>
+                {result.blockers && result.blockers.length > 0 && (
+                  <ul className="list-disc pl-5 mt-2 text-sm text-red-800">
+                    {result.blockers.map((b, i) => (
+                      <li key={i}>{b}</li>
+                    ))}
+                  </ul>
+                )}
+              </>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/system-admin/dev-portal/layout.tsx
+++ b/app/system-admin/dev-portal/layout.tsx
@@ -20,6 +20,7 @@ import {
     LucideIcon,
     SendHorizonal,
     UserCog,
+    Trash2,
 } from 'lucide-react';
 
 interface MenuItem {
@@ -56,6 +57,7 @@ const menuItems: MenuSection[] = [
             { href: '/system-admin/dev-portal/debug-checklist', icon: ListChecks, label: 'デバッグ項目', description: '機能検証チェック', color: 'blue' },
             { href: '/system-admin/dev-portal/debug-time', icon: Clock, label: 'デバッグ時刻', description: 'システム時刻変更', color: 'indigo' },
             { href: '/system-admin/dev-portal/sample-images', icon: ImageIcon, label: 'サンプル画像', description: 'モック用素材', color: 'pink' },
+            { href: '/system-admin/dev-portal/delete-worker', icon: Trash2, label: 'ワーカー削除', description: 'テスト用完全削除', color: 'red' },
         ],
     },
     {

--- a/app/system-admin/dev-portal/page.tsx
+++ b/app/system-admin/dev-portal/page.tsx
@@ -243,6 +243,7 @@ const SYSTEM_ADMIN_TREE: SiteMapNode[] = [
             { name: 'debug-time', title: 'デバッグ時刻設定', href: '/system-admin/dev-portal/debug-time' },
             { name: 'error-alert', title: 'エラー通知設定', href: '/system-admin/dev-portal/error-alert' },
             { name: 'test-notifications', title: 'テスト通知送信', href: '/system-admin/dev-portal/test-notifications' },
+            { name: 'delete-worker', title: 'ワーカー完全削除（テスト用）', href: '/system-admin/dev-portal/delete-worker' },
         ]
     },
 ];
@@ -447,6 +448,15 @@ export default function DevPortalPage() {
                                 <p className="text-lg font-bold text-purple-600 group-hover:text-purple-700">指標・計算式</p>
                             </div>
                             <Calculator className="w-8 h-8 text-purple-200 group-hover:text-purple-300" />
+                        </div>
+                    </Link>
+                    <Link href="/system-admin/dev-portal/delete-worker" className="bg-white rounded-xl shadow-sm border border-gray-200 p-4 hover:border-red-300 hover:shadow-md transition-all group">
+                        <div className="flex items-center justify-between">
+                            <div>
+                                <p className="text-xs font-medium text-gray-500">テスト用</p>
+                                <p className="text-lg font-bold text-red-600 group-hover:text-red-700">ワーカー完全削除</p>
+                            </div>
+                            <AlertTriangle className="w-8 h-8 text-red-200 group-hover:text-red-300" />
                         </div>
                     </Link>
                 </div>

--- a/components/admin/attendance/ModificationRequestDetail.tsx
+++ b/components/admin/attendance/ModificationRequestDetail.tsx
@@ -178,8 +178,11 @@ export function ModificationRequestDetail({
               <td className="px-4 py-3 text-center text-sm text-blue-700">
                 {requestedEndTime}
               </td>
-              <td className="px-4 py-3 text-center text-sm text-blue-700">
+              <td className="px-4 py-3 text-center text-sm text-gray-400">
                 {request.requestedBreakTime}分
+                {request.requestedBreakTime === scheduledBreakTime && (
+                  <span className="block text-xs">（変更なし）</span>
+                )}
               </td>
             </tr>
           </tbody>

--- a/components/attendance/ModificationForm.tsx
+++ b/components/attendance/ModificationForm.tsx
@@ -2,11 +2,14 @@
 
 /**
  * 勤怠変更申請フォームコンポーネント
+ * - 勤務時間の変更をスクロールホイール型ピッカーで入力
+ * - 休憩時間は元の求人設定値を引き継ぎ（ワーカーからの変更不可）
  */
 
 import { useState, useEffect } from 'react';
-import { AlertCircle, Clock, Coffee } from 'lucide-react';
+import { AlertCircle, Clock } from 'lucide-react';
 import { calculateSalary, formatCurrency, formatMinutesToHoursAndMinutes } from '@/src/lib/salary-calculator';
+import { TimeWheelPicker } from '@/components/ui/TimeWheelPicker';
 
 interface ModificationFormProps {
   attendance: {
@@ -38,13 +41,6 @@ export interface ModificationFormData {
   comment: string;
 }
 
-// 時・分の個別オプション生成（1分単位での時刻指定用）
-const HOUR_OPTIONS = Array.from({ length: 24 }, (_, h) => h.toString().padStart(2, '0'));
-const MINUTE_OPTIONS = Array.from({ length: 60 }, (_, m) => m.toString().padStart(2, '0'));
-
-// 休憩時間オプション
-const BREAK_OPTIONS = [0, 15, 30, 45, 60, 90, 120];
-
 export function ModificationForm({
   attendance,
   scheduledTime,
@@ -57,9 +53,10 @@ export function ModificationForm({
   // フォーム状態
   const [startTime, setStartTime] = useState(scheduledTime.startTime);
   const [endTime, setEndTime] = useState(scheduledTime.endTime);
-  const [hasBreak, setHasBreak] = useState(scheduledTime.breakTime > 0);
-  const [breakTime, setBreakTime] = useState(scheduledTime.breakTime);
   const [comment, setComment] = useState('');
+
+  // 休憩時間は元の求人設定値を固定で使用
+  const breakTime = scheduledTime.breakTime;
 
   // 計算結果
   const [calculatedAmount, setCalculatedAmount] = useState(0);
@@ -83,13 +80,13 @@ export function ModificationForm({
     const result = calculateSalary({
       startTime: start,
       endTime: end,
-      breakMinutes: hasBreak ? breakTime : 0,
+      breakMinutes: breakTime,
       hourlyRate: scheduledTime.hourlyWage,
     });
 
     setCalculatedAmount(result.totalPay + scheduledTime.transportationFee);
     setWorkedMinutes(result.workedMinutes);
-  }, [startTime, endTime, hasBreak, breakTime, scheduledTime, workDate]);
+  }, [startTime, endTime, breakTime, scheduledTime, workDate]);
 
   const handleSubmit = () => {
     if (!comment.trim()) {
@@ -100,8 +97,8 @@ export function ModificationForm({
     onSubmit({
       startTime,
       endTime,
-      breakTime: hasBreak ? breakTime : 0,
-      hasBreak,
+      breakTime,
+      hasBreak: breakTime > 0,
       comment,
     });
   };
@@ -147,105 +144,30 @@ export function ModificationForm({
         </div>
       </div>
 
-      {/* 勤務時間入力 */}
+      {/* 勤務時間入力（スクロールホイール型ピッカー） */}
       <div>
-        <label className="block text-sm font-medium text-gray-700 mb-2">
+        <label className="block text-sm font-medium text-gray-700 mb-3">
           勤務時間
         </label>
-        <div className="flex items-center gap-2">
-          {/* 開始時刻: 時 */}
-          <select
-            value={startTime.split(':')[0]}
-            onChange={(e) => setStartTime(`${e.target.value}:${startTime.split(':')[1]}`)}
-            className="w-16 px-2 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#66cc99] text-center"
-          >
-            {HOUR_OPTIONS.map((h) => (
-              <option key={`sh-${h}`} value={h}>{h}</option>
-            ))}
-          </select>
-          <span className="text-gray-500">:</span>
-          {/* 開始時刻: 分 */}
-          <select
-            value={startTime.split(':')[1]}
-            onChange={(e) => setStartTime(`${startTime.split(':')[0]}:${e.target.value}`)}
-            className="w-16 px-2 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#66cc99] text-center"
-          >
-            {MINUTE_OPTIONS.map((m) => (
-              <option key={`sm-${m}`} value={m}>{m}</option>
-            ))}
-          </select>
-          <span className="text-gray-500 mx-1">〜</span>
-          {/* 終了時刻: 時 */}
-          <select
-            value={endTime.split(':')[0]}
-            onChange={(e) => setEndTime(`${e.target.value}:${endTime.split(':')[1]}`)}
-            className="w-16 px-2 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#66cc99] text-center"
-          >
-            {HOUR_OPTIONS.map((h) => (
-              <option key={`eh-${h}`} value={h}>{h}</option>
-            ))}
-          </select>
-          <span className="text-gray-500">:</span>
-          {/* 終了時刻: 分 */}
-          <select
-            value={endTime.split(':')[1]}
-            onChange={(e) => setEndTime(`${endTime.split(':')[0]}:${e.target.value}`)}
-            className="w-16 px-2 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#66cc99] text-center"
-          >
-            {MINUTE_OPTIONS.map((m) => (
-              <option key={`em-${m}`} value={m}>{m}</option>
-            ))}
-          </select>
+        <div className="flex items-center justify-center gap-3">
+          <TimeWheelPicker
+            value={startTime}
+            onChange={setStartTime}
+            label="開始"
+            className="flex-1"
+          />
+          <span className="text-gray-400 text-lg font-medium">〜</span>
+          <TimeWheelPicker
+            value={endTime}
+            onChange={setEndTime}
+            label="終了"
+            className="flex-1"
+          />
         </div>
-        <p className="text-xs text-gray-500 mt-1">
+        <p className="text-xs text-gray-500 mt-2">
           実働時間: {formatMinutesToHoursAndMinutes(workedMinutes)}
+          {breakTime > 0 && `（休憩${breakTime}分を含む）`}
         </p>
-      </div>
-
-      {/* 休憩時間 */}
-      <div>
-        <label className="block text-sm font-medium text-gray-700 mb-2">
-          休憩時間
-        </label>
-        <div className="space-y-2">
-          <div className="flex items-center gap-4">
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="radio"
-                checked={!hasBreak}
-                onChange={() => setHasBreak(false)}
-                className="w-4 h-4 text-[#66cc99]"
-              />
-              <span>なし</span>
-            </label>
-            <label className="flex items-center gap-2 cursor-pointer">
-              <input
-                type="radio"
-                checked={hasBreak}
-                onChange={() => setHasBreak(true)}
-                className="w-4 h-4 text-[#66cc99]"
-              />
-              <span>あり</span>
-            </label>
-          </div>
-
-          {hasBreak && (
-            <div className="flex items-center gap-2">
-              <Coffee className="w-4 h-4 text-gray-400" />
-              <select
-                value={breakTime}
-                onChange={(e) => setBreakTime(Number(e.target.value))}
-                className="px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#66cc99]"
-              >
-                {BREAK_OPTIONS.map((minutes) => (
-                  <option key={minutes} value={minutes}>
-                    {minutes}分
-                  </option>
-                ))}
-              </select>
-            </div>
-          )}
-        </div>
       </div>
 
       {/* コメント */}

--- a/components/attendance/ModificationForm.tsx
+++ b/components/attendance/ModificationForm.tsx
@@ -38,18 +38,9 @@ export interface ModificationFormData {
   comment: string;
 }
 
-// 時間オプション生成（00:00〜23:30を30分刻み）
-const generateTimeOptions = () => {
-  const options: string[] = [];
-  for (let h = 0; h < 24; h++) {
-    for (let m = 0; m < 60; m += 30) {
-      options.push(`${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')}`);
-    }
-  }
-  return options;
-};
-
-const TIME_OPTIONS = generateTimeOptions();
+// 時・分の個別オプション生成（1分単位での時刻指定用）
+const HOUR_OPTIONS = Array.from({ length: 24 }, (_, h) => h.toString().padStart(2, '0'));
+const MINUTE_OPTIONS = Array.from({ length: 60 }, (_, m) => m.toString().padStart(2, '0'));
 
 // 休憩時間オプション
 const BREAK_OPTIONS = [0, 15, 30, 45, 60, 90, 120];
@@ -162,27 +153,47 @@ export function ModificationForm({
           勤務時間
         </label>
         <div className="flex items-center gap-2">
+          {/* 開始時刻: 時 */}
           <select
-            value={startTime}
-            onChange={(e) => setStartTime(e.target.value)}
-            className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#66cc99]"
+            value={startTime.split(':')[0]}
+            onChange={(e) => setStartTime(`${e.target.value}:${startTime.split(':')[1]}`)}
+            className="w-16 px-2 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#66cc99] text-center"
           >
-            {TIME_OPTIONS.map((time) => (
-              <option key={`start-${time}`} value={time}>
-                {time}
-              </option>
+            {HOUR_OPTIONS.map((h) => (
+              <option key={`sh-${h}`} value={h}>{h}</option>
             ))}
           </select>
-          <span className="text-gray-500">〜</span>
+          <span className="text-gray-500">:</span>
+          {/* 開始時刻: 分 */}
           <select
-            value={endTime}
-            onChange={(e) => setEndTime(e.target.value)}
-            className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#66cc99]"
+            value={startTime.split(':')[1]}
+            onChange={(e) => setStartTime(`${startTime.split(':')[0]}:${e.target.value}`)}
+            className="w-16 px-2 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#66cc99] text-center"
           >
-            {TIME_OPTIONS.map((time) => (
-              <option key={`end-${time}`} value={time}>
-                {time}
-              </option>
+            {MINUTE_OPTIONS.map((m) => (
+              <option key={`sm-${m}`} value={m}>{m}</option>
+            ))}
+          </select>
+          <span className="text-gray-500 mx-1">〜</span>
+          {/* 終了時刻: 時 */}
+          <select
+            value={endTime.split(':')[0]}
+            onChange={(e) => setEndTime(`${e.target.value}:${endTime.split(':')[1]}`)}
+            className="w-16 px-2 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#66cc99] text-center"
+          >
+            {HOUR_OPTIONS.map((h) => (
+              <option key={`eh-${h}`} value={h}>{h}</option>
+            ))}
+          </select>
+          <span className="text-gray-500">:</span>
+          {/* 終了時刻: 分 */}
+          <select
+            value={endTime.split(':')[1]}
+            onChange={(e) => setEndTime(`${endTime.split(':')[0]}:${e.target.value}`)}
+            className="w-16 px-2 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#66cc99] text-center"
+          >
+            {MINUTE_OPTIONS.map((m) => (
+              <option key={`em-${m}`} value={m}>{m}</option>
             ))}
           </select>
         </div>

--- a/components/auth/EmailVerificationRequiredModal.tsx
+++ b/components/auth/EmailVerificationRequiredModal.tsx
@@ -54,10 +54,16 @@ export function EmailVerificationRequiredModal({ open, email, onClose }: Props) 
     setIsSending(true);
     setErrorMessage(null);
     try {
+      // 現在のページを認証完了後の戻り先として送信
+      // （メールリンククリック後、このページに戻って応募を続けられる）
+      const returnUrl =
+        typeof window !== 'undefined'
+          ? window.location.pathname + window.location.search
+          : null;
       const res = await fetch('/api/auth/resend-verification', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email }),
+        body: JSON.stringify({ email, returnUrl }),
       });
       const data = await res.json();
       if (res.ok) {

--- a/components/auth/EmailVerificationRequiredModal.tsx
+++ b/components/auth/EmailVerificationRequiredModal.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
+import toast from 'react-hot-toast';
+
+interface Props {
+  open: boolean;
+  email: string;
+  onClose: () => void;
+}
+
+// サーバー側クールダウン（email-verification.ts の RESEND_COOLDOWN_MINUTES = 5分）と揃える
+const CLIENT_COOLDOWN_MS = 5 * 60_000;
+
+export function EmailVerificationRequiredModal({ open, email, onClose }: Props) {
+  const [isSending, setIsSending] = useState(false);
+  const [sentOnce, setSentOnce] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [cooldownRemaining, setCooldownRemaining] = useState(0); // クライアント側の連打防止
+  const closeBtnRef = useRef<HTMLButtonElement>(null);
+
+  // open/email 変更時に状態リセット
+  useEffect(() => {
+    if (!open) return;
+    setSentOnce(false);
+    setErrorMessage(null);
+    setCooldownRemaining(0);
+  }, [open, email]);
+
+  // ESC & 初期フォーカス
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', onKey);
+    // 開いた直後に閉じるボタンへフォーカス
+    setTimeout(() => closeBtnRef.current?.focus(), 10);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  // cooldown カウントダウン
+  useEffect(() => {
+    if (cooldownRemaining <= 0) return;
+    const t = setTimeout(() => setCooldownRemaining(r => r - 1), 1000);
+    return () => clearTimeout(t);
+  }, [cooldownRemaining]);
+
+  if (!open) return null;
+
+  const handleResend = async () => {
+    if (isSending || !email || cooldownRemaining > 0) return;
+    setIsSending(true);
+    setErrorMessage(null);
+    try {
+      const res = await fetch('/api/auth/resend-verification', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        toast.success(data.message || '認証メールを再送しました');
+        setSentOnce(true);
+        setCooldownRemaining(Math.ceil(CLIENT_COOLDOWN_MS / 1000));
+      } else {
+        // サーバー側クールダウン等のエラーはインラインで表示
+        setErrorMessage(data.error || '再送に失敗しました');
+      }
+    } catch {
+      setErrorMessage('再送中にネットワークエラーが発生しました');
+    } finally {
+      setIsSending(false);
+    }
+  };
+
+  const buttonLabel = (() => {
+    if (isSending) return '送信中...';
+    if (cooldownRemaining > 0) {
+      const min = Math.floor(cooldownRemaining / 60);
+      const sec = cooldownRemaining % 60;
+      return `再送可能まで ${min}:${String(sec).padStart(2, '0')}`;
+    }
+    if (sentOnce) return '認証メールを再送する';
+    return '認証メールを送信する';
+  })();
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 z-[100] flex items-end justify-center sm:items-center"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="email-verify-modal-title"
+    >
+      <div
+        className="bg-white w-full max-w-md sm:rounded-3xl rounded-t-3xl p-6"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between mb-4">
+          <h3 id="email-verify-modal-title" className="text-lg font-bold text-gray-800">
+            メール認証が必要です
+          </h3>
+          <button
+            ref={closeBtnRef}
+            type="button"
+            onClick={onClose}
+            className="text-gray-400 text-2xl leading-none px-2"
+            aria-label="閉じる"
+          >
+            ×
+          </button>
+        </div>
+
+        <p className="text-sm text-gray-700 leading-relaxed mb-3">
+          求人への応募にはメールアドレスの認証が必要です。
+          <br />
+          登録時に <span className="font-semibold">{email}</span> 宛にお送りした認証メールのリンクをクリックしてください。
+        </p>
+        <p className="text-xs text-gray-500 mb-4">
+          メールが見つからない場合は、迷惑メールフォルダもご確認ください。
+        </p>
+
+        {errorMessage && (
+          <div
+            role="alert"
+            aria-live="polite"
+            className="mb-4 p-3 rounded-lg bg-red-50 border border-red-200 text-red-700 text-sm"
+          >
+            {errorMessage}
+          </div>
+        )}
+
+        <div className="flex flex-col gap-3">
+          <button
+            type="button"
+            onClick={handleResend}
+            disabled={isSending || cooldownRemaining > 0}
+            className="w-full py-3 rounded-full bg-[#2AADCF] text-white font-semibold shadow-md disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {buttonLabel}
+          </button>
+          <Link
+            href="/mypage/profile"
+            className="text-center text-sm text-[#2AADCF] underline"
+            onClick={onClose}
+          >
+            メールアドレスを変更する
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/job/JobCard.tsx
+++ b/components/job/JobCard.tsx
@@ -161,7 +161,7 @@ const JobCardComponent: React.FC<JobCardProps> = ({ job, facility, selectedDate,
               )}
               {job.requiresInterview && (
                 <span className="bg-red-500 text-white text-[10px] font-bold px-2 py-1 rounded shadow-sm">
-                  審査あり
+                  選考あり
                 </span>
               )}
             </div>
@@ -283,7 +283,7 @@ const JobCardComponent: React.FC<JobCardProps> = ({ job, facility, selectedDate,
               )}
               {job.requiresInterview && (
                 <span className="bg-red-500 text-white text-[9px] font-bold px-1.5 py-0.5 rounded shadow-sm">
-                  審査あり
+                  選考あり
                 </span>
               )}
             </div>

--- a/components/job/JobDetailClient.tsx
+++ b/components/job/JobDetailClient.tsx
@@ -16,6 +16,7 @@ import toast from 'react-hot-toast';
 import { useErrorToast } from '@/components/ui/PersistentErrorToast';
 import { trackGA4Event } from '@/src/lib/ga4-events';
 import { useDebugError, extractDebugInfo } from '@/components/debug/DebugErrorBanner';
+import { EmailVerificationRequiredModal } from '@/components/auth/EmailVerificationRequiredModal';
 
 // デフォルトのプレースホルダー画像
 const DEFAULT_JOB_IMAGE = '/images/samples/job_default_noimage.png';
@@ -96,6 +97,8 @@ export function JobDetailClient({ job, facility, relatedJobs: _relatedJobs, faci
   // プロフィール未完了モーダル
   const [showProfileModal, setShowProfileModal] = useState(false);
   const [profileMissingFields, setProfileMissingFields] = useState<string[]>([]);
+  // メール未認証モーダル
+  const [emailNotVerifiedModal, setEmailNotVerifiedModal] = useState<{ open: boolean; email: string }>({ open: false, email: '' });
 
   // 応募確認モーダル
   const [showApplyConfirmModal, setShowApplyConfirmModal] = useState(false);
@@ -462,7 +465,7 @@ export function JobDetailClient({ job, facility, relatedJobs: _relatedJobs, faci
     setSelectedWorkDateIds([]); // 選択をクリア
 
     const isOffer = job.jobType === 'OFFER';
-    toast.success(isOffer ? 'オファーを受け付けました' : '応募を受け付けました');
+    const optimisticToastId = toast.success(isOffer ? 'オファーを受け付けました' : '応募を受け付けました');
 
     // 4. バックグラウンドでAPI実行
     try {
@@ -495,9 +498,16 @@ export function JobDetailClient({ job, facility, relatedJobs: _relatedJobs, faci
       } else {
         // 失敗時：ロールバック
         setAppliedWorkDateIds(previousAppliedIds);
+        // 楽観UI で出した成功トーストのみを打ち消す（他のトーストに影響しない）
+        toast.dismiss(optimisticToastId);
 
+        // メール未認証エラーの場合はモーダル表示
+        if ('errorCode' in result && result.errorCode === 'EMAIL_NOT_VERIFIED') {
+          const email = ('email' in result && typeof result.email === 'string') ? result.email : '';
+          setEmailNotVerifiedModal({ open: true, email });
+        }
         // プロフィール未完了エラーの場合はモーダル表示
-        if ('missingFields' in result && result.missingFields) {
+        else if ('missingFields' in result && result.missingFields) {
           const missingFields = result.missingFields as string[];
           setProfileMissingFields(missingFields);
           setShowProfileModal(true);
@@ -537,6 +547,8 @@ export function JobDetailClient({ job, facility, relatedJobs: _relatedJobs, faci
       console.error('Application error:', error);
       // 失敗時：ロールバック
       setAppliedWorkDateIds(previousAppliedIds);
+      // 楽観UI で出した成功トーストのみを打ち消す
+      toast.dismiss(optimisticToastId);
       // デバッグ用エラー通知
       const debugInfo = extractDebugInfo(error);
       showDebugError({
@@ -1576,6 +1588,13 @@ export function JobDetailClient({ job, facility, relatedJobs: _relatedJobs, faci
           </div>
         </div>
       )}
+
+      {/* メール未認証モーダル */}
+      <EmailVerificationRequiredModal
+        open={emailNotVerifiedModal.open}
+        email={emailNotVerifiedModal.email}
+        onClose={() => setEmailNotVerifiedModal({ open: false, email: '' })}
+      />
 
       {/* 応募確認モーダル */}
       {showApplyConfirmModal && (

--- a/components/job/JobDetailClient.tsx
+++ b/components/job/JobDetailClient.tsx
@@ -709,7 +709,7 @@ export function JobDetailClient({ job, facility, relatedJobs: _relatedJobs, faci
             )}
             {job.requiresInterview && (
               <span className="bg-red-500 text-white text-xs font-bold px-2 py-1 rounded shadow-md">
-                審査あり
+                選考あり
               </span>
             )}
           </div>
@@ -1379,7 +1379,7 @@ export function JobDetailClient({ job, facility, relatedJobs: _relatedJobs, faci
               </p>
             )}
             <p className="mt-2 text-xs text-gray-500">
-              ※この施設の審査あり求人における面接通過率です（採用・不採用の結果が出た応募が対象）
+              ※この施設の選考あり求人における面接通過率です（採用・不採用の結果が出た応募が対象）
             </p>
           </div>
         </div>
@@ -1602,9 +1602,9 @@ export function JobDetailClient({ job, facility, relatedJobs: _relatedJobs, faci
                   <div className="flex items-start gap-2">
                     <AlertTriangle className="w-5 h-5 text-yellow-600 flex-shrink-0 mt-0.5" />
                     <div>
-                      <p className="text-sm font-bold text-yellow-800">審査あり求人です</p>
+                      <p className="text-sm font-bold text-yellow-800">選考あり求人です</p>
                       <p className="text-xs text-yellow-700 mt-1">
-                        応募後、施設による審査があります。審査通過後にマッチングが成立します。
+                        応募後、施設による選考があります。選考通過後にマッチングが成立します。
                       </p>
                     </div>
                   </div>
@@ -1731,7 +1731,7 @@ export function JobDetailClient({ job, facility, relatedJobs: _relatedJobs, faci
                 disabled={isEditingSelfPR}
                 className="flex-1 px-4 py-2.5 bg-primary text-white font-medium rounded-lg hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                {job.jobType === 'OFFER' ? 'オファーを受ける' : (job.requiresInterview ? '応募する（審査あり）' : '応募する')}
+                {job.jobType === 'OFFER' ? 'オファーを受ける' : (job.requiresInterview ? '応募する（選考あり）' : '応募する')}
               </button>
             </div>
           </div>

--- a/components/job/JobDetailClient.tsx
+++ b/components/job/JobDetailClient.tsx
@@ -375,10 +375,23 @@ export function JobDetailClient({ job, facility, relatedJobs: _relatedJobs, faci
       return;
     }
 
-    // プロフィール完了チェック（応募前に必須、失敗時も応募を阻止）
+    // メール認証・プロフィール完了チェック（応募前に必須）
+    // 優先順位: error → email_verified → profile complete
     setIsApplying(true);
     try {
       const profileResult = await getMissingProfileFields();
+      // API エラー時は汎用エラー表示（誤モーダル回避）
+      if (profileResult?.hasError) {
+        toast.error('プロフィールの確認に失敗しました。もう一度お試しください。');
+        setIsApplying(false);
+        return;
+      }
+      // メール未認証ならメール認証モーダルを表示して停止
+      if (profileResult && !profileResult.emailVerified) {
+        setEmailNotVerifiedModal({ open: true, email: profileResult.email });
+        setIsApplying(false);
+        return;
+      }
       if (profileResult && !profileResult.isComplete) {
         setProfileMissingFields(profileResult.missingFields);
         setShowProfileModal(true);

--- a/components/job/WidgetJobCard.tsx
+++ b/components/job/WidgetJobCard.tsx
@@ -118,7 +118,7 @@ const WidgetJobCardComponent: React.FC<WidgetJobCardProps> = ({ job, facility, s
               <span className="bg-teal-500 text-white text-[9px] font-bold px-1.5 py-0.5 rounded shadow-sm">説明会</span>
             )}
             {job.requiresInterview && (
-              <span className="bg-red-500 text-white text-[9px] font-bold px-1.5 py-0.5 rounded shadow-sm">審査あり</span>
+              <span className="bg-red-500 text-white text-[9px] font-bold px-1.5 py-0.5 rounded shadow-sm">選考あり</span>
             )}
           </div>
           {shouldShowUnavailable && (

--- a/components/profile/ProfileIncompleteBanner.tsx
+++ b/components/profile/ProfileIncompleteBanner.tsx
@@ -28,8 +28,14 @@ export function ProfileIncompleteBanner() {
     const fetchProfile = async () => {
       try {
         const result = await getMissingProfileFields();
-        setMissingFields(result.missingFields);
-        setMissingCount(result.missingCount);
+        // hasError 時は未完了扱いしない（バナー非表示）
+        if (result.hasError) {
+          setMissingFields([]);
+          setMissingCount(0);
+        } else {
+          setMissingFields(result.missingFields);
+          setMissingCount(result.missingCount);
+        }
       } catch (error) {
         console.error('[ProfileIncompleteBanner] Error:', error);
       } finally {

--- a/components/ui/TimeWheelPicker.tsx
+++ b/components/ui/TimeWheelPicker.tsx
@@ -1,0 +1,268 @@
+'use client';
+
+import { useState, useRef, useEffect, useCallback } from 'react';
+
+interface TimeWheelPickerProps {
+  value: string; // "HH:MM" 形式
+  onChange: (value: string) => void;
+  label?: string;
+  className?: string;
+}
+
+interface WheelColumnProps {
+  items: string[];
+  selectedIndex: number;
+  onSelect: (index: number) => void;
+  suffix?: string;
+}
+
+const ITEM_HEIGHT = 44;
+const VISIBLE_ITEMS = 5;
+const WHEEL_HEIGHT = ITEM_HEIGHT * VISIBLE_ITEMS;
+
+function WheelColumn({ items, selectedIndex, onSelect, suffix = '' }: WheelColumnProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isDragging = useRef(false);
+  const startY = useRef(0);
+  const startScrollTop = useRef(0);
+  const lastMoveTime = useRef(0);
+  const lastMoveY = useRef(0);
+  const velocity = useRef(0);
+  const animationRef = useRef<number | null>(null);
+  const isSettling = useRef(false);
+
+  // スクロール位置を選択項目に合わせる
+  const scrollToIndex = useCallback((index: number, smooth = true) => {
+    if (!containerRef.current) return;
+    const targetScroll = index * ITEM_HEIGHT;
+    if (smooth) {
+      containerRef.current.scrollTo({ top: targetScroll, behavior: 'smooth' });
+    } else {
+      containerRef.current.scrollTop = targetScroll;
+    }
+  }, []);
+
+  // 初期位置設定
+  useEffect(() => {
+    scrollToIndex(selectedIndex, false);
+  }, [selectedIndex, scrollToIndex]);
+
+  // スクロール停止後にスナップ
+  const settleToNearest = useCallback(() => {
+    if (!containerRef.current || isSettling.current) return;
+    isSettling.current = true;
+    const scrollTop = containerRef.current.scrollTop;
+    const nearestIndex = Math.round(scrollTop / ITEM_HEIGHT);
+    const clampedIndex = Math.max(0, Math.min(items.length - 1, nearestIndex));
+    scrollToIndex(clampedIndex, true);
+    if (clampedIndex !== selectedIndex) {
+      onSelect(clampedIndex);
+    }
+    setTimeout(() => { isSettling.current = false; }, 200);
+  }, [items.length, selectedIndex, onSelect, scrollToIndex]);
+
+  // タッチ開始
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    if (animationRef.current) {
+      cancelAnimationFrame(animationRef.current);
+      animationRef.current = null;
+    }
+    isDragging.current = true;
+    startY.current = e.touches[0].clientY;
+    startScrollTop.current = containerRef.current?.scrollTop ?? 0;
+    lastMoveTime.current = Date.now();
+    lastMoveY.current = e.touches[0].clientY;
+    velocity.current = 0;
+  }, []);
+
+  // タッチ移動
+  const handleTouchMove = useCallback((e: React.TouchEvent) => {
+    if (!isDragging.current || !containerRef.current) return;
+    e.preventDefault();
+    const currentY = e.touches[0].clientY;
+    const diff = startY.current - currentY;
+    containerRef.current.scrollTop = startScrollTop.current + diff;
+
+    const now = Date.now();
+    const dt = now - lastMoveTime.current;
+    if (dt > 0) {
+      velocity.current = (lastMoveY.current - currentY) / dt;
+    }
+    lastMoveTime.current = now;
+    lastMoveY.current = currentY;
+  }, []);
+
+  // タッチ終了 — 慣性スクロール
+  const handleTouchEnd = useCallback(() => {
+    isDragging.current = false;
+    if (!containerRef.current) return;
+
+    const v = velocity.current;
+    if (Math.abs(v) > 0.3) {
+      // 慣性: 速度に応じて追加スクロール
+      const momentum = v * 150;
+      const target = containerRef.current.scrollTop + momentum;
+      const nearestIndex = Math.round(target / ITEM_HEIGHT);
+      const clampedIndex = Math.max(0, Math.min(items.length - 1, nearestIndex));
+      scrollToIndex(clampedIndex, true);
+      if (clampedIndex !== selectedIndex) {
+        onSelect(clampedIndex);
+      }
+    } else {
+      settleToNearest();
+    }
+  }, [items.length, selectedIndex, onSelect, scrollToIndex, settleToNearest]);
+
+  // マウスホイール対応（PC）
+  const handleWheel = useCallback((e: React.WheelEvent) => {
+    e.preventDefault();
+    const direction = e.deltaY > 0 ? 1 : -1;
+    const newIndex = Math.max(0, Math.min(items.length - 1, selectedIndex + direction));
+    if (newIndex !== selectedIndex) {
+      onSelect(newIndex);
+      scrollToIndex(newIndex, true);
+    }
+  }, [items.length, selectedIndex, onSelect, scrollToIndex]);
+
+  // 項目クリック
+  const handleItemClick = useCallback((index: number) => {
+    if (index !== selectedIndex) {
+      onSelect(index);
+    }
+    scrollToIndex(index, true);
+  }, [selectedIndex, onSelect, scrollToIndex]);
+
+  return (
+    <div className="relative" style={{ height: WHEEL_HEIGHT }}>
+      {/* 選択行のハイライト */}
+      <div
+        className="absolute left-0 right-0 bg-[#66cc99]/10 border-y border-[#66cc99]/30 pointer-events-none z-10"
+        style={{ top: ITEM_HEIGHT * 2, height: ITEM_HEIGHT }}
+      />
+      {/* グラデーションマスク（上下のフェード） */}
+      <div className="absolute inset-0 pointer-events-none z-20 bg-gradient-to-b from-white via-transparent to-white" style={{ backgroundSize: '100% 100%', backgroundImage: 'linear-gradient(to bottom, rgba(255,255,255,0.95) 0%, rgba(255,255,255,0) 30%, rgba(255,255,255,0) 70%, rgba(255,255,255,0.95) 100%)' }} />
+      <div
+        ref={containerRef}
+        className="h-full overflow-hidden touch-none"
+        style={{ scrollbarWidth: 'none', msOverflowStyle: 'none', WebkitOverflowScrolling: 'touch' }}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+        onWheel={handleWheel}
+      >
+        {/* 上下のパディング（2アイテム分） */}
+        <div style={{ height: ITEM_HEIGHT * 2 }} />
+        {items.map((item, index) => {
+          const isSelected = index === selectedIndex;
+          return (
+            <div
+              key={index}
+              className={`flex items-center justify-center cursor-pointer select-none transition-colors ${
+                isSelected ? 'text-gray-900 font-bold text-lg' : 'text-gray-400 text-base'
+              }`}
+              style={{ height: ITEM_HEIGHT }}
+              onClick={() => handleItemClick(index)}
+            >
+              {item}{suffix}
+            </div>
+          );
+        })}
+        <div style={{ height: ITEM_HEIGHT * 2 }} />
+      </div>
+    </div>
+  );
+}
+
+const HOURS = Array.from({ length: 24 }, (_, i) => i.toString().padStart(2, '0'));
+const MINUTES = Array.from({ length: 60 }, (_, i) => i.toString().padStart(2, '0'));
+
+export function TimeWheelPicker({ value, onChange, label, className = '' }: TimeWheelPickerProps) {
+  const [hour, minute] = value.split(':');
+  const hourIndex = HOURS.indexOf(hour) >= 0 ? HOURS.indexOf(hour) : 0;
+  const minuteIndex = MINUTES.indexOf(minute) >= 0 ? MINUTES.indexOf(minute) : 0;
+
+  const [isOpen, setIsOpen] = useState(false);
+  const [tempHour, setTempHour] = useState(hourIndex);
+  const [tempMinute, setTempMinute] = useState(minuteIndex);
+
+  // モーダルを開くときに現在値を同期
+  const handleOpen = () => {
+    setTempHour(hourIndex);
+    setTempMinute(minuteIndex);
+    setIsOpen(true);
+  };
+
+  const handleConfirm = () => {
+    onChange(`${HOURS[tempHour]}:${MINUTES[tempMinute]}`);
+    setIsOpen(false);
+  };
+
+  const handleCancel = () => {
+    setIsOpen(false);
+  };
+
+  return (
+    <>
+      {/* 表示ボタン */}
+      <button
+        type="button"
+        onClick={handleOpen}
+        className={`px-4 py-3 border border-gray-300 rounded-lg bg-white text-center font-medium text-gray-900 focus:outline-none focus:ring-2 focus:ring-[#66cc99] active:bg-gray-50 ${className}`}
+      >
+        {label && <span className="text-xs text-gray-500 block mb-0.5">{label}</span>}
+        <span className="text-xl">{value}</span>
+      </button>
+
+      {/* ピッカーモーダル */}
+      {isOpen && (
+        <div className="fixed inset-0 z-50 flex items-end justify-center">
+          {/* オーバーレイ */}
+          <div className="absolute inset-0 bg-black/40" onClick={handleCancel} />
+          {/* ピッカー本体 */}
+          <div className="relative w-full max-w-md bg-white rounded-t-2xl pb-safe animate-slide-up">
+            {/* ヘッダー */}
+            <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
+              <button
+                type="button"
+                onClick={handleCancel}
+                className="text-gray-500 text-sm px-3 py-1"
+              >
+                キャンセル
+              </button>
+              <span className="text-sm font-medium text-gray-700">
+                {label || '時刻を選択'}
+              </span>
+              <button
+                type="button"
+                onClick={handleConfirm}
+                className="text-[#66cc99] font-bold text-sm px-3 py-1"
+              >
+                決定
+              </button>
+            </div>
+            {/* ホイール */}
+            <div className="flex items-center justify-center px-8 py-4">
+              <div className="flex-1">
+                <WheelColumn
+                  items={HOURS}
+                  selectedIndex={tempHour}
+                  onSelect={setTempHour}
+                />
+              </div>
+              <div className="text-2xl font-bold text-gray-400 mx-2">:</div>
+              <div className="flex-1">
+                <WheelColumn
+                  items={MINUTES}
+                  selectedIndex={tempMinute}
+                  onSelect={setTempMinute}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+export default TimeWheelPicker;

--- a/constants/time.ts
+++ b/constants/time.ts
@@ -23,13 +23,11 @@ export const END_HOUR_OPTIONS = [
   })),
 ];
 
-// 分選択用（00, 15, 30, 45）
-export const MINUTE_OPTIONS = [
-  { value: '00', label: '00分' },
-  { value: '15', label: '15分' },
-  { value: '30', label: '30分' },
-  { value: '45', label: '45分' },
-] as const;
+// 分選択用（00〜59、1分単位）
+export const MINUTE_OPTIONS = Array.from({ length: 60 }, (_, i) => ({
+  value: i.toString().padStart(2, '0'),
+  label: `${i.toString().padStart(2, '0')}分`,
+})) as readonly { value: string; label: string }[];
 
 export const BREAK_TIME_OPTIONS = [
   { value: 0, label: 'なし' },

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -20,7 +20,7 @@ interface AuthContextType {
   user: Session['user'] | null;
   isAuthenticated: boolean;
   isLoading: boolean;
-  login: (email: string, password: string) => Promise<{ success: boolean; error?: string }>;
+  login: (identifier: string, password: string) => Promise<{ success: boolean; error?: string }>;
   logout: () => Promise<void>;
   // 施設管理者認証（改善版）
   admin: FacilityAdmin | null;
@@ -125,11 +125,11 @@ function AuthContextProvider({ children }: { children: ReactNode }) {
     };
   }, [admin]);
 
-  // ワーカーログイン
-  const login = async (email: string, password: string) => {
+  // ワーカーログイン（メール or 電話番号）
+  const login = async (identifier: string, password: string) => {
     try {
       const result = await signIn('credentials', {
-        email,
+        identifier,
         password,
         redirect: false,
       });

--- a/contexts/BadgeContext.tsx
+++ b/contexts/BadgeContext.tsx
@@ -35,7 +35,10 @@ export function BadgeProvider({ children }: { children: ReactNode }) {
           setUnreadMessages(data.unreadMessages ?? 0);
           setUnreadAnnouncements(data.unreadAnnouncements ?? 0);
         }
-        setProfileMissingCount(profileData.missingCount);
+        // hasError 時は未完了扱いしない（前回値維持）
+        if (!profileData.hasError) {
+          setProfileMissingCount(profileData.missingCount);
+        }
       } catch (error) {
         console.error('[BadgeContext] Failed to refresh badges:', error);
       }

--- a/docs/features/system-admin.md
+++ b/docs/features/system-admin.md
@@ -622,27 +622,123 @@ enum FacilityStatus {
 
 ---
 
-## 15. 画面一覧
+## 15. 画面一覧（全46画面）
+
+### 認証
 
 | パス | 画面名 | 説明 |
 |------|--------|------|
 | `/system-admin/login` | ログイン | システム管理者ログイン |
+
+### ダッシュボード・アラート
+
+| パス | 画面名 | 説明 |
+|------|--------|------|
 | `/system-admin` | ダッシュボード | 統計サマリー・アラート |
-| `/system-admin/analytics` | アナリティクス | 詳細統計・分析・エクスポート |
+| `/system-admin/alerts` | アラート一覧 | アラート一覧・対応 |
+
+### アナリティクス
+
+| パス | 画面名 | 説明 |
+|------|--------|------|
+| `/system-admin/analytics` | アナリティクス | 詳細統計・分析 |
+| `/system-admin/analytics/ai` | マッチング最適化AI | AI分析・予測機能 |
+| `/system-admin/analytics/export` | スプレッドシートDL | データエクスポート |
+| `/system-admin/analytics/regions` | 地域登録 | 地域マスタ管理 |
+
+### ワーカー管理
+
+| パス | 画面名 | 説明 |
+|------|--------|------|
 | `/system-admin/workers` | ワーカー管理 | 一覧・検索・一括操作 |
 | `/system-admin/workers/[id]` | ワーカー詳細 | 詳細・編集・停止 |
+
+### 施設管理
+
+| パス | 画面名 | 説明 |
+|------|--------|------|
 | `/system-admin/facilities` | 施設管理 | 一覧・検索・一括操作 |
-| `/system-admin/facilities/[id]` | 施設詳細 | 詳細・編集・停止 |
-| `/system-admin/facilities/[id]/map` | マップピン調整 | 地図マーカー位置調整 |
-| `/system-admin/jobs` | 求人管理 | URL検索・監視結果 |
-| `/system-admin/templates` | テンプレート管理 | 一覧・承認・編集 |
-| `/system-admin/applications` | 応募管理 | 一覧・ステータス変更 |
-| `/system-admin/reviews` | レビュー管理 | 一覧・監視結果 |
-| `/system-admin/messages` | メッセージ管理 | NGワード・監視結果 |
-| `/system-admin/content` | コンテンツ管理 | お知らせ・FAQ |
-| `/system-admin/settings` | システム設定 | マスタ・ポリシー |
-| `/system-admin/alerts` | アラート管理 | アラート一覧・対応 |
-| `/system-admin/security` | セキュリティ | アカウント・ログ |
+| `/system-admin/facilities/new` | 施設新規登録 | 新規施設の登録 |
+
+### 求人管理
+
+| パス | 画面名 | 説明 |
+|------|--------|------|
+| `/system-admin/jobs` | 求人管理 | 求人一覧・検索・管理 |
+
+### 勤怠管理
+
+| パス | 画面名 | 説明 |
+|------|--------|------|
+| `/system-admin/attendance` | 勤怠管理 | 勤怠一覧・管理 |
+
+### CSV出力
+
+| パス | 画面名 | 説明 |
+|------|--------|------|
+| `/system-admin/csv-export` | CSV出力 | タブ切替で各種データ出力（worker-info, client-info, job-info, shift-info, staff-info, attendance-info） |
+
+### お知らせ管理
+
+| パス | 画面名 | 説明 |
+|------|--------|------|
+| `/system-admin/announcements` | お知らせ管理 | お知らせ一覧 |
+| `/system-admin/announcements/create` | お知らせ新規作成 | 新規お知らせの作成 |
+| `/system-admin/announcements/[id]` | お知らせ編集 | 既存お知らせの編集 |
+
+### コンテンツ管理
+
+| パス | 画面名 | 説明 |
+|------|--------|------|
+| `/system-admin/content` | コンテンツ管理ハブ | コンテンツ管理メニュー |
+| `/system-admin/content/faq` | FAQ編集 | FAQ管理・編集 |
+| `/system-admin/content/user-guide` | ご利用ガイド編集 | ご利用ガイド管理・編集 |
+| `/system-admin/content/legal` | 利用規約・PP編集 | 利用規約・プライバシーポリシー編集 |
+| `/system-admin/content/notifications` | 通知管理 | 通知テンプレート管理 |
+| `/system-admin/content/labor-template` | 労働条件通知書テンプレート | 労働条件通知書の管理 |
+| `/system-admin/content/templates` | テンプレート管理 | 各種テンプレートの管理 |
+
+### LP管理
+
+| パス | 画面名 | 説明 |
+|------|--------|------|
+| `/system-admin/lp` | LP管理 | ランディングページ管理 |
+| `/system-admin/lp/genres` | LPジャンル管理 | LPジャンルの管理 |
+| `/system-admin/lp/guide` | LP作成ガイド | LP作成のガイドライン |
+| `/system-admin/lp/recommended-jobs` | おすすめ求人管理 | おすすめ求人の設定 |
+| `/system-admin/lp/recommended-jobs/preview` | おすすめ求人プレビュー | おすすめ求人の表示確認 |
+| `/system-admin/lp/tracking` | LPトラッキング | LP効果測定 |
+| `/system-admin/lp/tracking/public-jobs` | 公開求人トラッキング | 公開求人の効果測定 |
+| `/system-admin/lp/tracking/spec` | トラッキングスペック | トラッキング仕様 |
+
+### システム設定（super_admin専用）
+
+| パス | 画面名 | 説明 |
+|------|--------|------|
+| `/system-admin/settings/admins` | 管理者アカウント管理 | 管理者の追加・編集・削除 |
+| `/system-admin/settings/form-destinations` | フォーム送信先設定 | フォーム通知先の設定 |
+| `/system-admin/settings/minimum-wage` | 最低賃金管理 | 最低賃金マスタの管理 |
+| `/system-admin/settings/system` | システム設定 | システム全般の設定 |
+
+### 開発ポータル（super_admin専用）
+
+| パス | 画面名 | 説明 |
+|------|--------|------|
+| `/system-admin/dev-portal` | 開発者ポータル | 開発者向け管理メニュー |
+| `/system-admin/dev-portal/admin-logs` | 管理者ログ | 管理者操作ログ |
+| `/system-admin/dev-portal/logs` | システムログ | システム動作ログ |
+| `/system-admin/dev-portal/notification-logs` | 通知ログ | 通知送信ログ |
+| `/system-admin/dev-portal/error-alert` | エラーアラート設定 | エラー通知先の設定 |
+| `/system-admin/dev-portal/test-notifications` | テスト通知 | 通知のテスト送信 |
+| `/system-admin/dev-portal/debug-checklist` | デバッグチェックリスト | デバッグ用チェック項目 |
+| `/system-admin/dev-portal/debug-time` | デバッグ時刻制御 | テスト用時刻の制御 |
+| `/system-admin/dev-portal/sample-images` | サンプル画像 | テスト用サンプル画像管理 |
+| `/system-admin/dev-portal/formulas` | 給与計算式 | 給与計算ロジックの確認・管理 |
+
+### サイドバーナビゲーション構成
+
+- **全管理者共通**: ダッシュボード, アナリティクス, ワーカー管理, 施設管理, 求人管理, 勤怠管理, CSV出力, コンテンツ管理, LP管理
+- **super_admin専用**: システム設定, 開発ポータル
 
 ---
 
@@ -694,3 +790,4 @@ enum FacilityStatus {
 | 2025-12-05 | マップピン位置調整機能を追加 |
 | 2025-12-09 | 詳細要件定義書として大幅拡充。アナリティクス、AI監視機能、DB設計案を追加 |
 | 2025-12-09 | 確定版。マッチング最適化AI（予測機能）、ダッシュボード、エクスポート機能、一括操作、アラート機能、退会機能、登録離脱率トラッキングを追加。パスワード表示機能は削除（リセット機能のみ） |
+| 2026-04-09 | 画面一覧を実際のpage.tsxファイルに基づき全面更新（18画面→46画面）。セクション別にグループ化。存在しない画面（templates, applications, reviews, messages, security, facilities/[id], facilities/[id]/map）を削除し、新規画面を追加 |

--- a/docs/service-overview.html
+++ b/docs/service-overview.html
@@ -1,0 +1,1406 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>タスタス サービス概要・機能一覧</title>
+<style>
+  :root {
+    --primary: #2563eb;
+    --primary-light: #dbeafe;
+    --secondary: #059669;
+    --secondary-light: #d1fae5;
+    --accent: #7c3aed;
+    --accent-light: #ede9fe;
+    --warning: #d97706;
+    --warning-light: #fef3c7;
+    --danger: #dc2626;
+    --danger-light: #fee2e2;
+    --gray-50: #f9fafb;
+    --gray-100: #f3f4f6;
+    --gray-200: #e5e7eb;
+    --gray-300: #d1d5db;
+    --gray-500: #6b7280;
+    --gray-700: #374151;
+    --gray-900: #111827;
+    --radius: 12px;
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Hiragino Kaku Gothic ProN', 'Noto Sans JP', sans-serif;
+    background: var(--gray-50);
+    color: var(--gray-900);
+    line-height: 1.7;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 24px;
+  }
+
+  /* Header */
+  header {
+    background: linear-gradient(135deg, #1e40af 0%, #2563eb 50%, #3b82f6 100%);
+    color: white;
+    padding: 48px 0 56px;
+    position: relative;
+    overflow: hidden;
+  }
+  header::after {
+    content: '';
+    position: absolute;
+    bottom: -2px;
+    left: 0;
+    right: 0;
+    height: 32px;
+    background: var(--gray-50);
+    border-radius: 24px 24px 0 0;
+  }
+  header h1 {
+    font-size: 2rem;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+  }
+  header p {
+    margin-top: 8px;
+    font-size: 1.05rem;
+    opacity: 0.9;
+  }
+  .header-meta {
+    margin-top: 20px;
+    display: flex;
+    gap: 16px;
+    flex-wrap: wrap;
+    font-size: 0.85rem;
+  }
+  .header-meta span {
+    background: rgba(255,255,255,0.15);
+    padding: 4px 14px;
+    border-radius: 20px;
+    backdrop-filter: blur(4px);
+  }
+
+  /* Navigation */
+  .toc {
+    background: white;
+    border-radius: var(--radius);
+    padding: 28px 32px;
+    margin: -16px 0 32px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+    position: relative;
+    z-index: 1;
+  }
+  .toc h2 {
+    font-size: 1rem;
+    color: var(--gray-500);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    margin-bottom: 16px;
+  }
+  .toc-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    gap: 8px;
+  }
+  .toc a {
+    color: var(--primary);
+    text-decoration: none;
+    font-size: 0.92rem;
+    padding: 6px 0;
+    display: block;
+    transition: color 0.15s;
+  }
+  .toc a:hover { color: #1d4ed8; text-decoration: underline; }
+
+  /* Section */
+  section {
+    margin-bottom: 40px;
+  }
+  section > h2 {
+    font-size: 1.4rem;
+    font-weight: 700;
+    color: var(--gray-900);
+    margin-bottom: 20px;
+    padding-bottom: 10px;
+    border-bottom: 2px solid var(--primary);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  section > h2 .badge {
+    font-size: 0.7rem;
+    font-weight: 600;
+    background: var(--primary-light);
+    color: var(--primary);
+    padding: 2px 10px;
+    border-radius: 12px;
+    letter-spacing: 0.04em;
+  }
+
+  h3 {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--gray-700);
+    margin: 24px 0 12px;
+  }
+
+  /* Cards */
+  .card {
+    background: white;
+    border-radius: var(--radius);
+    padding: 24px;
+    margin-bottom: 16px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.04);
+    border: 1px solid var(--gray-200);
+  }
+  .card-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 14px;
+  }
+  .card-icon {
+    width: 40px;
+    height: 40px;
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.2rem;
+    flex-shrink: 0;
+  }
+  .card-title {
+    font-size: 1.05rem;
+    font-weight: 700;
+  }
+  .card-desc {
+    font-size: 0.92rem;
+    color: var(--gray-500);
+    line-height: 1.6;
+  }
+
+  /* Feature Grid */
+  .feature-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+    gap: 16px;
+  }
+
+  /* Tables */
+  .table-wrap {
+    overflow-x: auto;
+    margin: 12px 0;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.88rem;
+    background: white;
+    border-radius: var(--radius);
+    overflow: hidden;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.04);
+  }
+  thead {
+    background: var(--gray-100);
+  }
+  th {
+    text-align: left;
+    padding: 12px 16px;
+    font-weight: 600;
+    color: var(--gray-700);
+    white-space: nowrap;
+    border-bottom: 1px solid var(--gray-200);
+  }
+  td {
+    padding: 10px 16px;
+    border-bottom: 1px solid var(--gray-100);
+    color: var(--gray-700);
+    vertical-align: top;
+  }
+  tr:last-child td { border-bottom: none; }
+  tr:hover td { background: var(--gray-50); }
+
+  /* Tags */
+  .tag {
+    display: inline-block;
+    font-size: 0.72rem;
+    font-weight: 600;
+    padding: 2px 8px;
+    border-radius: 6px;
+    letter-spacing: 0.02em;
+  }
+  .tag-blue { background: var(--primary-light); color: var(--primary); }
+  .tag-green { background: var(--secondary-light); color: var(--secondary); }
+  .tag-purple { background: var(--accent-light); color: var(--accent); }
+  .tag-orange { background: var(--warning-light); color: var(--warning); }
+  .tag-red { background: var(--danger-light); color: var(--danger); }
+
+  /* Role bars */
+  .role-bar {
+    padding: 6px 16px;
+    border-radius: 8px;
+    font-size: 0.82rem;
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .role-worker { background: #dbeafe; color: #1e40af; }
+  .role-facility { background: #d1fae5; color: #065f46; }
+  .role-system { background: #ede9fe; color: #5b21b6; }
+
+  /* Stats row */
+  .stats-row {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 16px;
+    margin: 20px 0;
+  }
+  .stat-card {
+    background: white;
+    border-radius: var(--radius);
+    padding: 20px;
+    text-align: center;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.04);
+    border: 1px solid var(--gray-200);
+  }
+  .stat-number {
+    font-size: 2rem;
+    font-weight: 800;
+    color: var(--primary);
+    line-height: 1;
+  }
+  .stat-label {
+    font-size: 0.82rem;
+    color: var(--gray-500);
+    margin-top: 6px;
+  }
+
+  /* List style */
+  ul.feature-list {
+    list-style: none;
+    padding: 0;
+  }
+  ul.feature-list li {
+    padding: 8px 0 8px 24px;
+    position: relative;
+    font-size: 0.92rem;
+    color: var(--gray-700);
+  }
+  ul.feature-list li::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 16px;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--primary);
+  }
+
+  /* Collapsible */
+  details {
+    background: white;
+    border-radius: var(--radius);
+    border: 1px solid var(--gray-200);
+    margin-bottom: 12px;
+  }
+  details summary {
+    padding: 14px 20px;
+    cursor: pointer;
+    font-weight: 600;
+    font-size: 0.95rem;
+    color: var(--gray-700);
+    user-select: none;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  details summary::marker { content: ''; }
+  details summary::before {
+    content: '\25B6';
+    font-size: 0.7rem;
+    transition: transform 0.2s;
+    color: var(--gray-500);
+  }
+  details[open] summary::before { transform: rotate(90deg); }
+  details > div {
+    padding: 0 20px 16px;
+  }
+
+  /* Footer */
+  footer {
+    text-align: center;
+    padding: 40px 0;
+    color: var(--gray-500);
+    font-size: 0.82rem;
+    border-top: 1px solid var(--gray-200);
+    margin-top: 48px;
+  }
+
+  /* Print */
+  @media print {
+    header { background: #2563eb !important; -webkit-print-color-adjust: exact; }
+    details { break-inside: avoid; }
+    details[open] summary ~ * { display: block !important; }
+  }
+
+  @media (max-width: 640px) {
+    .feature-grid { grid-template-columns: 1fr; }
+    .stats-row { grid-template-columns: repeat(2, 1fr); }
+    header h1 { font-size: 1.5rem; }
+    .toc-grid { grid-template-columns: 1fr; }
+  }
+</style>
+</head>
+<body>
+
+<header>
+  <div class="container">
+    <h1>タスタス</h1>
+    <p>看護師・介護士向け 単発/短期 求人マッチングWebサービス</p>
+    <div class="header-meta">
+      <span>本番: tastas.work</span>
+      <span>Next.js 14 + TypeScript</span>
+      <span>Supabase / PostgreSQL</span>
+      <span>Vercel デプロイ</span>
+      <span>PWA対応</span>
+    </div>
+  </div>
+</header>
+
+<main class="container">
+
+<!-- 目次 -->
+<nav class="toc">
+  <h2>目次</h2>
+  <div class="toc-grid">
+    <a href="#overview">1. サービス概要</a>
+    <a href="#tech">2. 技術スタック</a>
+    <a href="#roles">3. ユーザーロール</a>
+    <a href="#core">4. コア機能</a>
+    <a href="#worker-pages">5. 求職者向け画面</a>
+    <a href="#facility-pages">6. 施設管理者向け画面</a>
+    <a href="#system-pages">7. システム管理者向け画面</a>
+    <a href="#api">8. API一覧</a>
+    <a href="#cron">9. 自動処理（Cron）</a>
+    <a href="#data">10. データモデル</a>
+    <a href="#integrations">11. 外部連携</a>
+    <a href="#security">12. セキュリティ</a>
+  </div>
+</nav>
+
+<!-- サービス概要 -->
+<section id="overview">
+  <h2>1. サービス概要</h2>
+  <div class="card">
+    <p>
+      <strong>+タスタス</strong>は、看護師・介護士が単発や短期のシフト（1日単位）で働ける求人と、
+      医療・介護施設をマッチングするWebプラットフォームです。
+      求職者はスマートフォンから求人検索・応募・QR出退勤・レビューまで完結でき、
+      施設側はブラウザ上で求人掲載・応募管理・労働者評価を一括管理できます。
+    </p>
+  </div>
+
+  <div class="stats-row">
+    <div class="stat-card">
+      <div class="stat-number">70+</div>
+      <div class="stat-label">画面数（ページ）</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-number">80+</div>
+      <div class="stat-label">APIエンドポイント</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-number">30+</div>
+      <div class="stat-label">データモデル</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-number">3</div>
+      <div class="stat-label">ユーザーロール</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-number">6</div>
+      <div class="stat-label">Cronジョブ</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-number">3</div>
+      <div class="stat-label">通知チャネル</div>
+    </div>
+  </div>
+</section>
+
+<!-- 技術スタック -->
+<section id="tech">
+  <h2>2. 技術スタック</h2>
+  <div class="feature-grid">
+    <div class="card">
+      <div class="card-header">
+        <div class="card-icon" style="background:#dbeafe;color:#2563eb;">F</div>
+        <div class="card-title">フロントエンド</div>
+      </div>
+      <ul class="feature-list">
+        <li>Next.js 14（App Router）</li>
+        <li>TypeScript（Strict Mode）</li>
+        <li>Tailwind CSS</li>
+        <li>PWA（Web Push / Service Worker）</li>
+      </ul>
+    </div>
+    <div class="card">
+      <div class="card-header">
+        <div class="card-icon" style="background:#d1fae5;color:#059669;">B</div>
+        <div class="card-title">バックエンド</div>
+      </div>
+      <ul class="feature-list">
+        <li>Next.js Server Actions / API Routes</li>
+        <li>Prisma ORM</li>
+        <li>NextAuth.js（JWT認証）</li>
+        <li>Resend（トランザクションメール）</li>
+      </ul>
+    </div>
+    <div class="card">
+      <div class="card-header">
+        <div class="card-icon" style="background:#ede9fe;color:#7c3aed;">D</div>
+        <div class="card-title">データベース / インフラ</div>
+      </div>
+      <ul class="feature-list">
+        <li>PostgreSQL（Supabase）</li>
+        <li>Supabase Storage（画像・ファイル）</li>
+        <li>Vercel（ホスティング / Cron）</li>
+        <li>Docker（ローカル開発DB）</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<!-- ユーザーロール -->
+<section id="roles">
+  <h2>3. ユーザーロール</h2>
+  <div class="table-wrap">
+    <table>
+      <thead>
+        <tr><th>ロール</th><th>対象</th><th>認証方式</th><th>セッション</th><th>主な権限</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><span class="role-bar role-worker">求職者（Worker）</span></td>
+          <td>看護師・介護士</td>
+          <td>NextAuth.js JWT + メール認証</td>
+          <td>30日間</td>
+          <td>求人検索・応募・出退勤・レビュー・メッセージ</td>
+        </tr>
+        <tr>
+          <td><span class="role-bar role-facility">施設管理者（Facility Admin）</span></td>
+          <td>医療・介護施設の管理者</td>
+          <td>カスタムCookie認証</td>
+          <td>8時間</td>
+          <td>求人管理・応募管理・ワーカー評価・メッセージ</td>
+        </tr>
+        <tr>
+          <td><span class="role-bar role-system">システム管理者（System Admin）</span></td>
+          <td>プラットフォーム運営者</td>
+          <td>カスタムCookie認証</td>
+          <td>8時間</td>
+          <td>全データ管理・分析・設定・マスカレード</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<!-- コア機能 -->
+<section id="core">
+  <h2>4. コア機能 <span class="badge">12カテゴリ</span></h2>
+
+  <div class="feature-grid">
+
+    <!-- 求人マッチング -->
+    <div class="card">
+      <div class="card-header">
+        <div class="card-icon" style="background:#dbeafe;color:#2563eb;">1</div>
+        <div class="card-title">求人マッチングエンジン</div>
+      </div>
+      <div class="card-desc">
+        <ul class="feature-list">
+          <li>8次元以上のフィルタ検索（都道府県・市区町村・時給・サービス種別・交通手段・条件・求人タイプ・距離）</li>
+          <li>即時マッチ / 審査マッチの2モード</li>
+          <li>5種求人タイプ: 通常・オリエンテーション・勤務実績限定・お気に入り限定・オファー</li>
+          <li>日付別の募集枠管理と自動締切</li>
+          <li>キャンセル率の自動集計</li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- QR出退勤 -->
+    <div class="card">
+      <div class="card-header">
+        <div class="card-icon" style="background:#d1fae5;color:#059669;">2</div>
+        <div class="card-title">QR出退勤システム</div>
+      </div>
+      <div class="card-desc">
+        <ul class="feature-list">
+          <li>施設ごとのQRコード発行・印刷</li>
+          <li>ワーカーがスマホでスキャンして出退勤打刻</li>
+          <li>緊急コードによるフォールバック</li>
+          <li>打刻時刻の修正リクエスト → 施設承認フロー</li>
+          <li>給与自動計算（残業1.25倍 / 深夜1.25倍）</li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- 相互レビュー -->
+    <div class="card">
+      <div class="card-header">
+        <div class="card-icon" style="background:#ede9fe;color:#7c3aed;">3</div>
+        <div class="card-title">相互レビューシステム</div>
+      </div>
+      <div class="card-desc">
+        <ul class="feature-list">
+          <li>勤務完了後に双方向レビュー解放</li>
+          <li>施設→ワーカー: 5項目評価（出勤・技術・遂行・コミュニケーション・態度）</li>
+          <li>ワーカー→施設: 総合星評価 + コメント</li>
+          <li>他施設からのワーカー閲覧時にレビュー表示</li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- メッセージ -->
+    <div class="card">
+      <div class="card-header">
+        <div class="card-icon" style="background:#fef3c7;color:#d97706;">4</div>
+        <div class="card-title">メッセージ機能</div>
+      </div>
+      <div class="card-desc">
+        <ul class="feature-list">
+          <li>応募前でも常時チャット可能</li>
+          <li>施設単位 / ワーカー単位の会話スレッド</li>
+          <li>ファイル添付: 画像・PDF・Excel等（1メッセージ3ファイル、15MB上限）</li>
+          <li>システム自動メッセージ（マッチング・リマインド・完了等）</li>
+          <li>ポーリングによるリアルタイム更新</li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- 通知 -->
+    <div class="card">
+      <div class="card-header">
+        <div class="card-icon" style="background:#fee2e2;color:#dc2626;">5</div>
+        <div class="card-title">3チャネル通知システム</div>
+      </div>
+      <div class="card-desc">
+        <ul class="feature-list">
+          <li><strong>アプリ内通知</strong>: Notification画面で確認</li>
+          <li><strong>メール通知</strong>: Resend経由のトランザクションメール</li>
+          <li><strong>Web Push（PWA）</strong>: VAPID方式、iOS対応（ホーム追加必要）</li>
+          <li>イベント別の通知タイミング設定</li>
+          <li>前日リマインド・当日リマインド・勤務後レビュー催促</li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- 分析 -->
+    <div class="card">
+      <div class="card-header">
+        <div class="card-icon" style="background:#dbeafe;color:#2563eb;">6</div>
+        <div class="card-title">包括的アナリティクス</div>
+      </div>
+      <div class="card-desc">
+        <ul class="feature-list">
+          <li><strong>ワーカー分析</strong>: 登録・離脱・キャンセル率・レビュー・属性別</li>
+          <li><strong>施設分析</strong>: 登録・離脱・求人作成率・マッチング率</li>
+          <li><strong>マッチング分析</strong>: 応募数・マッチ数・マッチ所要時間</li>
+          <li><strong>LP分析</strong>: ランディングページ・キャンペーン・LINE追跡</li>
+          <li><strong>GA4連携</strong>: コンバージョンイベント取得</li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- LP管理 -->
+    <div class="card">
+      <div class="card-header">
+        <div class="card-icon" style="background:#d1fae5;color:#059669;">7</div>
+        <div class="card-title">ランディングページ（LP）管理</div>
+      </div>
+      <div class="card-desc">
+        <ul class="feature-list">
+          <li>DB管理のLP作成・編集</li>
+          <li>キャンペーンコード・LINEタグ対応</li>
+          <li>ジャンル/カテゴリ分類</li>
+          <li>埋め込み可能な求人ウィジェット</li>
+          <li>ページビュー・クリック・登録のトラッキング</li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- CSV連携 -->
+    <div class="card">
+      <div class="card-header">
+        <div class="card-icon" style="background:#ede9fe;color:#7c3aed;">8</div>
+        <div class="card-title">CSVエクスポート（CROSSNAVI連携）</div>
+      </div>
+      <div class="card-desc">
+        <ul class="feature-list">
+          <li>6種のCSVエクスポート: クライアント・求人・シフト・スタッフ・勤怠・ワーカー</li>
+          <li>UTF-8 BOM / CRLF / ダブルクォート形式</li>
+          <li>日付範囲・テキスト検索のフィルタUI</li>
+          <li>給与計算システム CROSSNAVI との連携</li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- 労働条件通知書 -->
+    <div class="card">
+      <div class="card-header">
+        <div class="card-icon" style="background:#fef3c7;color:#d97706;">9</div>
+        <div class="card-title">労働条件通知書</div>
+      </div>
+      <div class="card-desc">
+        <ul class="feature-list">
+          <li>テンプレートベースの労働契約書管理</li>
+          <li>応募ごとの通知書閲覧・ダウンロード</li>
+          <li>トークンベースのセキュアダウンロードリンク</li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- 最低賃金 -->
+    <div class="card">
+      <div class="card-header">
+        <div class="card-icon" style="background:#fee2e2;color:#dc2626;">10</div>
+        <div class="card-title">最低賃金管理</div>
+      </div>
+      <div class="card-desc">
+        <ul class="feature-list">
+          <li>都道府県別の最低賃金テーブル管理</li>
+          <li>施行日（effective_from）による自動切替</li>
+          <li>CSVインポート / エクスポート</li>
+          <li>変更履歴管理</li>
+          <li>求人作成時の時給バリデーション・警告</li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- お気に入り/ブックマーク -->
+    <div class="card">
+      <div class="card-header">
+        <div class="card-icon" style="background:#dbeafe;color:#2563eb;">11</div>
+        <div class="card-title">お気に入り・ブックマーク</div>
+      </div>
+      <div class="card-desc">
+        <ul class="feature-list">
+          <li>施設のお気に入り登録</li>
+          <li>求人の「あとで見る」ブックマーク</li>
+          <li>施設ミュート機能（非表示）</li>
+          <li>施設側のお気に入りワーカー管理</li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- 開発者ポータル -->
+    <div class="card">
+      <div class="card-header">
+        <div class="card-icon" style="background:#d1fae5;color:#059669;">12</div>
+        <div class="card-title">開発者ポータル</div>
+      </div>
+      <div class="card-desc">
+        <ul class="feature-list">
+          <li>サイトマップ / ページ構成可視化</li>
+          <li>デバッグツール（DB疎通・環境変数・時刻確認）</li>
+          <li>通知ログビューア・テスト送信</li>
+          <li>給与計算式リファレンス</li>
+          <li>デバッグ用JST時刻オーバーライド</li>
+          <li>アクティビティログ</li>
+        </ul>
+      </div>
+    </div>
+
+  </div>
+</section>
+
+<!-- 求職者向け画面 -->
+<section id="worker-pages">
+  <h2>5. 求職者向け画面一覧 <span class="badge">WORKER</span></h2>
+
+  <details open>
+    <summary>認証・登録（6画面）</summary>
+    <div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>パス</th><th>画面名</th><th>概要</th></tr></thead>
+          <tbody>
+            <tr><td><code>/login</code></td><td>ログイン</td><td>メール/パスワードでのログイン</td></tr>
+            <tr><td><code>/register</code></td><td>新規登録リダイレクト</td><td>/register/worker へ自動転送</td></tr>
+            <tr><td><code>/register/worker</code></td><td>ワーカー新規登録</td><td>2ステップ式（①基本情報 → ②住所・資格・同意）URL遷移なしstate切替。登録完了→/auth/verify-pendingへ遷移</td></tr>
+            <tr><td colspan="3" style="background:#f8fafc;padding:8px 16px;font-size:0.85em;">
+              <strong>SMS認証フロー</strong>（SmsVerificationコンポーネント内、URL遷移なし）<br>
+              [input] 電話番号入力 → POST /api/sms/send-code →
+              [codeSent] 6桁コード入力 → POST /api/sms/verify-code → JWT取得 →
+              [verified] 認証済み表示<br>
+              再送信クールダウン60秒 / 電話番号変更時は自動リセット / GA4タグ発火なし<br>
+              <strong>GA4イベント:</strong> registration_page_view（表示時）, sign_up（登録完了時）/ ステップ遷移・SMS認証時は発火なし
+            </td></tr>
+            <tr><td><code>/auth/verify</code></td><td>メール認証結果</td><td>認証完了/エラー/期限切れ表示</td></tr>
+            <tr><td><code>/auth/verify-pending</code></td><td>認証待ち</td><td>メール送信済み案内</td></tr>
+            <tr><td><code>/auth/resend-verification</code></td><td>認証メール再送信</td><td>再送トリガー画面</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </details>
+
+  <details>
+    <summary>求人検索・応募（7画面）</summary>
+    <div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>パス</th><th>画面名</th><th>概要</th></tr></thead>
+          <tbody>
+            <tr><td><code>/</code></td><td>求人一覧（トップ）</td><td>フィルタ検索・無限スクロール</td></tr>
+            <tr><td><code>/jobs/[id]</code></td><td>求人詳細</td><td>タブ形式（概要・詳細・条件・レビュー）</td></tr>
+            <tr><td><code>/jobs/[id]/labor-document</code></td><td>労働条件通知書</td><td>労働契約の閲覧（要認証）</td></tr>
+            <tr><td><code>/public/jobs</code></td><td>公開求人一覧</td><td>ログイン不要の求人一覧</td></tr>
+            <tr><td><code>/public/jobs/[id]</code></td><td>公開求人詳細</td><td>ログイン不要の求人詳細</td></tr>
+            <tr><td><code>/application-complete</code></td><td>応募完了</td><td>応募完了画面</td></tr>
+            <tr><td><code>/job-list</code></td><td>求人一覧（別レイアウト）</td><td>代替リスト表示</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </details>
+
+  <details>
+    <summary>マイジョブ・応募管理（4画面）</summary>
+    <div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>パス</th><th>画面名</th><th>概要</th></tr></thead>
+          <tbody>
+            <tr><td><code>/my-jobs</code></td><td>マイジョブ</td><td>タブ: 承認待ち・予定・勤務中・完了・キャンセル</td></tr>
+            <tr><td><code>/my-jobs/[id]</code></td><td>マイジョブ詳細</td><td>応募詳細情報</td></tr>
+            <tr><td><code>/my-jobs/[id]/labor-document</code></td><td>労働条件通知書（マッチ済み）</td><td>マッチ済み求人の契約書</td></tr>
+            <tr><td><code>/applications</code></td><td>応募管理</td><td>応募ステータス一覧</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </details>
+
+  <details>
+    <summary>マイページ（10画面）</summary>
+    <div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>パス</th><th>画面名</th><th>概要</th></tr></thead>
+          <tbody>
+            <tr><td><code>/mypage</code></td><td>マイページトップ</td><td>ナビゲーションハブ</td></tr>
+            <tr><td><code>/mypage/profile</code></td><td>プロフィール編集</td><td>全プロフィールセクション</td></tr>
+            <tr><td><code>/mypage/applications</code></td><td>応募履歴</td><td>過去の応募一覧</td></tr>
+            <tr><td><code>/mypage/reviews</code></td><td>投稿したレビュー</td><td>自分が書いたレビュー一覧</td></tr>
+            <tr><td><code>/mypage/reviews/received</code></td><td>受け取ったレビュー</td><td>施設からの評価一覧</td></tr>
+            <tr><td><code>/mypage/reviews/[applicationId]</code></td><td>レビュー投稿</td><td>勤務後のレビュー入力フォーム</td></tr>
+            <tr><td><code>/mypage/muted-facilities</code></td><td>ミュート施設</td><td>非表示施設の管理</td></tr>
+            <tr><td><code>/mypage/notifications</code></td><td>通知設定</td><td>プッシュ通知の設定</td></tr>
+            <tr><td><code>/mypage/attendance/[id]</code></td><td>出退勤詳細</td><td>QR打刻の記録詳細</td></tr>
+            <tr><td><code>/password-reset</code></td><td>パスワードリセット</td><td>パスワードリセット申請</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </details>
+
+  <details>
+    <summary>コミュニケーション・その他（8画面）</summary>
+    <div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>パス</th><th>画面名</th><th>概要</th></tr></thead>
+          <tbody>
+            <tr><td><code>/messages</code></td><td>メッセージ</td><td>施設とのチャット（メッセージ/お知らせタブ）</td></tr>
+            <tr><td><code>/notifications</code></td><td>通知一覧</td><td>システム・アクティビティ通知</td></tr>
+            <tr><td><code>/favorites</code></td><td>お気に入り施設</td><td>ブックマーク済み施設</td></tr>
+            <tr><td><code>/bookmarks</code></td><td>あとで見る</td><td>保存した求人一覧</td></tr>
+            <tr><td><code>/facilities/[id]</code></td><td>施設詳細</td><td>施設情報・レビュー・他の求人</td></tr>
+            <tr><td><code>/attendance</code></td><td>QR出退勤</td><td>QRスキャン / 緊急コード入力</td></tr>
+            <tr><td><code>/attendance/modify</code></td><td>出退勤修正</td><td>打刻時刻の修正リクエスト</td></tr>
+            <tr><td><code>/contact</code></td><td>お問い合わせ</td><td>問い合わせフォーム</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </details>
+</section>
+
+<!-- 施設管理者向け画面 -->
+<section id="facility-pages">
+  <h2>6. 施設管理者向け画面一覧 <span class="badge">FACILITY</span></h2>
+
+  <details open>
+    <summary>求人管理（7画面）</summary>
+    <div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>パス</th><th>画面名</th><th>概要</th></tr></thead>
+          <tbody>
+            <tr><td><code>/admin/jobs</code></td><td>求人一覧</td><td>全求人のフィルタ表示</td></tr>
+            <tr><td><code>/admin/jobs/new</code></td><td>求人作成</td><td>求人作成フォーム（時給・条件・日程等）</td></tr>
+            <tr><td><code>/admin/jobs/[id]</code></td><td>求人詳細</td><td>求人詳細 + 応募者概要</td></tr>
+            <tr><td><code>/admin/jobs/[id]/edit</code></td><td>求人編集</td><td>求人編集フォーム</td></tr>
+            <tr><td><code>/admin/jobs/templates</code></td><td>テンプレート一覧</td><td>再利用可能なテンプレート</td></tr>
+            <tr><td><code>/admin/jobs/templates/new</code></td><td>テンプレート作成</td><td>テンプレート作成フォーム</td></tr>
+            <tr><td><code>/admin/jobs/templates/[id]/edit</code></td><td>テンプレート編集</td><td>テンプレート編集フォーム</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </details>
+
+  <details>
+    <summary>応募・ワーカー管理（9画面）</summary>
+    <div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>パス</th><th>画面名</th><th>概要</th></tr></thead>
+          <tbody>
+            <tr><td><code>/admin/applications</code></td><td>応募者管理</td><td>求人別 / ワーカー別の2ビュー</td></tr>
+            <tr><td><code>/admin/workers</code></td><td>ワーカー一覧</td><td>フィルタ・検索付きリスト</td></tr>
+            <tr><td><code>/admin/workers/[id]</code></td><td>ワーカー詳細</td><td>プロフィール・勤務履歴・評価</td></tr>
+            <tr><td><code>/admin/workers/[id]/review</code></td><td>ワーカー評価</td><td>5項目評価フォーム</td></tr>
+            <tr><td><code>/admin/workers/[id]/certificates</code></td><td>資格証明書</td><td>ワーカーの資格情報</td></tr>
+            <tr><td><code>/admin/workers/[id]/emergency-contacts</code></td><td>緊急連絡先</td><td>緊急連絡先情報</td></tr>
+            <tr><td><code>/admin/workers/[id]/schedules</code></td><td>スケジュール</td><td>シフトスケジュール表示</td></tr>
+            <tr><td><code>/admin/workers/[id]/labor-documents</code></td><td>労働条件通知書一覧</td><td>ワーカーの全通知書</td></tr>
+            <tr><td><code>/admin/workers/[id]/labor-documents/[appId]</code></td><td>労働条件通知書詳細</td><td>応募別の通知書</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </details>
+
+  <details>
+    <summary>出退勤・シフト管理（4画面）</summary>
+    <div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>パス</th><th>画面名</th><th>概要</th></tr></thead>
+          <tbody>
+            <tr><td><code>/admin/attendance</code></td><td>QRコード印刷</td><td>施設のQRコード表示・印刷</td></tr>
+            <tr><td><code>/admin/tasks/attendance</code></td><td>出退勤修正リクエスト一覧</td><td>承認待ちの修正申請</td></tr>
+            <tr><td><code>/admin/tasks/attendance/[id]</code></td><td>出退勤修正リクエスト詳細</td><td>個別の修正申請の確認・承認</td></tr>
+            <tr><td><code>/admin/shifts</code></td><td>シフトカレンダー</td><td>週次/月次のシフト表示</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </details>
+
+  <details>
+    <summary>コミュニケーション・設定（8画面）</summary>
+    <div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>パス</th><th>画面名</th><th>概要</th></tr></thead>
+          <tbody>
+            <tr><td><code>/admin/messages</code></td><td>メッセージ</td><td>ワーカーとのチャット</td></tr>
+            <tr><td><code>/admin/reviews</code></td><td>施設レビュー</td><td>ワーカーからのレビュー一覧</td></tr>
+            <tr><td><code>/admin/worker-reviews</code></td><td>ワーカーレビュー</td><td>投稿したワーカー評価</td></tr>
+            <tr><td><code>/admin/facility</code></td><td>施設情報</td><td>施設プロフィール編集</td></tr>
+            <tr><td><code>/admin/notifications</code></td><td>通知一覧</td><td>施設向け通知</td></tr>
+            <tr><td><code>/admin/reports/usage</code></td><td>利用レポート</td><td>請求・勤務詳細レポート</td></tr>
+            <tr><td><code>/admin/settings/offer-templates</code></td><td>オファーテンプレート</td><td>オファーメッセージの定型文管理</td></tr>
+            <tr><td><code>/admin/faq</code></td><td>FAQ</td><td>施設向けFAQ</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </details>
+</section>
+
+<!-- システム管理者向け画面 -->
+<section id="system-pages">
+  <h2>7. システム管理者向け画面一覧 <span class="badge">SYSTEM ADMIN</span></h2>
+
+  <details open>
+    <summary>ダッシュボード・分析（6画面）</summary>
+    <div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>パス</th><th>画面名</th><th>概要</th></tr></thead>
+          <tbody>
+            <tr><td><code>/system-admin</code></td><td>ダッシュボード</td><td>KPIカード・チャート・アラート</td></tr>
+            <tr><td><code>/system-admin/analytics</code></td><td>分析メイン</td><td>ワーカー/施設/マッチングタブ</td></tr>
+            <tr><td><code>/system-admin/analytics/regions</code></td><td>地域登録</td><td>分析用地域設定</td></tr>
+            <tr><td><code>/system-admin/analytics/export</code></td><td>分析エクスポート</td><td>スプレッドシートデータ出力</td></tr>
+            <tr><td><code>/system-admin/analytics/ai</code></td><td>AI予測（デモ）</td><td>マッチング最適化AI</td></tr>
+            <tr><td><code>/system-admin/alerts</code></td><td>システムアラート</td><td>異常検知アラート</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </details>
+
+  <details>
+    <summary>ユーザー・施設・求人管理（5画面）</summary>
+    <div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>パス</th><th>画面名</th><th>概要</th></tr></thead>
+          <tbody>
+            <tr><td><code>/system-admin/workers</code></td><td>ワーカー管理</td><td>プラットフォーム全体のワーカー一覧</td></tr>
+            <tr><td><code>/system-admin/workers/[id]</code></td><td>ワーカー詳細</td><td>拡張プロフィール表示</td></tr>
+            <tr><td><code>/system-admin/facilities</code></td><td>施設管理</td><td>全施設・マスカレード・ジオコーディング</td></tr>
+            <tr><td><code>/system-admin/facilities/new</code></td><td>施設作成</td><td>システム側からの施設登録</td></tr>
+            <tr><td><code>/system-admin/jobs</code></td><td>全求人管理</td><td>プラットフォーム全体の求人一覧</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </details>
+
+  <details>
+    <summary>コンテンツ管理（10画面）</summary>
+    <div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>パス</th><th>画面名</th><th>概要</th></tr></thead>
+          <tbody>
+            <tr><td><code>/system-admin/content</code></td><td>コンテンツ管理ハブ</td><td>各サブセクションへのリンク</td></tr>
+            <tr><td><code>/system-admin/content/faq</code></td><td>FAQエディタ</td><td>ワーカー/施設FAQ CRUD</td></tr>
+            <tr><td><code>/system-admin/content/user-guide</code></td><td>ユーザーガイド</td><td>施設向けPDFガイド管理</td></tr>
+            <tr><td><code>/system-admin/content/legal</code></td><td>法的文書</td><td>利用規約・プライバシーポリシーエディタ</td></tr>
+            <tr><td><code>/system-admin/content/labor-template</code></td><td>労働条件テンプレート</td><td>通知書テンプレート管理</td></tr>
+            <tr><td><code>/system-admin/content/templates</code></td><td>メッセージテンプレート</td><td>求人・メール・メッセージテンプレート</td></tr>
+            <tr><td><code>/system-admin/content/notifications</code></td><td>通知設定</td><td>タイミング・対象設定</td></tr>
+            <tr><td><code>/system-admin/announcements</code></td><td>お知らせ管理</td><td>プラットフォーム全体のお知らせCRUD</td></tr>
+            <tr><td><code>/system-admin/announcements/create</code></td><td>お知らせ新規作成</td><td>新しいお知らせの作成</td></tr>
+            <tr><td><code>/system-admin/announcements/[id]</code></td><td>お知らせ編集</td><td>既存お知らせの編集</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </details>
+
+  <details>
+    <summary>LP・CSV・設定（15画面）</summary>
+    <div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>パス</th><th>画面名</th><th>概要</th></tr></thead>
+          <tbody>
+            <tr><td><code>/system-admin/login</code></td><td>ログイン</td><td>システム管理者ログイン画面</td></tr>
+            <tr><td><code>/system-admin/lp</code></td><td>LP管理</td><td>ランディングページ管理</td></tr>
+            <tr><td><code>/system-admin/lp/genres</code></td><td>LPジャンル</td><td>ジャンル/カテゴリ管理</td></tr>
+            <tr><td><code>/system-admin/lp/guide</code></td><td>LP作成ガイド</td><td>ランディングページ作成ガイド</td></tr>
+            <tr><td><code>/system-admin/lp/recommended-jobs</code></td><td>おすすめ求人</td><td>注目求人管理</td></tr>
+            <tr><td><code>/system-admin/lp/recommended-jobs/preview</code></td><td>おすすめ求人プレビュー</td><td>おすすめ求人の表示プレビュー</td></tr>
+            <tr><td><code>/system-admin/lp/tracking</code></td><td>LPトラッキング</td><td>LP閲覧・コンバージョン追跡</td></tr>
+            <tr><td><code>/system-admin/lp/tracking/public-jobs</code></td><td>公開求人トラッキング</td><td>公開求人ページの閲覧追跡</td></tr>
+            <tr><td><code>/system-admin/lp/tracking/spec</code></td><td>トラッキングスペック</td><td>トラッキング仕様・設定</td></tr>
+            <tr><td><code>/system-admin/csv-export</code></td><td>CSVエクスポート</td><td>CROSSNAVI連携エクスポート</td></tr>
+            <tr><td><code>/system-admin/attendance</code></td><td>出退勤管理</td><td>プラットフォーム全体の勤怠データ</td></tr>
+            <tr><td><code>/system-admin/settings/admins</code></td><td>管理者ユーザー管理</td><td>システム管理者アカウントCRUD</td></tr>
+            <tr><td><code>/system-admin/settings/form-destinations</code></td><td>フォーム送信先設定</td><td>フォーム送信先メールアドレス管理</td></tr>
+            <tr><td><code>/system-admin/settings/minimum-wage</code></td><td>最低賃金設定</td><td>都道府県別最低賃金管理</td></tr>
+            <tr><td><code>/system-admin/settings/system</code></td><td>システム設定</td><td>機能フラグ管理</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </details>
+
+  <details>
+    <summary>開発者ポータル（10画面）</summary>
+    <div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>パス</th><th>画面名</th><th>概要</th></tr></thead>
+          <tbody>
+            <tr><td><code>/system-admin/dev-portal</code></td><td>開発者ポータル</td><td>サイトマップ・デバッグツール・メモ帳</td></tr>
+            <tr><td><code>/system-admin/dev-portal/admin-logs</code></td><td>管理者ログ</td><td>管理者操作の監査ログ</td></tr>
+            <tr><td><code>/system-admin/dev-portal/debug-checklist</code></td><td>デバッグチェックリスト</td><td>デバッグ項目チェック</td></tr>
+            <tr><td><code>/system-admin/dev-portal/debug-time</code></td><td>デバッグ時刻制御</td><td>JSTタイムオーバーライド</td></tr>
+            <tr><td><code>/system-admin/dev-portal/error-alert</code></td><td>エラーアラート設定</td><td>アラート受信者管理</td></tr>
+            <tr><td><code>/system-admin/dev-portal/formulas</code></td><td>給与計算式</td><td>賃金計算ロジック表示</td></tr>
+            <tr><td><code>/system-admin/dev-portal/logs</code></td><td>アクティビティログ</td><td>システム全体のログ</td></tr>
+            <tr><td><code>/system-admin/dev-portal/notification-logs</code></td><td>通知ログ</td><td>Push/メール送信履歴</td></tr>
+            <tr><td><code>/system-admin/dev-portal/sample-images</code></td><td>サンプル画像</td><td>開発用サンプル画像管理</td></tr>
+            <tr><td><code>/system-admin/dev-portal/test-notifications</code></td><td>テスト通知</td><td>テストメール/Push送信</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </details>
+</section>
+
+<!-- API一覧 -->
+<section id="api">
+  <h2>8. API一覧 <span class="badge">80+ ENDPOINTS</span></h2>
+
+  <details>
+    <summary>認証API（6エンドポイント）</summary>
+    <div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>パス</th><th>メソッド</th><th>概要</th></tr></thead>
+          <tbody>
+            <tr><td><code>/api/auth/[...nextauth]</code></td><td>*</td><td>NextAuth.jsハンドラ</td></tr>
+            <tr><td><code>/api/auth/register</code></td><td>POST</td><td>ワーカー新規登録</td></tr>
+            <tr><td><code>/api/auth/verify</code></td><td>GET</td><td>メール認証（サーバーサイドリダイレクト）</td></tr>
+            <tr><td><code>/api/auth/auto-login</code></td><td>GET</td><td>認証後自動ログイン</td></tr>
+            <tr><td><code>/api/auth/resend-verification</code></td><td>POST</td><td>認証メール再送信</td></tr>
+            <tr><td><code>/api/auth/preview-verification-email</code></td><td>GET</td><td>メールテンプレートプレビュー（dev）</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </details>
+
+  <details>
+    <summary>求人・検索API（3エンドポイント）</summary>
+    <div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>パス</th><th>概要</th></tr></thead>
+          <tbody>
+            <tr><td><code>/api/jobs</code></td><td>求人一覧取得（フィルタ対応）</td></tr>
+            <tr><td><code>/api/jobs/counts</code></td><td>ステータス/フィルタ別求人件数</td></tr>
+            <tr><td><code>/api/minimum-wage</code></td><td>都道府県別最低賃金データ</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </details>
+
+  <details>
+    <summary>メッセージAPI（6エンドポイント）</summary>
+    <div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>パス</th><th>概要</th></tr></thead>
+          <tbody>
+            <tr><td><code>/api/messages/conversations</code></td><td>ワーカー: 会話一覧</td></tr>
+            <tr><td><code>/api/messages/detail</code></td><td>ワーカー: スレッドメッセージ</td></tr>
+            <tr><td><code>/api/messages/announcements</code></td><td>ワーカー: お知らせ一覧</td></tr>
+            <tr><td><code>/api/admin/messages/conversations</code></td><td>施設: 会話一覧</td></tr>
+            <tr><td><code>/api/admin/messages/detail</code></td><td>施設: スレッドメッセージ</td></tr>
+            <tr><td><code>/api/admin/messages/announcements</code></td><td>施設: お知らせ一覧</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </details>
+
+  <details>
+    <summary>施設管理API（15エンドポイント）</summary>
+    <div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>パス</th><th>概要</th></tr></thead>
+          <tbody>
+            <tr><td><code>/api/admin/session-check</code></td><td>管理者セッション検証</td></tr>
+            <tr><td><code>/api/admin/facility</code></td><td>施設情報取得・更新</td></tr>
+            <tr><td><code>/api/admin/jobs/list</code></td><td>施設求人一覧</td></tr>
+            <tr><td><code>/api/admin/applications</code></td><td>応募者一覧</td></tr>
+            <tr><td><code>/api/admin/applications/by-worker</code></td><td>ワーカー別応募一覧</td></tr>
+            <tr><td><code>/api/admin/workers/list</code></td><td>ワーカー一覧</td></tr>
+            <tr><td><code>/api/admin/workers/[id]</code></td><td>ワーカー詳細</td></tr>
+            <tr><td><code>/api/admin/workers/[id]/certificates</code></td><td>資格証明書</td></tr>
+            <tr><td><code>/api/admin/workers/[id]/emergency-contacts</code></td><td>緊急連絡先</td></tr>
+            <tr><td><code>/api/admin/workers/[id]/schedules</code></td><td>スケジュール</td></tr>
+            <tr><td><code>/api/admin/shifts</code></td><td>シフトデータ</td></tr>
+            <tr><td><code>/api/admin/reviews</code></td><td>レビュー</td></tr>
+            <tr><td><code>/api/admin/notifications</code></td><td>施設通知</td></tr>
+            <tr><td><code>/api/admin/labor-documents/request</code></td><td>労働条件通知書トークンリクエスト</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </details>
+
+  <details>
+    <summary>勤怠・ファイル・Push・銀行API（9エンドポイント）</summary>
+    <div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>パス</th><th>概要</th></tr></thead>
+          <tbody>
+            <tr><td><code>/api/attendance/record</code></td><td>出退勤打刻記録</td></tr>
+            <tr><td><code>/api/upload</code></td><td>ファイルアップロード</td></tr>
+            <tr><td><code>/api/upload/presigned</code></td><td>署名付きアップロードURL生成</td></tr>
+            <tr><td><code>/api/download/labor-docs/[token]</code></td><td>トークンベース労働条件通知書DL</td></tr>
+            <tr><td><code>/api/push/subscribe</code></td><td>Push通知サブスクリプション登録</td></tr>
+            <tr><td><code>/api/push/unsubscribe</code></td><td>Push通知サブスクリプション解除</td></tr>
+            <tr><td><code>/api/push/send</code></td><td>Push通知送信</td></tr>
+            <tr><td><code>/api/bank/search</code></td><td>銀行名検索</td></tr>
+            <tr><td><code>/api/bank/[bankCode]/branches</code></td><td>銀行支店一覧</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </details>
+
+  <details>
+    <summary>LP・トラッキングAPI（12エンドポイント）</summary>
+    <div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>パス</th><th>概要</th></tr></thead>
+          <tbody>
+            <tr><td><code>/api/lp/[id]</code></td><td>LP取得</td></tr>
+            <tr><td><code>/api/lp/[id]/html</code></td><td>LP HTML取得</td></tr>
+            <tr><td><code>/api/lp-config</code></td><td>LP設定</td></tr>
+            <tr><td><code>/api/lp-campaign-codes</code></td><td>キャンペーンコード管理</td></tr>
+            <tr><td><code>/api/lp-code-genres</code></td><td>LPジャンルコード</td></tr>
+            <tr><td><code>/api/lp-tracking</code></td><td>LPページビュートラッキング</td></tr>
+            <tr><td><code>/api/job-analytics</code></td><td>求人閲覧/クリック分析</td></tr>
+            <tr><td><code>/api/ga-analytics</code></td><td>Google Analyticsデータ取得</td></tr>
+            <tr><td><code>/api/funnel-analytics</code></td><td>登録ファネル分析</td></tr>
+            <tr><td><code>/api/job-search-tracking</code></td><td>検索クエリトラッキング</td></tr>
+            <tr><td><code>/api/job-detail-tracking</code></td><td>求人詳細閲覧トラッキング</td></tr>
+            <tr><td><code>/api/application-click-tracking</code></td><td>応募ボタンクリックトラッキング</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </details>
+
+  <details>
+    <summary>システム管理API（20+エンドポイント）</summary>
+    <div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>パス</th><th>概要</th></tr></thead>
+          <tbody>
+            <tr><td><code>/api/system-admin/auth</code></td><td>ログイン/ログアウト</td></tr>
+            <tr><td><code>/api/system-admin/admins</code></td><td>管理者ユーザー管理</td></tr>
+            <tr><td><code>/api/system-admin/alerts</code></td><td>システムアラート</td></tr>
+            <tr><td><code>/api/system-admin/attendance-csv</code></td><td>勤怠CSVエクスポート</td></tr>
+            <tr><td><code>/api/system-admin/client-csv</code></td><td>クライアントCSVエクスポート</td></tr>
+            <tr><td><code>/api/system-admin/job-csv</code></td><td>求人CSVエクスポート</td></tr>
+            <tr><td><code>/api/system-admin/shift-csv</code></td><td>シフトCSVエクスポート</td></tr>
+            <tr><td><code>/api/system-admin/staff-csv</code></td><td>スタッフCSVエクスポート</td></tr>
+            <tr><td><code>/api/system-admin/worker-csv</code></td><td>ワーカーCSVエクスポート</td></tr>
+            <tr><td><code>/api/system-admin/activity-logs</code></td><td>アクティビティログ</td></tr>
+            <tr><td><code>/api/system-admin/error-alert-recipients</code></td><td>アラート受信者設定</td></tr>
+            <tr><td><code>/api/system-admin/minimum-wage</code></td><td>最低賃金CRUD</td></tr>
+            <tr><td><code>/api/system-admin/minimum-wage/import</code></td><td>最低賃金CSVインポート</td></tr>
+            <tr><td><code>/api/system-admin/minimum-wage/export</code></td><td>最低賃金CSVエクスポート</td></tr>
+            <tr><td><code>/api/system-admin/minimum-wage/history</code></td><td>最低賃金変更履歴</td></tr>
+            <tr><td><code>/api/system-admin/notification-logs</code></td><td>通知送信履歴</td></tr>
+            <tr><td><code>/api/system-admin/notification-settings</code></td><td>通知タイミング設定</td></tr>
+            <tr><td><code>/api/system-admin/recommended-jobs</code></td><td>おすすめ求人管理</td></tr>
+            <tr><td><code>/api/system-admin/system-settings</code></td><td>機能フラグ</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </details>
+</section>
+
+<!-- Cronジョブ -->
+<section id="cron">
+  <h2>9. 自動処理（Cron Jobs） <span class="badge">6 JOBS</span></h2>
+  <div class="table-wrap">
+    <table>
+      <thead><tr><th>パス</th><th>実行タイミング</th><th>処理内容</th></tr></thead>
+      <tbody>
+        <tr>
+          <td><code>/api/cron/update-statuses</code></td>
+          <td>定期実行</td>
+          <td>シフト時刻に基づくステータス自動遷移<br><span class="tag tag-blue">SCHEDULED → WORKING → COMPLETED_PENDING</span></td>
+        </tr>
+        <tr>
+          <td><code>/api/cron/job-batch</code></td>
+          <td>毎日</td>
+          <td>求人ステータス更新（期限切れ・締切チェック）<br><span class="tag tag-green">PUBLISHED → EXPIRED</span></td>
+        </tr>
+        <tr>
+          <td><code>/api/cron/notifications</code></td>
+          <td>毎日</td>
+          <td>事前リマインド送信（前日・当日・勤務後レビュー催促）</td>
+        </tr>
+        <tr>
+          <td><code>/api/cron/email-quota</code></td>
+          <td>毎日</td>
+          <td>Resendメール送信クォータチェック</td>
+        </tr>
+        <tr>
+          <td><code>/api/cron/error-alert</code></td>
+          <td>定期実行</td>
+          <td>エラーアラートメール送信</td>
+        </tr>
+        <tr>
+          <td><code>/api/cron/update-bank-data</code></td>
+          <td>定期実行</td>
+          <td>銀行マスターデータ更新</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<!-- データモデル -->
+<section id="data">
+  <h2>10. 主要データモデル <span class="badge">30+ MODELS</span></h2>
+
+  <details open>
+    <summary>ユーザー・認証関連</summary>
+    <div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>モデル</th><th>概要</th><th>主なフィールド</th></tr></thead>
+          <tbody>
+            <tr><td><strong>User</strong></td><td>ワーカー（求職者）プロフィール</td><td>名前・カナ・生年月日・電話・住所・資格・勤務希望・銀行口座・年金番号・緊急連絡先・位置情報</td></tr>
+            <tr><td><strong>Facility</strong></td><td>施設情報</td><td>名前・法人名・住所・位置情報・画像・連絡先・初回ウェルカムメッセージ・QRトークン・緊急コード</td></tr>
+            <tr><td><strong>FacilityAdmin</strong></td><td>施設管理者アカウント</td><td>メール・パスワード・施設紐付き</td></tr>
+            <tr><td><strong>SystemAdmin</strong></td><td>システム管理者アカウント</td><td>メール・パスワード・権限レベル</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </details>
+
+  <details>
+    <summary>求人・マッチング関連</summary>
+    <div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>モデル</th><th>概要</th><th>主なフィールド</th></tr></thead>
+          <tbody>
+            <tr><td><strong>Job</strong></td><td>求人（親）</td><td>タイトル・時間・時給・交通費・条件・フラグ・求人タイプ（5種）</td></tr>
+            <tr><td><strong>JobWorkDate</strong></td><td>勤務日（子）</td><td>日付・募集枠数・応募数・マッチ数・締切日</td></tr>
+            <tr><td><strong>Application</strong></td><td>応募</td><td>ワーカー-勤務日紐付き・ステータス（6段階）・キャンセル元</td></tr>
+            <tr><td><strong>JobTemplate</strong></td><td>求人テンプレート</td><td>施設別の再利用テンプレート</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </details>
+
+  <details>
+    <summary>コミュニケーション・評価関連</summary>
+    <div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>モデル</th><th>概要</th></tr></thead>
+          <tbody>
+            <tr><td><strong>Message</strong></td><td>チャットメッセージ（ファイル添付対応）</td></tr>
+            <tr><td><strong>Review</strong></td><td>双方向レビュー（5項目評価＋コメント）</td></tr>
+            <tr><td><strong>Notification</strong></td><td>アプリ内通知レコード</td></tr>
+            <tr><td><strong>PushSubscription</strong></td><td>デバイス別Push購読情報</td></tr>
+            <tr><td><strong>SystemAnnouncement</strong></td><td>プラットフォームお知らせ</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </details>
+
+  <details>
+    <summary>勤怠・給与関連</summary>
+    <div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>モデル</th><th>概要</th></tr></thead>
+          <tbody>
+            <tr><td><strong>Attendance</strong></td><td>QR出退勤記録（チェックイン/アウト時刻・位置）</td></tr>
+            <tr><td><strong>AttendanceModificationRequest</strong></td><td>打刻修正リクエスト（ワーカー申請 → 施設承認）</td></tr>
+            <tr><td><strong>MinimumWage</strong></td><td>都道府県別最低賃金（施行日付き）</td></tr>
+            <tr><td><strong>MinimumWageHistory</strong></td><td>最低賃金変更履歴</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </details>
+
+  <details>
+    <summary>お気に入り・ブックマーク・その他</summary>
+    <div>
+      <div class="table-wrap">
+        <table>
+          <thead><tr><th>モデル</th><th>概要</th></tr></thead>
+          <tbody>
+            <tr><td><strong>Bookmark</strong></td><td>求人ブックマーク（FAVORITE / WATCH_LATER）</td></tr>
+            <tr><td><strong>FacilityFavorite</strong></td><td>施設お気に入り</td></tr>
+            <tr><td><strong>MutedFacility</strong></td><td>施設ミュート</td></tr>
+            <tr><td><strong>FavoriteWorker</strong></td><td>施設のお気に入りワーカー</td></tr>
+            <tr><td><strong>LandingPage</strong></td><td>ランディングページ</td></tr>
+            <tr><td><strong>LPGenre</strong></td><td>LPジャンル分類</td></tr>
+            <tr><td><strong>ActivityLog</strong></td><td>管理操作の監査ログ</td></tr>
+            <tr><td><strong>SystemSettings</strong></td><td>プラットフォーム機能フラグ（KV）</td></tr>
+            <tr><td><strong>BankMaster</strong></td><td>銀行・支店マスターデータ</td></tr>
+            <tr><td><strong>OfferTemplate</strong></td><td>オファーメッセージ定型文</td></tr>
+            <tr><td><strong>NotificationSetting</strong></td><td>イベント別通知設定</td></tr>
+            <tr><td><strong>AnalyticsRegion</strong></td><td>分析用地域定義</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </details>
+</section>
+
+<!-- 外部連携 -->
+<section id="integrations">
+  <h2>11. 外部連携 <span class="badge">INTEGRATIONS</span></h2>
+  <div class="table-wrap">
+    <table>
+      <thead><tr><th>サービス</th><th>用途</th><th>連携方式</th></tr></thead>
+      <tbody>
+        <tr><td><strong>Supabase</strong></td><td>PostgreSQL DB + ファイルストレージ</td><td>Prisma ORM / Supabase JS SDK</td></tr>
+        <tr><td><strong>Vercel</strong></td><td>ホスティング・Cron・デプロイ</td><td>Git連携自動デプロイ</td></tr>
+        <tr><td><strong>Resend</strong></td><td>トランザクションメール送信</td><td>Resend API</td></tr>
+        <tr><td><strong>Google Analytics 4</strong></td><td>コンバージョントラッキング</td><td>GA4 Reporting API</td></tr>
+        <tr><td><strong>CROSSNAVI</strong></td><td>給与計算・人事管理システム</td><td>CSV一括エクスポート</td></tr>
+        <tr><td><strong>LINE</strong></td><td>LP経由のLINE友達追加追跡</td><td>LINEタグ・リダイレクトURL</td></tr>
+        <tr><td><strong>Web Push (VAPID)</strong></td><td>PWAプッシュ通知</td><td>Service Worker / VAPID認証</td></tr>
+      </tbody>
+    </table>
+  </div>
+</section>
+
+<!-- セキュリティ -->
+<section id="security">
+  <h2>12. セキュリティ</h2>
+  <div class="feature-grid">
+    <div class="card">
+      <div class="card-header">
+        <div class="card-icon" style="background:#fee2e2;color:#dc2626;">A</div>
+        <div class="card-title">認証・認可</div>
+      </div>
+      <ul class="feature-list">
+        <li>JWT認証（ワーカー30日 / 管理者8時間）</li>
+        <li>メール認証必須（ワーカー登録時）</li>
+        <li>パスワードリセット（トークンベース、24時間有効）</li>
+        <li>ロール別アクセス制御（3段階）</li>
+        <li>マスカレード（システム管理者→施設管理者）</li>
+      </ul>
+    </div>
+    <div class="card">
+      <div class="card-header">
+        <div class="card-icon" style="background:#dbeafe;color:#2563eb;">P</div>
+        <div class="card-title">データ保護</div>
+      </div>
+      <ul class="feature-list">
+        <li>環境変数によるシークレット管理</li>
+        <li>Server Actions経由のDB操作（直接クエリ不可）</li>
+        <li>ファイルアップロードの署名付きURL</li>
+        <li>労働条件通知書のトークンゲートダウンロード</li>
+        <li>JST基準の日時処理（タイムゾーンバグ防止）</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+</main>
+
+<footer>
+  <div class="container">
+    <p>+タスタス サービス概要・機能一覧 | 最終更新: 2026年3月4日</p>
+    <p>本番環境: tastas.work | ステージング: stg-share-worker.vercel.app</p>
+  </div>
+</footer>
+
+</body>
+</html>

--- a/docs/specifications/screen-specification.md
+++ b/docs/specifications/screen-specification.md
@@ -1,6 +1,6 @@
 # +タスタス - 画面仕様書（実装ベース）
 
-> **最終更新**: 2025-12-15
+> **最終更新**: 2026-04-09
 > **ステータス**: 実稼働システムからの逆引き定義
 
 ---
@@ -12,7 +12,8 @@
 /                           → 求人一覧（トップ）
 /jobs/[id]                  → 求人詳細
 /login                      → ログイン
-/register                   → 会員登録（工事中）
+/register                   → /register/worker へリダイレクト
+/register/worker             → ワーカー新規登録（詳細は下記「登録フロー補足」参照）
 /application-confirm        → 応募確認
 /application-complete       → 応募完了
 /my-jobs                    → 仕事管理（応募・勤務状況）
@@ -28,6 +29,53 @@
 /favorites                  → お気に入り
 /facilities/[id]            → 施設詳細
 ```
+
+#### 登録フロー補足: `/register/worker`
+
+**ステップ遷移（URL変化なし・useState切替）:**
+```
+ステップ1: アカウント・基本情報
+  - メールアドレス（確認入力あり）
+  - 電話番号 + SMS認証（※下記参照）
+  - パスワード（確認入力あり）
+  - 氏名・フリガナ
+    ↓ 「次へ」ボタン（バリデーション通過後）
+ステップ2: 住所・資格・同意
+  - 住所（都道府県・市区町村）
+  - 保有資格（複数選択可）
+  - 利用規約・プライバシーポリシー同意
+    ↓ 「登録する」ボタン
+登録完了 → /auth/verify-pending へリダイレクト
+```
+
+**SMS認証フロー（SmsVerificationコンポーネント内 state遷移）:**
+```
+[input] 電話番号入力
+  ↓ 「認証コードを送信」ボタン
+  ↓ API: POST /api/sms/send-code
+[codeSent] 6桁認証コード入力
+  ↓ 「確認」ボタン
+  ↓ API: POST /api/sms/verify-code → JWTトークン取得
+[verified] 認証済み表示（✓ 電話番号認証済み）
+```
+- 再送信クールダウン: 60秒
+- 電話番号変更時: 自動で[input]状態にリセット
+- 認証成功時: verificationToken（JWT）を親フォームに返却
+- URL遷移・ページ遷移: 一切なし
+- GA4タグ発火: なし
+
+**GA4イベント発火ポイント:**
+| タイミング | イベント名 | 備考 |
+|---|---|---|
+| ページ表示時 | `registration_page_view` | RegistrationPageTracker.tsx、API記録あり |
+| 登録完了時 | `sign_up` | method=email、LP情報付与 |
+| ステップ遷移時 | なし | - |
+| SMS認証時 | なし | - |
+
+**関連ファイル:**
+- コンポーネント: `components/ui/SmsVerification.tsx`
+- トラッカー: `components/tracking/RegistrationPageTracker.tsx`
+- API: `app/api/sms/send-code/route.ts`, `app/api/sms/verify-code/route.ts`
 
 ### 1.2 施設管理者向け画面（17画面）
 ```
@@ -49,6 +97,56 @@
 /admin/worker-reviews           → ワーカーレビュー
 /admin/facility                 → 施設情報
 /admin/notifications            → 通知
+```
+
+### 1.3 システム管理者向け画面（46画面）
+```
+/system-admin/login                          → ログイン
+/system-admin                                → ダッシュボード
+/system-admin/analytics                      → アナリティクス
+/system-admin/analytics/ai                   → マッチング最適化AI
+/system-admin/analytics/export               → スプレッドシートDL
+/system-admin/analytics/regions              → 地域登録
+/system-admin/alerts                         → アラート一覧
+/system-admin/workers                        → ワーカー管理
+/system-admin/workers/[id]                   → ワーカー詳細
+/system-admin/facilities                     → 施設管理
+/system-admin/facilities/new                 → 施設新規登録
+/system-admin/jobs                           → 求人管理
+/system-admin/attendance                     → 勤怠管理
+/system-admin/csv-export                     → CSV出力
+/system-admin/announcements                  → お知らせ管理
+/system-admin/announcements/create           → お知らせ新規作成
+/system-admin/announcements/[id]             → お知らせ編集
+/system-admin/content                        → コンテンツ管理ハブ
+/system-admin/content/faq                    → FAQ編集
+/system-admin/content/user-guide             → ご利用ガイド編集
+/system-admin/content/legal                  → 利用規約・PP編集
+/system-admin/content/notifications          → 通知管理
+/system-admin/content/labor-template         → 労働条件通知書テンプレート
+/system-admin/content/templates              → テンプレート管理
+/system-admin/lp                             → LP管理
+/system-admin/lp/genres                      → LPジャンル管理
+/system-admin/lp/guide                       → LP作成ガイド
+/system-admin/lp/recommended-jobs            → おすすめ求人管理
+/system-admin/lp/recommended-jobs/preview    → おすすめ求人プレビュー
+/system-admin/lp/tracking                    → LPトラッキング
+/system-admin/lp/tracking/public-jobs        → 公開求人トラッキング
+/system-admin/lp/tracking/spec               → トラッキングスペック
+/system-admin/settings/admins                → 管理者アカウント管理
+/system-admin/settings/form-destinations     → フォーム送信先設定
+/system-admin/settings/minimum-wage          → 最低賃金管理
+/system-admin/settings/system                → システム設定
+/system-admin/dev-portal                     → 開発者ポータル
+/system-admin/dev-portal/admin-logs          → 管理者ログ
+/system-admin/dev-portal/logs                → システムログ
+/system-admin/dev-portal/notification-logs   → 通知ログ
+/system-admin/dev-portal/error-alert         → エラーアラート設定
+/system-admin/dev-portal/test-notifications  → テスト通知
+/system-admin/dev-portal/debug-checklist     → デバッグチェックリスト
+/system-admin/dev-portal/debug-time          → デバッグ時刻制御
+/system-admin/dev-portal/sample-images       → サンプル画像
+/system-admin/dev-portal/formulas            → 給与計算式
 ```
 
 ---
@@ -589,6 +687,7 @@
 
 | 日付 | 内容 |
 |------|------|
+| 2026-04-09 | システム管理者向け画面一覧（46画面）をセクション1.3に追加 |
 | 2025-12-15 | 求人詳細画面に応募確認モーダル追加（審査あり/なし対応、自己PR編集機能） |
 | 2025-12-15 | 仕事管理画面のキャンセル確認モーダル仕様拡充（SCHEDULED/WORKINGタブ） |
 | 2025-12-15 | 施設側応募管理画面でcancelled_by区別表示追加、審査中→応募取消への用語変更 |

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,14 +1,17 @@
 import { NextAuthOptions } from 'next-auth';
 import CredentialsProvider from 'next-auth/providers/credentials';
 import bcrypt from 'bcryptjs';
+import { Prisma } from '@prisma/client';
 import prisma from './prisma';
 import { logActivity } from './logger';
+import { parseLoginIdentifier } from '@/src/lib/auth/identifier';
 
 export const authOptions: NextAuthOptions = {
   providers: [
     CredentialsProvider({
       name: 'credentials',
       credentials: {
+        identifier: { label: 'Email or Phone', type: 'text' },
         email: { label: 'Email', type: 'email' },
         password: { label: 'Password', type: 'password' },
         autoLoginToken: { label: 'Auto Login Token', type: 'text' },
@@ -63,41 +66,87 @@ export const authOptions: NextAuthOptions = {
         }
 
         // 通常ログインモード
-        if (!credentials?.email || !credentials?.password) {
-          throw new Error('メールアドレスとパスワードを入力してください');
+        const rawIdentifier = credentials?.identifier ?? credentials?.email;
+        if (!rawIdentifier || !credentials?.password) {
+          throw new Error('ログイン情報とパスワードを入力してください');
         }
 
-        const user = await prisma.user.findUnique({
-          where: { email: credentials.email },
-        });
-
-
-        if (!user) {
-          // ログイン失敗（ユーザー不在）をログ記録
+        const parsed = parseLoginIdentifier(rawIdentifier);
+        if (parsed.type === 'invalid') {
           logActivity({
             userType: 'WORKER',
-            userEmail: credentials.email,
+            userEmail: rawIdentifier,
+            action: 'LOGIN_FAILED',
+            result: 'ERROR',
+            errorMessage: '識別子が不正な形式です',
+          }).catch(() => {});
+          throw new Error('メールアドレスまたはパスワードが正しくありません');
+        }
+
+        let user;
+        if (parsed.type === 'email') {
+          // 既存ユーザーの大小文字混在に対応。ただし case-variant 重複時は
+          // 認証先が曖昧になるためログイン不可とする
+          const emailMatches = await prisma.user.findMany({
+            where: { email: { equals: parsed.value, mode: 'insensitive' } },
+            orderBy: { id: 'desc' },
+          });
+          if (emailMatches.length > 1) {
+            console.warn(
+              '[AUTH] Multiple users for case-insensitive email match:',
+              parsed.value
+            );
+            logActivity({
+              userType: 'WORKER',
+              userEmail: parsed.value,
+              action: 'LOGIN_FAILED',
+              result: 'ERROR',
+              errorMessage: 'メールアドレスが重複しているためログイン不可',
+            }).catch(() => {});
+            throw new Error('メールアドレスまたはパスワードが正しくありません');
+          }
+          user = emailMatches[0];
+        } else {
+          // 電話番号ログイン: DB 側も正規化して比較（レガシーデータのハイフン・全角数字対応）
+          const rows = await prisma.$queryRaw<{ id: number }[]>(
+            Prisma.sql`SELECT id FROM users
+              WHERE regexp_replace(translate(phone_number, '０１２３４５６７８９', '0123456789'), '[^0-9]', '', 'g') = ${parsed.value}
+              AND phone_verified = true
+              AND deleted_at IS NULL
+              ORDER BY id DESC`
+          );
+          const candidates = rows.length > 0
+            ? await prisma.user.findMany({
+                where: { id: { in: rows.map((r) => r.id) } },
+                orderBy: { id: 'desc' },
+              })
+            : [];
+          if (candidates.length > 1) {
+            console.warn(
+              '[AUTH] Multiple phone_verified users for phone:',
+              parsed.value
+            );
+            logActivity({
+              userType: 'WORKER',
+              userEmail: parsed.value,
+              action: 'LOGIN_FAILED',
+              result: 'ERROR',
+              errorMessage: '電話番号が重複しているためログイン不可',
+            }).catch(() => {});
+            throw new Error('メールアドレスまたはパスワードが正しくありません');
+          }
+          user = candidates[0];
+        }
+
+        if (!user) {
+          logActivity({
+            userType: 'WORKER',
+            userEmail: rawIdentifier,
             action: 'LOGIN_FAILED',
             result: 'ERROR',
             errorMessage: 'ユーザーが見つかりません',
           }).catch(() => {});
           throw new Error('メールアドレスまたはパスワードが正しくありません');
-        }
-
-        // メールアドレス未認証チェック
-        if (!user.email_verified) {
-          // ログイン失敗（メール未認証）をログ記録
-          logActivity({
-            userType: 'WORKER',
-            userId: user.id,
-            userEmail: user.email,
-            action: 'LOGIN_FAILED',
-            targetType: 'User',
-            targetId: user.id,
-            result: 'ERROR',
-            errorMessage: 'メール未認証',
-          }).catch(() => {});
-          throw new Error('EMAIL_NOT_VERIFIED');
         }
 
         // テストユーザーログイン用の特別パスワード（開発環境 + 環境変数フラグ必須）
@@ -138,7 +187,7 @@ export const authOptions: NextAuthOptions = {
           action: 'LOGIN',
           targetType: 'User',
           targetId: user.id,
-          requestData: { method: 'credentials' },
+          requestData: { method: parsed.type === 'phone' ? 'phone_credentials' : 'credentials' },
           result: 'SUCCESS',
         }).catch(() => {});
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -38,6 +38,7 @@ const publicPaths = [
   '/register',
   '/admin/login',
   '/api/auth',
+  '/api/registration-tracking', // 登録ページ訪問トラッキング（未ログイン、BasicAuth は保持）
   '/auth', // メール認証関連（/auth/verify, /auth/verify-pending, /auth/resend-verification）
   '/dev-portal', // 開発用ポータル
   '/password-reset', // パスワードリセット

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -116,6 +116,11 @@ model User {
   /// 登録時のキャンペーンコードのジャンルプレフィックス（例: "AAA"）
   registration_genre_prefix  String? @map("registration_genre_prefix") @db.VarChar(3)
 
+  /// TasLink外部連携ID
+  taslink_id        String?   @map("taslink_id")
+  /// TasLink最終同期日時
+  taslink_synced_at DateTime? @map("taslink_synced_at")
+
   @@index([registration_lp_id])
   @@index([registration_genre_prefix])
   @@map("users")

--- a/scripts/taslink-bulk-sync.ts
+++ b/scripts/taslink-bulk-sync.ts
@@ -1,0 +1,237 @@
+/**
+ * TasLink 一括同期スクリプト
+ *
+ * 既存ワーカーの本番データを TasLink に一括取り込みするためのツール。
+ * 通常フロー（登録/プロフィール更新）と同じ mapUserToTasLinkPayload +
+ * syncWorkerToTasLink を再利用するため、挙動は個別同期と完全一致する。
+ *
+ * 使い方:
+ *   # 対象件数の確認のみ（APIは叩かない）
+ *   npx tsx scripts/taslink-bulk-sync.ts --dry-run
+ *
+ *   # 少数件でリハーサル（例: 5件）
+ *   npx tsx scripts/taslink-bulk-sync.ts --execute --limit=5
+ *
+ *   # 全件実行
+ *   npx tsx scripts/taslink-bulk-sync.ts --execute
+ *
+ *   # 未同期ユーザーのみ（taslink_id が NULL）を対象にする
+ *   npx tsx scripts/taslink-bulk-sync.ts --execute --only-unsynced
+ *
+ *   # 送信間隔を変更（デフォルト 200ms）
+ *   npx tsx scripts/taslink-bulk-sync.ts --execute --interval=500
+ *
+ * 環境変数:
+ *   DATABASE_URL      - 対象DBの接続文字列（.env.local から読み込む）
+ *   TASLINK_API_URL   - TasLink APIのベースURL
+ *   TASLINK_API_KEY   - TasLink APIのAPIキー
+ *
+ * 出力:
+ *   scripts/taslink-bulk-sync-<timestamp>.csv に結果を保存
+ *   （user_id, email, name, status, taslink_id, error）
+ *
+ * ⚠️ 本番DBを対象にする場合は、本プロジェクトのルールに従い
+ *    ユーザー自身がローカルから実行すること（Claude Code は実行しない）
+ */
+
+import dotenv from 'dotenv';
+import path from 'path';
+import fs from 'fs';
+
+// .env.local を自動読み込み（既存の環境変数も上書き）
+const envPath = path.resolve(process.cwd(), '.env.local');
+dotenv.config({ path: envPath, override: true });
+
+if (!process.env.DATABASE_URL) {
+  throw new Error(`DATABASE_URL が設定されていません (読み込み元: ${envPath})`);
+}
+
+if (!process.env.TASLINK_API_URL || !process.env.TASLINK_API_KEY) {
+  throw new Error(
+    'TASLINK_API_URL または TASLINK_API_KEY が設定されていません。\n' +
+    '.env.local または環境変数を確認してください。'
+  );
+}
+
+// ===== 引数パース =====
+
+function parseArg(flag: string): string | undefined {
+  const arg = process.argv.find(a => a.startsWith(`${flag}=`));
+  return arg ? arg.split('=')[1] : undefined;
+}
+
+const isDryRun = process.argv.includes('--dry-run');
+const isExecute = process.argv.includes('--execute');
+const onlyUnsynced = process.argv.includes('--only-unsynced');
+const limit = parseArg('--limit') ? parseInt(parseArg('--limit')!, 10) : undefined;
+const intervalMs = parseArg('--interval') ? parseInt(parseArg('--interval')!, 10) : 200;
+
+if (!isDryRun && !isExecute) {
+  console.log('使い方:');
+  console.log('  npx tsx scripts/taslink-bulk-sync.ts --dry-run');
+  console.log('  npx tsx scripts/taslink-bulk-sync.ts --execute [--limit=N] [--only-unsynced] [--interval=200]');
+  process.exit(1);
+}
+
+// ===== メイン処理 =====
+
+async function main() {
+  // dotenv 読み込み後に動的 import（環境変数の順序依存回避）
+  const { PrismaClient } = require('@prisma/client');
+  const { mapUserToTasLinkPayload, syncWorkerToTasLink } = require('../src/lib/taslink');
+
+  // Supabase pooler 対策
+  let dbUrl = process.env.DATABASE_URL!;
+  const separator = dbUrl.includes('?') ? '&' : '?';
+  if (!dbUrl.includes('pgbouncer=true')) {
+    dbUrl += `${separator}pgbouncer=true&connect_timeout=30`;
+  }
+
+  const prisma = new PrismaClient({
+    datasources: { db: { url: dbUrl } },
+  });
+
+  // 対象取得: 退会していない & 名前が入っている（TasLink の必須項目）
+  const where: any = {
+    deleted_at: null,
+    name: { not: '' },
+  };
+  if (onlyUnsynced) {
+    where.taslink_id = null;
+  }
+
+  const users = await prisma.user.findMany({
+    where,
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      last_name_kana: true,
+      first_name_kana: true,
+      gender: true,
+      birth_date: true,
+      phone_number: true,
+      postal_code: true,
+      prefecture: true,
+      city: true,
+      address_line: true,
+      qualifications: true,
+      desired_work_days: true,
+      desired_work_style: true,
+      work_histories: true,
+      self_pr: true,
+      taslink_id: true,
+    },
+    orderBy: { id: 'asc' },
+    ...(limit ? { take: limit } : {}),
+  });
+
+  console.log('======================================');
+  console.log('TasLink 一括同期');
+  console.log('======================================');
+  console.log(`モード       : ${isDryRun ? 'DRY RUN' : 'EXECUTE'}`);
+  console.log(`対象DB       : ${dbUrl.replace(/:[^:@]+@/, ':***@')}`);
+  console.log(`TASLINK_URL  : ${process.env.TASLINK_API_URL}`);
+  console.log(`フィルタ     : ${onlyUnsynced ? '未同期のみ (taslink_id IS NULL)' : '全ワーカー（名前あり・退会除く）'}`);
+  console.log(`件数上限     : ${limit ?? '無制限'}`);
+  console.log(`送信間隔     : ${intervalMs}ms`);
+  console.log(`対象件数     : ${users.length}`);
+  console.log('======================================\n');
+
+  // ペイロード生成段階でのスキップ判定（名前分割失敗など）
+  const skipped: Array<{ id: number; email: string; reason: string }> = [];
+  const targets: Array<{ user: any; payload: any }> = [];
+
+  for (const user of users) {
+    const payload = mapUserToTasLinkPayload(user);
+    if (!payload) {
+      skipped.push({
+        id: user.id,
+        email: user.email,
+        reason: 'payload生成失敗（氏名が不正）',
+      });
+      continue;
+    }
+    targets.push({ user, payload });
+  }
+
+  console.log(`同期対象     : ${targets.length}`);
+  console.log(`スキップ     : ${skipped.length}\n`);
+
+  if (skipped.length > 0) {
+    console.log('--- スキップ対象（先頭10件） ---');
+    skipped.slice(0, 10).forEach(s => {
+      console.log(`  ID:${s.id} ${s.email} - ${s.reason}`);
+    });
+    console.log('');
+  }
+
+  if (isDryRun) {
+    console.log('[DRY RUN] API呼び出しは行いません。--execute で実行してください。');
+    console.log('\nサンプルペイロード（先頭1件）:');
+    if (targets[0]) {
+      console.log(JSON.stringify(targets[0].payload, null, 2));
+    }
+    await prisma.$disconnect();
+    return;
+  }
+
+  // === 実行モード ===
+
+  const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+  const csvPath = path.resolve(process.cwd(), `scripts/taslink-bulk-sync-${timestamp}.csv`);
+  const csvRows: string[] = ['user_id,email,name,status,taslink_id,error'];
+
+  let successCount = 0;
+  let failCount = 0;
+
+  console.log(`同期開始 (${targets.length}件)...\n`);
+
+  for (let i = 0; i < targets.length; i++) {
+    const { user, payload } = targets[i];
+    const prefix = `[${i + 1}/${targets.length}]`;
+
+    try {
+      const result = await syncWorkerToTasLink(user.id, payload);
+      if (result.success) {
+        console.log(`  ${prefix} ✓ ID:${user.id} ${user.email} → taslink_id=${result.tasLinkId ?? '(空)'}`);
+        successCount++;
+        csvRows.push(`${user.id},"${user.email}","${user.name}",success,${result.tasLinkId ?? ''},`);
+      } else {
+        const errMsg = result.error ?? 'unknown';
+        console.log(`  ${prefix} ✗ ID:${user.id} ${user.email} - ${errMsg}`);
+        failCount++;
+        csvRows.push(`${user.id},"${user.email}","${user.name}",failed,,"${errMsg.replace(/"/g, '""')}"`);
+      }
+    } catch (err: any) {
+      const errMsg = err?.message ?? String(err);
+      console.log(`  ${prefix} ✗ ID:${user.id} ${user.email} - 例外: ${errMsg}`);
+      failCount++;
+      csvRows.push(`${user.id},"${user.email}","${user.name}",exception,,"${errMsg.replace(/"/g, '""')}"`);
+    }
+
+    // スキップ分をCSVに記録（最後のループで一括）
+    if (intervalMs > 0 && i < targets.length - 1) {
+      await new Promise(resolve => setTimeout(resolve, intervalMs));
+    }
+  }
+
+  // スキップ分もCSVに追記
+  for (const s of skipped) {
+    csvRows.push(`${s.id},"${s.email}","",skipped,,"${s.reason}"`);
+  }
+
+  fs.writeFileSync(csvPath, csvRows.join('\n'), 'utf-8');
+
+  console.log('\n======================================');
+  console.log(`結果: 成功 ${successCount}件 / 失敗 ${failCount}件 / スキップ ${skipped.length}件`);
+  console.log(`結果CSV: ${csvPath}`);
+  console.log('======================================');
+
+  await prisma.$disconnect();
+}
+
+main().catch(async (err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});

--- a/src/lib/actions/application-worker.ts
+++ b/src/lib/actions/application-worker.ts
@@ -229,6 +229,16 @@ export async function applyForJob(jobId: string, workDateId?: number) {
             return { success: false, error: 'アカウントが停止されているため、応募できません' };
         }
 
+        if (!user.email_verified) {
+            console.log('[applyForJob] Email not verified:', user.id);
+            return {
+                success: false,
+                errorCode: 'EMAIL_NOT_VERIFIED',
+                error: 'メールアドレスの認証が必要です',
+                email: user.email,
+            };
+        }
+
         const profileCheck = await checkProfileComplete(user.id);
         if (!profileCheck.isComplete) {
             console.log('[applyForJob] Profile incomplete:', profileCheck.missingFields);
@@ -445,6 +455,15 @@ export async function applyForJobMultipleDates(jobId: string, workDateIds: numbe
 
         const user = await getAuthenticatedUser();
         if (user.is_suspended) return { success: false, error: 'アカウントが停止されているため、応募できません' };
+
+        if (!user.email_verified) {
+            return {
+                success: false,
+                errorCode: 'EMAIL_NOT_VERIFIED',
+                error: 'メールアドレスの認証が必要です',
+                email: user.email,
+            };
+        }
 
         const profileCheck = await checkProfileComplete(user.id);
         if (!profileCheck.isComplete) {
@@ -806,6 +825,16 @@ export async function cancelApplicationByWorker(applicationId: number) {
         const user = await getAuthenticatedUser();
         console.log('[cancelApplicationByWorker] User:', user.id, 'Application:', applicationId);
 
+        if (!user.email_verified) {
+            console.log('[cancelApplicationByWorker] Email not verified:', user.id);
+            return {
+                success: false,
+                errorCode: 'EMAIL_NOT_VERIFIED',
+                error: 'メールアドレスの認証が必要です',
+                email: user.email,
+            };
+        }
+
         const application = await prisma.application.findFirst({
             where: { id: applicationId, user_id: user.id },
             include: {
@@ -988,6 +1017,16 @@ export async function acceptOffer(jobId: string, workDateId: number) {
         if (user.is_suspended) {
             console.log('[acceptOffer] User is suspended:', user.id);
             return { success: false, error: 'アカウントが停止されているため、オファーを受けられません' };
+        }
+
+        if (!user.email_verified) {
+            console.log('[acceptOffer] Email not verified:', user.id);
+            return {
+                success: false,
+                errorCode: 'EMAIL_NOT_VERIFIED',
+                error: 'メールアドレスの認証が必要です',
+                email: user.email,
+            };
         }
 
         const profileCheck = await checkProfileComplete(user.id);

--- a/src/lib/actions/dev-user-delete.ts
+++ b/src/lib/actions/dev-user-delete.ts
@@ -1,0 +1,305 @@
+'use server';
+
+import prisma from '@/lib/prisma';
+import { requireSystemAdminAuth } from '@/lib/system-admin-session-server';
+import { logActivity } from '@/lib/logger';
+
+export interface DeleteWorkerResult {
+  success: boolean;
+  message?: string;
+  blockers?: string[];
+  deletedUser?: { id: number; email: string; name: string };
+  counts?: {
+    applications: number;
+    bookmarks: number;
+    messages: number;
+    reviews: number;
+    attendances: number;
+    offeredJobsCleared: number;
+    workDateCountersAdjusted: number;
+    facilityRatingsRecalculated: number;
+  };
+}
+
+/**
+ * 開発・テスト用: ワーカーユーザーを完全削除（退会処理とは別物）
+ *
+ * 安全方針:
+ * - system-admin 認証必須
+ * - 本番環境では `ALLOW_DEV_USER_DELETE=true` でないと実行不可
+ * - 進行中の業務があれば削除拒否（SCHEDULED/WORKING 応募、未退勤 attendance）
+ * - JobWorkDate カウンター（applied/matched）を削除対象 Application 分だけ減算
+ * - 削除対象 Review があれば Facility.rating / review_count を再計算
+ * - Job.target_worker_id は null 化（求人自体は保持）
+ * - UserActivityLog は FK 無しのため残存（履歴保持）
+ */
+export async function deleteWorkerCompletely(
+  identifier: string
+): Promise<DeleteWorkerResult> {
+  let admin;
+  try {
+    admin = await requireSystemAdminAuth();
+  } catch {
+    return { success: false, message: 'システム管理者認証が必要です' };
+  }
+
+  if (
+    process.env.NODE_ENV === 'production' &&
+    process.env.ALLOW_DEV_USER_DELETE !== 'true'
+  ) {
+    return {
+      success: false,
+      message:
+        '本番環境ではこの機能は無効です（ALLOW_DEV_USER_DELETE=true で有効化）',
+    };
+  }
+
+  if (!identifier || !identifier.trim()) {
+    return { success: false, message: 'メールアドレスまたはユーザーIDを入力してください' };
+  }
+
+  const trimmed = identifier.trim();
+  const idAsNumber = /^\d+$/.test(trimmed) ? parseInt(trimmed, 10) : null;
+
+  const user = idAsNumber
+    ? await prisma.user.findUnique({ where: { id: idAsNumber } })
+    : await prisma.user.findFirst({
+        where: { email: { equals: trimmed, mode: 'insensitive' } },
+      });
+
+  if (!user) {
+    return {
+      success: false,
+      message: `ユーザーが見つかりません（入力値: ${trimmed}）`,
+    };
+  }
+
+  // --- 事前セーフガード: 施設業務に影響する状態があれば削除拒否 ---
+  const blockers: string[] = [];
+
+  // APPLIED も施設側で審査中なのでブロック対象に含める
+  const activeApps = await prisma.application.count({
+    where: {
+      user_id: user.id,
+      status: { in: ['APPLIED', 'SCHEDULED', 'WORKING', 'COMPLETED_PENDING'] },
+    },
+  });
+  if (activeApps > 0) {
+    blockers.push(
+      `審査中/進行中/完了待ちの応募が ${activeApps} 件あります（APPLIED / SCHEDULED / WORKING / COMPLETED_PENDING）。施設側の業務に影響するため削除できません。`
+    );
+  }
+
+  const activeAttendance = await prisma.attendance.count({
+    where: {
+      user_id: user.id,
+      check_out_time: null,
+    },
+  });
+  if (activeAttendance > 0) {
+    blockers.push(
+      `未退勤の勤怠レコードが ${activeAttendance} 件あります。退勤処理を完了してから削除してください。`
+    );
+  }
+
+  // オファー対象になっている未応答求人があれば拒否（施設が候補として保持している）
+  const offeredActive = await prisma.job.count({
+    where: {
+      target_worker_id: user.id,
+      status: { in: ['PUBLISHED', 'WORKING'] },
+    },
+  });
+  if (offeredActive > 0) {
+    blockers.push(
+      `施設から届いている未応答オファー求人が ${offeredActive} 件あります。施設側の候補者管理に影響するため削除できません。`
+    );
+  }
+
+  // 労働条件通知書のダウンロードトークン（施設が発行中）があれば拒否
+  // worker_id は FK 無しなので cascade 削除されず、削除後に dangling 化する
+  const pendingLaborDocTokens = await prisma.laborDocumentDownloadToken.count({
+    where: {
+      worker_id: user.id,
+      expires_at: { gt: new Date() },
+    },
+  });
+  if (pendingLaborDocTokens > 0) {
+    blockers.push(
+      `施設が発行中の労働条件通知書ダウンロードトークンが ${pendingLaborDocTokens} 件あります。期限切れまで待つかトークンを失効させてください。`
+    );
+  }
+
+  if (blockers.length > 0) {
+    return {
+      success: false,
+      message: '削除前提条件を満たしていません',
+      blockers,
+    };
+  }
+
+  // 監査ログ用: 影響を受けた主要エンティティのIDを収集
+  let appIdsForLog: number[] = [];
+  let facilityIdsForLog: number[] = [];
+  let threadIdsForLog: number[] = [];
+
+  try {
+    const result = await prisma.$transaction(async (tx) => {
+      // 1. Job.target_worker_id を null 化（FK onDelete 無しのため必須）
+      const offeredJobsCleared = await tx.job.updateMany({
+        where: { target_worker_id: user.id },
+        data: { target_worker_id: null },
+      });
+
+      // 2. 削除対象 Application（キャンセル済み・過去完了済み）を列挙し、
+      //    JobWorkDate のカウンターを減算
+      const appsToDelete = await tx.application.findMany({
+        where: { user_id: user.id },
+        select: { id: true, status: true, work_date_id: true },
+      });
+      appIdsForLog = appsToDelete.map((a) => a.id);
+
+      // MessageThread も削除対象（cascade で消えるので事前に ID を記録）
+      const threadsToDelete = await tx.messageThread.findMany({
+        where: { worker_id: user.id },
+        select: { id: true },
+      });
+      threadIdsForLog = threadsToDelete.map((t) => t.id);
+
+      let workDateCountersAdjusted = 0;
+      // applied_count はすべての非CANCELLED応募、matched_count は SCHEDULED/WORKING/COMPLETED_* でカウントされる想定
+      const wdCountMap = new Map<number, { applied: number; matched: number }>();
+      for (const app of appsToDelete) {
+        if (!app.work_date_id) continue;
+        const current = wdCountMap.get(app.work_date_id) ?? { applied: 0, matched: 0 };
+        // CANCELLED は applied_count から減算しない（応募時に decrement 済みのはず）
+        if (app.status !== 'CANCELLED') {
+          current.applied += 1;
+        }
+        // マッチング成立済みの状態だけ matched を減らす
+        if (['WORKING', 'COMPLETED_PENDING', 'COMPLETED_RATED'].includes(app.status)) {
+          current.matched += 1;
+        }
+        wdCountMap.set(app.work_date_id, current);
+      }
+      for (const [wdId, c] of Array.from(wdCountMap.entries())) {
+        if (c.applied === 0 && c.matched === 0) continue;
+        await tx.jobWorkDate.update({
+          where: { id: wdId },
+          data: {
+            applied_count: c.applied > 0 ? { decrement: c.applied } : undefined,
+            matched_count: c.matched > 0 ? { decrement: c.matched } : undefined,
+          },
+        });
+        workDateCountersAdjusted += 1;
+      }
+
+      // 3. 影響を受ける Facility ID を収集（Review 削除に伴う rating 再計算用）
+      // 施設の公開評価は「ワーカーが施設を評価した」レビューのみで集計される
+      // （既存実装 src/lib/actions/review-worker.ts と同じルール）
+      const affectedWorkerReviews = await tx.review.findMany({
+        where: { user_id: user.id, reviewer_type: 'WORKER' },
+        select: { facility_id: true },
+      });
+      const affectedFacilityIds = Array.from(
+        new Set(affectedWorkerReviews.map((r) => r.facility_id))
+      );
+      facilityIdsForLog = affectedFacilityIds;
+      // 全レビュー削除数（worker→facility + facility→worker）
+      const reviewsCount = await tx.review.count({
+        where: { user_id: user.id },
+      });
+
+      // カウンター取得（削除前）
+      const [bookmarksCount, messagesCount, attendancesCount] = await Promise.all([
+        tx.bookmark.count({
+          where: { OR: [{ user_id: user.id }, { target_user_id: user.id }] },
+        }),
+        tx.message.count({
+          where: { OR: [{ from_user_id: user.id }, { to_user_id: user.id }] },
+        }),
+        tx.attendance.count({ where: { user_id: user.id } }),
+      ]);
+
+      // 4. User 削除（他の関連テーブルは onDelete: Cascade）
+      await tx.user.delete({ where: { id: user.id } });
+
+      // 5. Facility rating を再計算（worker→facility レビューのみで平均、小数1桁丸め）
+      // 既存 src/lib/actions/review-worker.ts と同じロジックで整合をとる
+      let facilityRatingsRecalculated = 0;
+      for (const facilityId of affectedFacilityIds) {
+        const workerReviews = await tx.review.findMany({
+          where: { facility_id: facilityId, reviewer_type: 'WORKER' },
+          select: { rating: true },
+        });
+        const avg =
+          workerReviews.length > 0
+            ? workerReviews.reduce((s, r) => s + r.rating, 0) / workerReviews.length
+            : 0;
+        await tx.facility.update({
+          where: { id: facilityId },
+          data: {
+            rating: Math.round(avg * 10) / 10,
+            review_count: workerReviews.length,
+          },
+        });
+        facilityRatingsRecalculated += 1;
+      }
+
+      return {
+        applications: appsToDelete.length,
+        bookmarks: bookmarksCount,
+        messages: messagesCount,
+        reviews: reviewsCount,
+        attendances: attendancesCount,
+        offeredJobsCleared: offeredJobsCleared.count,
+        workDateCountersAdjusted,
+        facilityRatingsRecalculated,
+      };
+    });
+
+    logActivity({
+      userType: 'SYSTEM_ADMIN',
+      userId: admin.adminId,
+      userEmail: admin.email,
+      action: 'DELETE_USER_TEST',
+      targetType: 'User',
+      targetId: user.id,
+      requestData: {
+        deletedUserId: user.id,
+        deletedUserEmail: user.email,
+        deletedUserName: user.name,
+        counts: result,
+        // 追跡用: 削除で影響を受けた主要エンティティ ID 群
+        impactedApplicationIds: appIdsForLog,
+        impactedFacilityIds: facilityIdsForLog,
+        impactedMessageThreadIds: threadIdsForLog,
+      },
+      result: 'SUCCESS',
+    }).catch(() => {});
+
+    return {
+      success: true,
+      deletedUser: { id: user.id, email: user.email, name: user.name },
+      counts: result,
+    };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('[deleteWorkerCompletely] Error:', error);
+
+    logActivity({
+      userType: 'SYSTEM_ADMIN',
+      userId: admin.adminId,
+      userEmail: admin.email,
+      action: 'DELETE_USER_TEST_FAILED',
+      targetType: 'User',
+      targetId: user.id,
+      result: 'ERROR',
+      errorMessage: message,
+    }).catch(() => {});
+
+    return {
+      success: false,
+      message: `削除に失敗しました: ${message}`,
+    };
+  }
+}

--- a/src/lib/actions/dev-user-delete.ts
+++ b/src/lib/actions/dev-user-delete.ts
@@ -1,7 +1,11 @@
 'use server';
 
 import prisma from '@/lib/prisma';
-import { requireSystemAdminAuth } from '@/lib/system-admin-session-server';
+import { Prisma } from '@prisma/client';
+import {
+  requireSystemAdminAuth,
+  requireSuperAdminAuth,
+} from '@/lib/system-admin-session-server';
 import { logActivity } from '@/lib/logger';
 
 export interface DeleteWorkerResult {
@@ -18,6 +22,7 @@ export interface DeleteWorkerResult {
     offeredJobsCleared: number;
     workDateCountersAdjusted: number;
     facilityRatingsRecalculated: number;
+    laborDocTokensDeleted: number;
   };
 }
 
@@ -34,13 +39,24 @@ export interface DeleteWorkerResult {
  * - UserActivityLog は FK 無しのため残存（履歴保持）
  */
 export async function deleteWorkerCompletely(
-  identifier: string
+  identifier: string,
+  options?: { force?: boolean }
 ): Promise<DeleteWorkerResult> {
+  const force = options?.force === true;
+
   let admin;
   try {
-    admin = await requireSystemAdminAuth();
+    // 通常削除: system-admin 以上、force は super_admin に限定
+    admin = force
+      ? await requireSuperAdminAuth()
+      : await requireSystemAdminAuth();
   } catch {
-    return { success: false, message: 'システム管理者認証が必要です' };
+    return {
+      success: false,
+      message: force
+        ? '強制削除は super_admin 権限が必要です'
+        : 'システム管理者認証が必要です',
+    };
   }
 
   if (
@@ -74,81 +90,102 @@ export async function deleteWorkerCompletely(
     };
   }
 
-  // --- 事前セーフガード: 施設業務に影響する状態があれば削除拒否 ---
-  const blockers: string[] = [];
-
-  // APPLIED も施設側で審査中なのでブロック対象に含める
-  const activeApps = await prisma.application.count({
-    where: {
-      user_id: user.id,
-      status: { in: ['APPLIED', 'SCHEDULED', 'WORKING', 'COMPLETED_PENDING'] },
-    },
-  });
-  if (activeApps > 0) {
-    blockers.push(
-      `審査中/進行中/完了待ちの応募が ${activeApps} 件あります（APPLIED / SCHEDULED / WORKING / COMPLETED_PENDING）。施設側の業務に影響するため削除できません。`
-    );
-  }
-
-  const activeAttendance = await prisma.attendance.count({
-    where: {
-      user_id: user.id,
-      check_out_time: null,
-    },
-  });
-  if (activeAttendance > 0) {
-    blockers.push(
-      `未退勤の勤怠レコードが ${activeAttendance} 件あります。退勤処理を完了してから削除してください。`
-    );
-  }
-
-  // オファー対象になっている未応答求人があれば拒否（施設が候補として保持している）
-  const offeredActive = await prisma.job.count({
-    where: {
-      target_worker_id: user.id,
-      status: { in: ['PUBLISHED', 'WORKING'] },
-    },
-  });
-  if (offeredActive > 0) {
-    blockers.push(
-      `施設から届いている未応答オファー求人が ${offeredActive} 件あります。施設側の候補者管理に影響するため削除できません。`
-    );
-  }
-
-  // 労働条件通知書のダウンロードトークン（施設が発行中）があれば拒否
-  // worker_id は FK 無しなので cascade 削除されず、削除後に dangling 化する
-  const pendingLaborDocTokens = await prisma.laborDocumentDownloadToken.count({
-    where: {
-      worker_id: user.id,
-      expires_at: { gt: new Date() },
-    },
-  });
-  if (pendingLaborDocTokens > 0) {
-    blockers.push(
-      `施設が発行中の労働条件通知書ダウンロードトークンが ${pendingLaborDocTokens} 件あります。期限切れまで待つかトークンを失効させてください。`
-    );
-  }
-
-  if (blockers.length > 0) {
-    return {
-      success: false,
-      message: '削除前提条件を満たしていません',
-      blockers,
-    };
-  }
-
   // 監査ログ用: 影響を受けた主要エンティティのIDを収集
   let appIdsForLog: number[] = [];
   let facilityIdsForLog: number[] = [];
   let threadIdsForLog: number[] = [];
 
+  // blocker 情報をトランザクション外に伝えるための専用エラー
+  class BlockerError extends Error {
+    constructor(public readonly blockers: string[]) {
+      super('BLOCKERS');
+    }
+  }
+
   try {
-    const result = await prisma.$transaction(async (tx) => {
-      // 1. Job.target_worker_id を null 化（FK onDelete 無しのため必須）
-      const offeredJobsCleared = await tx.job.updateMany({
-        where: { target_worker_id: user.id },
-        data: { target_worker_id: null },
-      });
+    const result = await prisma.$transaction(
+      async (tx) => {
+        // 0. ユーザー ID に対する advisory xact lock + 行ロック
+        //    - advisory_xact_lock: 同じ削除コードの並行実行を直列化
+        //    - SELECT FOR UPDATE: PostgreSQL FK 制約により、子テーブル（Application,
+        //      Attendance, Bookmark, Message, Review, BankAccount, PushSubscription,
+        //      NearbyNotificationLog, MessageThread 等）への INSERT は親行に
+        //      FOR KEY SHARE を取得する。FOR UPDATE はこれと競合するため、
+        //      トランザクション commit まで新規 FK 子行の作成をブロックできる
+        const userLockKey = BigInt(user.id);
+        await tx.$queryRaw(
+          Prisma.sql`SELECT pg_advisory_xact_lock(${userLockKey}::bigint)`
+        );
+        await tx.$queryRaw(
+          Prisma.sql`SELECT id FROM users WHERE id = ${user.id} FOR UPDATE`
+        );
+        // 注: LaborDocumentDownloadToken は FK 無しのため FOR UPDATE で
+        // 新規発行をブロックできない。テストユーティリティとして race を受容
+        // （発行頻度は低く、テスト環境での競合確率は極めて低い）
+
+        // 0b. blocker チェック（トランザクション内で行うことで TOCTOU を防ぐ）
+        const txBlockers: string[] = [];
+
+        if (!force) {
+          const activeApps = await tx.application.count({
+            where: {
+              user_id: user.id,
+              status: { in: ['APPLIED', 'SCHEDULED', 'WORKING', 'COMPLETED_PENDING'] },
+            },
+          });
+          if (activeApps > 0) {
+            txBlockers.push(
+              `審査中/進行中/完了待ちの応募が ${activeApps} 件あります（APPLIED / SCHEDULED / WORKING / COMPLETED_PENDING）。施設側の業務に影響するため削除できません。`
+            );
+          }
+
+          const offeredActive = await tx.job.count({
+            where: {
+              target_worker_id: user.id,
+              status: { in: ['PUBLISHED', 'WORKING'] },
+            },
+          });
+          if (offeredActive > 0) {
+            txBlockers.push(
+              `施設から届いている未応答オファー求人が ${offeredActive} 件あります。施設側の候補者管理に影響するため削除できません。`
+            );
+          }
+
+          const pendingLaborDocTokens = await tx.laborDocumentDownloadToken.count({
+            where: {
+              worker_id: user.id,
+              expires_at: { gt: new Date() },
+            },
+          });
+          if (pendingLaborDocTokens > 0) {
+            txBlockers.push(
+              `施設が発行中の労働条件通知書ダウンロードトークンが ${pendingLaborDocTokens} 件あります。期限切れまで待つかトークンを失効させてください。`
+            );
+          }
+        }
+
+        // 未退勤 attendance は force でもブロック（critical check）
+        const activeAttendance = await tx.attendance.count({
+          where: {
+            user_id: user.id,
+            check_out_time: null,
+          },
+        });
+        if (activeAttendance > 0) {
+          txBlockers.push(
+            `未退勤の勤怠レコードが ${activeAttendance} 件あります。退勤処理を完了してから削除してください（強制削除でもバイパス不可）。`
+          );
+        }
+
+        if (txBlockers.length > 0) {
+          throw new BlockerError(txBlockers);
+        }
+
+        // 1. Job.target_worker_id を null 化（FK onDelete 無しのため必須）
+        const offeredJobsCleared = await tx.job.updateMany({
+          where: { target_worker_id: user.id },
+          data: { target_worker_id: null },
+        });
 
       // 2. 削除対象 Application（キャンセル済み・過去完了済み）を列挙し、
       //    JobWorkDate のカウンターを減算
@@ -176,7 +213,9 @@ export async function deleteWorkerCompletely(
           current.applied += 1;
         }
         // マッチング成立済みの状態だけ matched を減らす
-        if (['WORKING', 'COMPLETED_PENDING', 'COMPLETED_RATED'].includes(app.status)) {
+        // 既存 apply/admin フローでは APPLIED→SCHEDULED 時点で matched_count +1 されるため
+        // SCHEDULED も対象に含める
+        if (['SCHEDULED', 'WORKING', 'COMPLETED_PENDING', 'COMPLETED_RATED'].includes(app.status)) {
           current.matched += 1;
         }
         wdCountMap.set(app.work_date_id, current);
@@ -220,6 +259,12 @@ export async function deleteWorkerCompletely(
         tx.attendance.count({ where: { user_id: user.id } }),
       ]);
 
+      // 3b. 労働条件通知書ダウンロードトークンを user.delete の直前に削除
+      // advisory lock 下なので新規トークン発行は直列化される
+      const laborDocTokensDeleted = await tx.laborDocumentDownloadToken.deleteMany({
+        where: { worker_id: user.id },
+      });
+
       // 4. User 削除（他の関連テーブルは onDelete: Cascade）
       await tx.user.delete({ where: { id: user.id } });
 
@@ -254,17 +299,24 @@ export async function deleteWorkerCompletely(
         offeredJobsCleared: offeredJobsCleared.count,
         workDateCountersAdjusted,
         facilityRatingsRecalculated,
+        laborDocTokensDeleted: laborDocTokensDeleted.count,
       };
+    }, {
+      // 長時間ロックを避けるため timeout を設定
+      maxWait: 5000,
+      timeout: 30_000,
+      isolationLevel: Prisma.TransactionIsolationLevel.ReadCommitted,
     });
 
     logActivity({
       userType: 'SYSTEM_ADMIN',
       userId: admin.adminId,
       userEmail: admin.email,
-      action: 'DELETE_USER_TEST',
+      action: force ? 'DELETE_USER_TEST_FORCE' : 'DELETE_USER_TEST',
       targetType: 'User',
       targetId: user.id,
       requestData: {
+        force,
         deletedUserId: user.id,
         deletedUserEmail: user.email,
         deletedUserName: user.name,
@@ -283,6 +335,27 @@ export async function deleteWorkerCompletely(
       counts: result,
     };
   } catch (error) {
+    // BlockerError はトランザクション内で発生、ロールバック済み
+    if (error instanceof BlockerError) {
+      // ブロック時も監査ログを残す（force フラグ・試行ユーザー付き）
+      logActivity({
+        userType: 'SYSTEM_ADMIN',
+        userId: admin.adminId,
+        userEmail: admin.email,
+        action: force ? 'DELETE_USER_TEST_FORCE_BLOCKED' : 'DELETE_USER_TEST_BLOCKED',
+        targetType: 'User',
+        targetId: user.id,
+        requestData: { force, blockers: error.blockers },
+        result: 'ERROR',
+        errorMessage: 'BLOCKERS',
+      }).catch(() => {});
+      return {
+        success: false,
+        message: '削除前提条件を満たしていません',
+        blockers: error.blockers,
+      };
+    }
+
     const message = error instanceof Error ? error.message : String(error);
     console.error('[deleteWorkerCompletely] Error:', error);
 
@@ -290,9 +363,10 @@ export async function deleteWorkerCompletely(
       userType: 'SYSTEM_ADMIN',
       userId: admin.adminId,
       userEmail: admin.email,
-      action: 'DELETE_USER_TEST_FAILED',
+      action: force ? 'DELETE_USER_TEST_FORCE_FAILED' : 'DELETE_USER_TEST_FAILED',
       targetType: 'User',
       targetId: user.id,
+      requestData: { force },
       result: 'ERROR',
       errorMessage: message,
     }).catch(() => {});

--- a/src/lib/actions/dev-user-delete.ts
+++ b/src/lib/actions/dev-user-delete.ts
@@ -113,9 +113,11 @@ export async function deleteWorkerCompletely(
         //      FOR KEY SHARE を取得する。FOR UPDATE はこれと競合するため、
         //      トランザクション commit まで新規 FK 子行の作成をブロックできる
         const userLockKey = BigInt(user.id);
-        await tx.$queryRaw(
+        // pg_advisory_xact_lock は void を返すため $executeRaw を使用
+        await tx.$executeRaw(
           Prisma.sql`SELECT pg_advisory_xact_lock(${userLockKey}::bigint)`
         );
+        // SELECT FOR UPDATE は行を返すため $queryRaw でよい
         await tx.$queryRaw(
           Prisma.sql`SELECT id FROM users WHERE id = ${user.id} FOR UPDATE`
         );

--- a/src/lib/actions/job-worker.ts
+++ b/src/lib/actions/job-worker.ts
@@ -405,7 +405,7 @@ export async function getJobs(
     }
 
     // Date型を文字列に変換してシリアライズ可能にする
-    return jobs.map((job) => {
+    const result = jobs.map((job) => {
         // 一番近い勤務日を取得（互換性のため）
         const nearestWorkDate = job.workDates.length > 0 ? job.workDates[0] : null;
         // 総応募数を計算
@@ -502,6 +502,16 @@ export async function getJobs(
             isRecruitmentClosed: workDatesWithAvailability.length > 0 && workDatesWithAvailability.every(wd => wd.isRecruitmentClosed),
         };
     });
+
+    // 募集終了求人を下にまとめる（応募可能な求人が上、募集終了が下）
+    result.sort((a, b) => {
+        const aActive = a.hasAvailableWorkDate && !a.isRecruitmentClosed;
+        const bActive = b.hasAvailableWorkDate && !b.isRecruitmentClosed;
+        if (aActive === bActive) return 0;
+        return aActive ? -1 : 1;
+    });
+
+    return result;
 }
 
 /**
@@ -1330,6 +1340,14 @@ export async function getJobsListWithPagination(
     }
 
     const cleanedJobs = filteredJobsWithDistance.map(({ _distance, ...job }) => job);
+
+    // 募集終了求人を下にまとめる（応募可能な求人が上、募集終了が下）
+    cleanedJobs.sort((a, b) => {
+        const aActive = a.hasAvailableWorkDate && !a.isExpired && !a.isRecruitmentClosed;
+        const bActive = b.hasAvailableWorkDate && !b.isExpired && !b.isRecruitmentClosed;
+        if (aActive === bActive) return 0;
+        return aActive ? -1 : 1;
+    });
 
     return {
         jobs: cleanedJobs,

--- a/src/lib/actions/user-profile.ts
+++ b/src/lib/actions/user-profile.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { prisma } from '@/lib/prisma';
+import { Prisma } from '@prisma/client';
 import { revalidatePath } from 'next/cache';
 import { getAuthenticatedUser } from './helpers';
 import { geocodeAddress } from '@/src/lib/geocoding';
@@ -8,6 +9,7 @@ import { logActivity, getErrorMessage, getErrorStack } from '@/lib/logger';
 import { generateBankAccountName } from '@/lib/string-utils';
 import { validatePhoneVerificationToken } from '@/src/lib/auth/phone-verification';
 import { syncWorkerToTasLink, mapUserToTasLinkPayload } from '@/src/lib/taslink';
+import { normalizePhoneDigits, phoneLockKey as computePhoneLockKey } from '@/src/lib/auth/identifier';
 
 /**
  * SMS認証成功時に電話番号を即座にDBに保存する
@@ -16,19 +18,48 @@ export async function savePhoneVerification(phoneNumber: string, verificationTok
     try {
         const user = await getAuthenticatedUser();
 
-        const isValid = await validatePhoneVerificationToken(verificationToken, phoneNumber);
+        const normalizedPhone = normalizePhoneDigits(phoneNumber);
+        if (normalizedPhone.length < 10 || normalizedPhone.length > 11) {
+            return { success: false, error: '電話番号の形式が正しくありません' };
+        }
+
+        const isValid = await validatePhoneVerificationToken(verificationToken, normalizedPhone);
         if (!isValid) {
             return { success: false, error: '認証トークンが無効または期限切れです' };
         }
 
-        await prisma.user.update({
-            where: { id: user.id },
-            data: {
-                phone_number: phoneNumber,
-                phone_verified: true,
-                phone_verified_at: new Date(),
-            },
-        });
+        // 他ユーザーとの電話番号重複チェック（advisory lock で race 回避 + SQL 正規化比較）
+        const lockKey = computePhoneLockKey(normalizedPhone);
+        try {
+            await prisma.$transaction(async (tx) => {
+                await tx.$queryRaw(
+                    Prisma.sql`SELECT pg_advisory_xact_lock(${lockKey}::bigint)`
+                );
+                const dup = await tx.$queryRaw<{ id: number }[]>(
+                    Prisma.sql`SELECT id FROM users
+                        WHERE regexp_replace(translate(phone_number, '０１２３４５６７８９', '0123456789'), '[^0-9]', '', 'g') = ${normalizedPhone}
+                        AND phone_verified = true
+                        AND deleted_at IS NULL
+                        AND id <> ${user.id}
+                        LIMIT 1`
+                );
+                if (dup.length > 0) throw new Error('PHONE_DUPLICATE');
+
+                await tx.user.update({
+                    where: { id: user.id },
+                    data: {
+                        phone_number: normalizedPhone,
+                        phone_verified: true,
+                        phone_verified_at: new Date(),
+                    },
+                });
+            });
+        } catch (e) {
+            if (e instanceof Error && e.message === 'PHONE_DUPLICATE') {
+                return { success: false, error: 'この電話番号は既に他のアカウントで使われています' };
+            }
+            throw e;
+        }
 
         return { success: true };
     } catch (error) {
@@ -382,8 +413,39 @@ export async function updateUserProfile(formData: FormData) {
             };
         }
 
-        // 電話番号変更時のSMS認証チェック
-        const isPhoneChanged = phoneNumber !== user.phone_number;
+        // メール正規化（trim + lowercase）と他ユーザーとの重複チェック（case-insensitive）
+        const normalizedEmail = email.trim().toLowerCase();
+        if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalizedEmail)) {
+            return { success: false, error: 'メールアドレスの形式が正しくありません' };
+        }
+        const isEmailChanged = normalizedEmail !== user.email.toLowerCase();
+        if (isEmailChanged) {
+            const duplicatedEmail = await prisma.user.findFirst({
+                where: {
+                    email: { equals: normalizedEmail, mode: 'insensitive' },
+                    NOT: { id: user.id },
+                },
+                select: { id: true },
+            });
+            if (duplicatedEmail) {
+                return {
+                    success: false,
+                    error: 'このメールアドレスは既に他のアカウントで使われています',
+                };
+            }
+        }
+
+        // 電話番号を digits-only に正規化（register 側と一貫性維持）
+        const normalizedPhone = normalizePhoneDigits(phoneNumber);
+        if (normalizedPhone.length < 10 || normalizedPhone.length > 11) {
+            return {
+                success: false,
+                error: '電話番号の形式が正しくありません',
+            };
+        }
+
+        // 電話番号変更判定: DB 側の値も normalize してから比較（既存レガシーデータの表記ゆれ吸収）
+        const isPhoneChanged = normalizedPhone !== normalizePhoneDigits(user.phone_number);
         if (isPhoneChanged) {
             if (!phoneVerificationToken) {
                 return {
@@ -391,11 +453,27 @@ export async function updateUserProfile(formData: FormData) {
                     error: '電話番号の変更にはSMS認証が必要です',
                 };
             }
-            const isPhoneVerified = await validatePhoneVerificationToken(phoneVerificationToken, phoneNumber);
+            const isPhoneVerified = await validatePhoneVerificationToken(phoneVerificationToken, normalizedPhone);
             if (!isPhoneVerified) {
                 return {
                     success: false,
                     error: '電話番号の認証トークンが無効または期限切れです。再度認証を行ってください。',
+                };
+            }
+
+            // 他ユーザーとの電話番号重複チェック（SQL 側で正規化して比較）
+            const duplicatedPhone = await prisma.$queryRaw<{ id: number }[]>(
+                Prisma.sql`SELECT id FROM users
+                    WHERE regexp_replace(translate(phone_number, '０１２３４５６７８９', '0123456789'), '[^0-9]', '', 'g') = ${normalizedPhone}
+                    AND phone_verified = true
+                    AND deleted_at IS NULL
+                    AND id <> ${user.id}
+                    LIMIT 1`
+            );
+            if (duplicatedPhone.length > 0) {
+                return {
+                    success: false,
+                    error: 'この電話番号は既に他のアカウントで使われています',
                 };
             }
         }
@@ -485,13 +563,11 @@ export async function updateUserProfile(formData: FormData) {
             }
         }
 
-        // プロフィール更新
-        await prisma.user.update({
-            where: { id: user.id },
-            data: {
+        // プロフィール更新（phone 変更時は advisory lock で race 回避）
+        const updateData = {
                 name,
-                email,
-                phone_number: phoneNumber,
+                email: normalizedEmail,
+                phone_number: normalizedPhone,
                 ...(isPhoneChanged ? {
                     phone_verified: true,
                     phone_verified_at: new Date(),
@@ -539,8 +615,45 @@ export async function updateUserProfile(formData: FormData) {
                 // 更新者追跡
                 updated_by_type: 'WORKER',
                 updated_by_id: user.id,
-            },
-        });
+        };
+
+        if (isPhoneChanged) {
+            const lockKey = computePhoneLockKey(normalizedPhone);
+            try {
+                await prisma.$transaction(async (tx) => {
+                    await tx.$queryRaw(
+                        Prisma.sql`SELECT pg_advisory_xact_lock(${lockKey}::bigint)`
+                    );
+                    // ロック取得後、直前再チェック（正規化比較）
+                    const dup = await tx.$queryRaw<{ id: number }[]>(
+                        Prisma.sql`SELECT id FROM users
+                            WHERE regexp_replace(translate(phone_number, '０１２３４５６７８９', '0123456789'), '[^0-9]', '', 'g') = ${normalizedPhone}
+                            AND phone_verified = true
+                            AND deleted_at IS NULL
+                            AND id <> ${user.id}
+                            LIMIT 1`
+                    );
+                    if (dup.length > 0) throw new Error('PHONE_DUPLICATE_RACE');
+                    await tx.user.update({
+                        where: { id: user.id },
+                        data: updateData,
+                    });
+                });
+            } catch (e) {
+                if (e instanceof Error && e.message === 'PHONE_DUPLICATE_RACE') {
+                    return {
+                        success: false,
+                        error: 'この電話番号は既に他のアカウントで使われています',
+                    };
+                }
+                throw e;
+            }
+        } else {
+            await prisma.user.update({
+                where: { id: user.id },
+                data: updateData,
+            });
+        }
 
         // プロフィール関連ページのキャッシュを無効化
         revalidatePath('/mypage/profile');

--- a/src/lib/actions/user-profile.ts
+++ b/src/lib/actions/user-profile.ts
@@ -7,6 +7,7 @@ import { geocodeAddress } from '@/src/lib/geocoding';
 import { logActivity, getErrorMessage, getErrorStack } from '@/lib/logger';
 import { generateBankAccountName } from '@/lib/string-utils';
 import { validatePhoneVerificationToken } from '@/src/lib/auth/phone-verification';
+import { syncWorkerToTasLink, mapUserToTasLinkPayload } from '@/src/lib/taslink';
 
 /**
  * SMS認証成功時に電話番号を即座にDBに保存する
@@ -241,6 +242,28 @@ export async function updateUserSelfPR(selfPR: string): Promise<{ success: boole
             where: { id: user.id },
             data: { self_pr: selfPR.trim() || null, updated_by_type: 'WORKER', updated_by_id: user.id },
         });
+
+        // TasLinkへ自己PR更新を同期（DBからフルプロフィールを取得して送信）
+        try {
+            const fullUser = await prisma.user.findUnique({
+                where: { id: user.id },
+                select: {
+                    id: true, name: true, last_name_kana: true, first_name_kana: true,
+                    gender: true, birth_date: true, phone_number: true, email: true,
+                    postal_code: true, prefecture: true, city: true, address_line: true,
+                    qualifications: true, desired_work_days: true, desired_work_style: true,
+                    work_histories: true, self_pr: true,
+                },
+            });
+            if (fullUser) {
+                const tasLinkPayload = mapUserToTasLinkPayload(fullUser);
+                if (tasLinkPayload) {
+                    await syncWorkerToTasLink(user.id, tasLinkPayload);
+                }
+            }
+        } catch (tasLinkErr) {
+            console.error('[TasLink] Self-PR sync failed:', getErrorMessage(tasLinkErr));
+        }
 
         return { success: true };
     } catch (error) {
@@ -544,6 +567,34 @@ export async function updateUserProfile(formData: FormData) {
             },
             result: 'SUCCESS',
         }).catch(() => {});
+
+        // TasLinkへプロフィール更新を同期（同期完了を待つが、失敗しても更新は成功させる）
+        try {
+            const tasLinkPayload = mapUserToTasLinkPayload({
+                id: user.id,
+                name,
+                last_name_kana: lastNameKana,
+                first_name_kana: firstNameKana,
+                gender,
+                birth_date: birthDate ? new Date(birthDate) : null,
+                phone_number: phoneNumber,
+                email,
+                postal_code: postalCode,
+                prefecture,
+                city,
+                address_line: addressLine,
+                qualifications,
+                desired_work_days: desiredWorkDays,
+                desired_work_style: desiredWorkStyle,
+                work_histories: workHistories,
+                self_pr: selfPR,
+            });
+            if (tasLinkPayload) {
+                await syncWorkerToTasLink(user.id, tasLinkPayload);
+            }
+        } catch (tasLinkErr) {
+            console.error('[TasLink] Profile sync failed:', getErrorMessage(tasLinkErr));
+        }
 
         return {
             success: true,

--- a/src/lib/actions/user-profile.ts
+++ b/src/lib/actions/user-profile.ts
@@ -159,11 +159,18 @@ export async function checkProfileComplete(userId: number) {
 /**
  * 現在ログインしているワーカーの未入力プロフィール項目を取得する
  * BadgeContextやバナー表示用
+ * メール認証状態も併せて返す（応募前チェックで使用）
+ *
+ * エラー時は hasError=true を返す。呼び出し側は hasError を先に確認すべき
+ * （hasError 時の emailVerified/email/isComplete/missingFields はダミー値）
  */
 export async function getMissingProfileFields(): Promise<{
     isComplete: boolean;
     missingFields: string[];
     missingCount: number;
+    emailVerified: boolean;
+    email: string;
+    hasError: boolean;
 }> {
     try {
         const user = await getAuthenticatedUser();
@@ -172,11 +179,22 @@ export async function getMissingProfileFields(): Promise<{
             isComplete: result.isComplete,
             missingFields: result.missingFields,
             missingCount: result.missingFields.length,
+            emailVerified: user.email_verified,
+            email: user.email,
+            hasError: false,
         };
     } catch (error) {
-        // エラーの場合は安全側に倒す（未完了として扱う）
+        // エラーの場合は hasError=true を返し、呼び出し側でエラー処理させる
         console.error('[getMissingProfileFields] Error:', error);
-        return { isComplete: false, missingFields: ['プロフィール確認に失敗しました'], missingCount: 1 };
+        return {
+            isComplete: false,
+            missingFields: ['プロフィール確認に失敗しました'],
+            missingCount: 1,
+            // エラー時のダミー値（呼び出し側は hasError を先に見るべき）
+            emailVerified: true,
+            email: '',
+            hasError: true,
+        };
     }
 }
 

--- a/src/lib/actions/user-profile.ts
+++ b/src/lib/actions/user-profile.ts
@@ -32,7 +32,8 @@ export async function savePhoneVerification(phoneNumber: string, verificationTok
         const lockKey = computePhoneLockKey(normalizedPhone);
         try {
             await prisma.$transaction(async (tx) => {
-                await tx.$queryRaw(
+                // pg_advisory_xact_lock は void を返すため $executeRaw を使用
+                await tx.$executeRaw(
                     Prisma.sql`SELECT pg_advisory_xact_lock(${lockKey}::bigint)`
                 );
                 const dup = await tx.$queryRaw<{ id: number }[]>(
@@ -621,7 +622,8 @@ export async function updateUserProfile(formData: FormData) {
             const lockKey = computePhoneLockKey(normalizedPhone);
             try {
                 await prisma.$transaction(async (tx) => {
-                    await tx.$queryRaw(
+                    // pg_advisory_xact_lock は void を返すため $executeRaw を使用
+                    await tx.$executeRaw(
                         Prisma.sql`SELECT pg_advisory_xact_lock(${lockKey}::bigint)`
                     );
                     // ロック取得後、直前再チェック（正規化比較）

--- a/src/lib/auth/email-verification.ts
+++ b/src/lib/auth/email-verification.ts
@@ -2,6 +2,7 @@ import { prisma } from '@/lib/prisma';
 import { Resend } from 'resend';
 import crypto from 'crypto';
 import { cacheResendQuotaHeader } from '@/src/lib/resend-quota';
+import { sanitizeReturnUrl } from '@/src/lib/auth/return-url';
 
 // Resend設定（遅延初期化 - APIキーがない場合はnull）
 let resend: Resend | null = null;
@@ -29,11 +30,14 @@ export function generateVerificationToken(): string {
 
 /**
  * ユーザーに認証トークンを設定し、認証メールを送信
+ * returnUrl: 認証完了後に戻す URL（相対パスのみ受理、応募中のページなど）
+ * サニタイズは `@/src/lib/auth/return-url` の sanitizeReturnUrl に委譲
  */
 export async function sendVerificationEmail(
   userId: number,
   email: string,
-  name: string
+  name: string,
+  options?: { returnUrl?: string | null }
 ): Promise<{ success: boolean; error?: string }> {
   try {
     // トークン生成
@@ -49,8 +53,11 @@ export async function sendVerificationEmail(
       },
     });
 
-    // 認証URL
-    const verificationUrl = `${APP_URL}/api/auth/verify?token=${token}`;
+    // 認証URL（returnUrl は相対パスのみ許可、query として付与）
+    const safeReturnUrl = sanitizeReturnUrl(options?.returnUrl);
+    const verificationUrl = safeReturnUrl
+      ? `${APP_URL}/api/auth/verify?token=${token}&returnUrl=${encodeURIComponent(safeReturnUrl)}`
+      : `${APP_URL}/api/auth/verify?token=${token}`;
 
     // メール送信が無効化されている場合はログのみ
     if (process.env.DISABLE_EMAIL_SENDING === 'true') {
@@ -153,7 +160,8 @@ export async function verifyEmailToken(
  * 認証メールを再送信
  */
 export async function resendVerificationEmail(
-  email: string
+  email: string,
+  options?: { returnUrl?: string | null }
 ): Promise<{ success: boolean; error?: string }> {
   try {
     // メールアドレスでユーザーを検索
@@ -192,7 +200,9 @@ export async function resendVerificationEmail(
     }
 
     // 再送信
-    return await sendVerificationEmail(user.id, user.email, user.name);
+    return await sendVerificationEmail(user.id, user.email, user.name, {
+      returnUrl: options?.returnUrl,
+    });
   } catch (error: any) {
     console.error('[Email Verification] Resend error:', error);
     return { success: false, error: error.message };

--- a/src/lib/auth/identifier.ts
+++ b/src/lib/auth/identifier.ts
@@ -27,10 +27,12 @@ export function normalizePhoneDigits(input: string | undefined | null): string {
 }
 
 /**
- * 正規化済み電話番号を Postgres advisory lock キー用の bigint に変換する。
+ * 正規化済み電話番号を Postgres advisory lock キー用の数値文字列に変換する。
+ * BigInt を直接 $queryRaw に渡すと driver 側でシリアライズ問題が起きるため、
+ * 文字列として渡して SQL 側で `::bigint` キャストする。
  */
-export function phoneLockKey(normalized: string): bigint {
-  return BigInt(normalized.replace(/^0+/, '') || '0');
+export function phoneLockKey(normalized: string): string {
+  return normalized.replace(/^0+/, '') || '0';
 }
 
 export function parseLoginIdentifier(raw: string | undefined | null): LoginIdentifier {

--- a/src/lib/auth/identifier.ts
+++ b/src/lib/auth/identifier.ts
@@ -1,0 +1,56 @@
+export type LoginIdentifier =
+  | { type: 'email'; value: string }
+  | { type: 'phone'; value: string }
+  | { type: 'invalid' };
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function normalize(input: string): string {
+  return input
+    .trim()
+    .replace(/[Ａ-Ｚａ-ｚ０-９]/g, (ch) =>
+      String.fromCharCode(ch.charCodeAt(0) - 0xfee0)
+    )
+    .replace(/＠/g, '@')
+    .replace(/\u3000/g, ' ');
+}
+
+/**
+ * 電話番号を「数字のみ」の正規化形式に変換する。
+ * 全角数字・ハイフン・スペース・括弧などをすべて除去。
+ */
+export function normalizePhoneDigits(input: string | undefined | null): string {
+  if (!input) return '';
+  return input
+    .replace(/[０-９]/g, (ch) => String.fromCharCode(ch.charCodeAt(0) - 0xfee0))
+    .replace(/[^0-9]/g, '');
+}
+
+/**
+ * 正規化済み電話番号を Postgres advisory lock キー用の bigint に変換する。
+ */
+export function phoneLockKey(normalized: string): bigint {
+  return BigInt(normalized.replace(/^0+/, '') || '0');
+}
+
+export function parseLoginIdentifier(raw: string | undefined | null): LoginIdentifier {
+  if (!raw) return { type: 'invalid' };
+
+  const normalized = normalize(raw);
+  if (!normalized) return { type: 'invalid' };
+
+  if (EMAIL_RE.test(normalized)) {
+    return { type: 'email', value: normalized.toLowerCase() };
+  }
+
+  // 電話番号候補: 数字・ハイフン・スペース・括弧・プラスのみを許可
+  if (!/^[0-9\s\-+()]+$/.test(normalized)) {
+    return { type: 'invalid' };
+  }
+  const digitsOnly = normalized.replace(/[^0-9]/g, '');
+  if (digitsOnly.length === 10 || digitsOnly.length === 11) {
+    return { type: 'phone', value: digitsOnly };
+  }
+
+  return { type: 'invalid' };
+}

--- a/src/lib/auth/phone-verification.ts
+++ b/src/lib/auth/phone-verification.ts
@@ -5,7 +5,7 @@
  */
 import { SignJWT, jwtVerify } from 'jose';
 
-const TOKEN_EXPIRY = '10m'; // 10分有効
+const TOKEN_EXPIRY = '7d'; // 7日間有効
 
 function getSecret(): Uint8Array {
   const secret = process.env.NEXTAUTH_SECRET;

--- a/src/lib/auth/phone-verification.ts
+++ b/src/lib/auth/phone-verification.ts
@@ -2,8 +2,12 @@
  * 電話番号認証用JWT生成・検証ユーティリティ
  * CPaaS NOWでのSMS認証成功後に短期トークンを発行し、
  * 登録・プロフィール更新時にサーバー側で検証する
+ *
+ * 入力の表記ゆれ（ハイフン・全角数字など）で検証結果が変わらないよう、
+ * 発行・検証の両方で digits-only に正規化してから一致比較する。
  */
 import { SignJWT, jwtVerify } from 'jose';
+import { normalizePhoneDigits } from '@/src/lib/auth/identifier';
 
 const TOKEN_EXPIRY = '7d'; // 7日間有効
 
@@ -23,7 +27,8 @@ export async function createPhoneVerificationToken(phone: string): Promise<strin
   const secret = getSecret();
 
   return new SignJWT({
-    phone,
+    // payload は正規化後の digits-only で保存
+    phone: normalizePhoneDigits(phone),
     verifiedAt: Date.now(),
     purpose: 'phone-verification',
   })
@@ -36,7 +41,7 @@ export async function createPhoneVerificationToken(phone: string): Promise<strin
 /**
  * 電話番号認証JWTトークンを検証
  * @param token JWTトークン
- * @param expectedPhone 期待する電話番号（リクエストの電話番号と一致するか確認）
+ * @param expectedPhone 期待する電話番号（正規化前後どちらでも可）
  * @returns 検証成功ならtrue
  */
 export async function validatePhoneVerificationToken(
@@ -48,10 +53,14 @@ export async function validatePhoneVerificationToken(
     const { payload } = await jwtVerify(token, secret);
 
     // 電話番号の一致を確認
-    if (payload.phone !== expectedPhone) {
+    // 後方互換: 旧トークン（payload.phone が raw 形式）も受けるため両側 normalize して比較
+    const expectedNormalized = normalizePhoneDigits(expectedPhone);
+    const payloadPhone = typeof payload.phone === 'string' ? payload.phone : '';
+    const payloadNormalized = normalizePhoneDigits(payloadPhone);
+    if (payloadNormalized !== expectedNormalized) {
       console.warn('[Phone Verification] Phone mismatch:', {
-        expected: expectedPhone,
-        got: payload.phone,
+        expected: expectedNormalized,
+        got: payloadPhone,
       });
       return false;
     }

--- a/src/lib/auth/return-url.ts
+++ b/src/lib/auth/return-url.ts
@@ -1,0 +1,15 @@
+/**
+ * 認証メール等で使用する returnUrl の共通サニタイザ
+ *
+ * - 相対パス（"/" 始まり、"//" で始まらない）のみ許可
+ * - 最大長制限で URL 長制限や中継経路でのリンク破損を防止
+ * - null/undefined/不正値は null を返す
+ */
+const MAX_RETURN_URL_LENGTH = 512;
+
+export function sanitizeReturnUrl(raw: string | undefined | null): string | null {
+  if (!raw || typeof raw !== 'string') return null;
+  if (raw.length > MAX_RETURN_URL_LENGTH) return null;
+  if (!raw.startsWith('/') || raw.startsWith('//')) return null;
+  return raw;
+}

--- a/src/lib/auth/session-cookie.ts
+++ b/src/lib/auth/session-cookie.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server';
+import { encode } from 'next-auth/jwt';
+
+const SESSION_MAX_AGE_SECONDS = 30 * 24 * 60 * 60;
+
+export type SessionCookieUser = {
+  id: number;
+  email: string;
+  name: string;
+};
+
+export async function issueSessionCookie(
+  response: NextResponse,
+  user: SessionCookieUser
+): Promise<void> {
+  const secret = process.env.NEXTAUTH_SECRET;
+  if (!secret) {
+    throw new Error('NEXTAUTH_SECRET is not configured');
+  }
+
+  const jwtToken = await encode({
+    token: {
+      id: String(user.id),
+      email: user.email,
+      name: user.name,
+      sub: String(user.id),
+    },
+    secret,
+    maxAge: SESSION_MAX_AGE_SECONDS,
+  });
+
+  const isProduction = process.env.NODE_ENV === 'production';
+  const cookieName = isProduction
+    ? '__Secure-next-auth.session-token'
+    : 'next-auth.session-token';
+
+  response.cookies.set(cookieName, jwtToken, {
+    httpOnly: true,
+    secure: isProduction,
+    sameSite: 'lax',
+    path: '/',
+    maxAge: SESSION_MAX_AGE_SECONDS,
+  });
+
+  response.headers.set('Cache-Control', 'no-store');
+  response.headers.set('Referrer-Policy', 'no-referrer');
+}

--- a/src/lib/content-actions.ts
+++ b/src/lib/content-actions.ts
@@ -351,6 +351,14 @@ export async function updateSingleFaqOrder(id: number, sortOrder: number) {
 
 // ========== 利用規約・プライバシーポリシー ==========
 
+// 公開ページ（ISR/動的レンダリング）のキャッシュ無効化対象
+function getPublicLegalPaths(docType: 'TERMS' | 'PRIVACY', targetType: 'WORKER' | 'FACILITY'): string[] {
+    if (docType === 'PRIVACY' && targetType === 'WORKER') return ['/privacy'];
+    if (docType === 'TERMS' && targetType === 'WORKER') return ['/terms'];
+    if (docType === 'TERMS' && targetType === 'FACILITY') return ['/terms/facility'];
+    return [];
+}
+
 export async function getLegalDocument(docType: 'TERMS' | 'PRIVACY', targetType: 'WORKER' | 'FACILITY') {
     const doc = await prisma.legalDocument.findFirst({
         where: {
@@ -413,6 +421,9 @@ export async function createLegalDocument(data: {
     });
 
     revalidatePath('/system-admin/content/legal');
+    for (const path of getPublicLegalPaths(data.docType, data.targetType)) {
+        revalidatePath(path);
+    }
     return doc;
 }
 
@@ -443,6 +454,9 @@ export async function revertToLegalDocumentVersion(id: number) {
     });
 
     revalidatePath('/system-admin/content/legal');
+    for (const path of getPublicLegalPaths(targetDoc.doc_type as 'TERMS' | 'PRIVACY', targetDoc.target_type as 'WORKER' | 'FACILITY')) {
+        revalidatePath(path);
+    }
 }
 
 // ========== ご利用ガイド ==========

--- a/src/lib/cpaasnow.ts
+++ b/src/lib/cpaasnow.ts
@@ -8,7 +8,7 @@ const API_TOKEN = process.env.CPAAS_NOW_API_TOKEN;
 
 // SMS本文テンプレート
 // {{verification_code}}: 認証コードに置換、{{expiration_minutes}}: 有効期限(分)に置換
-const SMS_TEMPLATE = '【タスタス】認証コード: {{verification_code}}\r\n有効期限: {{expiration_minutes}}分';
+const SMS_TEMPLATE = '【タスタス】認証コード: {{verification_code}}\r\n有効期限: 7日間';
 
 export interface SendCodeResult {
   success: boolean;
@@ -45,7 +45,7 @@ export async function sendVerificationCode(phoneNumber: string): Promise<SendCod
         message: SMS_TEMPLATE,
         code_type: 'numeric',
         code_size: 6,
-        expiration_minutes: 10,
+        expiration_minutes: 10080, // 7日間（60分 × 24時間 × 7日）
       }),
     });
 

--- a/src/lib/cpaasnow.ts
+++ b/src/lib/cpaasnow.ts
@@ -8,7 +8,13 @@ const API_TOKEN = process.env.CPAAS_NOW_API_TOKEN;
 
 // SMS本文テンプレート
 // {{verification_code}}: 認証コードに置換、{{expiration_minutes}}: 有効期限(分)に置換
-const SMS_TEMPLATE = '【タスタス】認証コード: {{verification_code}}\r\n有効期限: 7日間';
+// CPaaS NOW 要件: {{expiration_minutes}} プレースホルダを本文に含めること
+const SMS_TEMPLATE = '【タスタス】認証コード: {{verification_code}}\r\n有効期限: {{expiration_minutes}}分';
+
+// CPaaS NOW の API 制約により 5-60 分のみ有効。
+// SMS コード自体の有効期限（コード検証はこの時間内に実施する必要がある）。
+// 検証成功後に発行する JWT（src/lib/auth/phone-verification.ts）は 7 日間有効。
+const SMS_EXPIRATION_MINUTES = 60;
 
 export interface SendCodeResult {
   success: boolean;
@@ -45,7 +51,7 @@ export async function sendVerificationCode(phoneNumber: string): Promise<SendCod
         message: SMS_TEMPLATE,
         code_type: 'numeric',
         code_size: 6,
-        expiration_minutes: 10080, // 7日間（60分 × 24時間 × 7日）
+        expiration_minutes: SMS_EXPIRATION_MINUTES,
       }),
     });
 

--- a/src/lib/taslink.ts
+++ b/src/lib/taslink.ts
@@ -270,7 +270,24 @@ export async function syncWorkerToTasLink(
     }
 
     if (response.status === 401) {
-      console.error('[TasLink] Authentication failed: invalid API key');
+      // 診断情報: キー値の不可視文字/貼り間違いを特定するためのフィンガープリント
+      // 機密漏洩を避けるため先頭4/末尾4文字のみ出力。完全な値はログに残さない
+      const keyStr = API_KEY || '';
+      const hasWhitespace = /\s/.test(keyStr);
+      const hasQuotes = /["'`]/.test(keyStr);
+      const hasJsonChars = /[{}:]/.test(keyStr);
+      console.error('[TasLink] Authentication failed: invalid API key', {
+        userId,
+        apiUrl: API_URL,
+        keyPrefix: keyStr.slice(0, 4),
+        keySuffix: keyStr.slice(-4),
+        keyLength: keyStr.length,
+        suspicious: {
+          hasWhitespace,
+          hasQuotes,
+          hasJsonChars,
+        },
+      });
       return { success: false, error: 'Authentication failed (401)' };
     }
 

--- a/src/lib/taslink.ts
+++ b/src/lib/taslink.ts
@@ -180,6 +180,10 @@ export function mapUserToTasLinkPayload(user: UserDataForSync): TasLinkWorkerPay
     externalId: String(user.id),
     lastName: nameResult.lastName,
     firstName: nameResult.firstName,
+    // tastas 経由で登録/同期されたワーカーを示す固定値。
+    // TasLink 側の登録経路マスタに合わせる値。
+    // 変更が必要な場合は TASLINK_REGISTRATION_SOURCE 環境変数で上書き可能。
+    registrationSource: process.env.TASLINK_REGISTRATION_SOURCE || 'ジョブマッチング',
   };
 
   if (user.last_name_kana) payload.lastNameKana = user.last_name_kana;

--- a/src/lib/taslink.ts
+++ b/src/lib/taslink.ts
@@ -1,0 +1,289 @@
+/**
+ * TasLink 外部API連携クライアント
+ * ワーカー（求職者）情報をTasLinkへ同期するサーバーサイドモジュール
+ *
+ * NOTE for TasLink developers:
+ * - externalId にはタスタス側の user.id（数値→文字列）を使用
+ * - POST /api/v1/external/workers で upsert（同じexternalIdなら更新）
+ * - レスポンスの id フィールドをタスタス側DBに保存している
+ *   → レスポンス形式が { data: { id: "xxx" } } 等の場合はパース処理の調整が必要
+ * - qualifications → jobTypes/qualifications のマッピングは暫定実装
+ *   → TasLink側マスタと完全一致しない値は "その他" にフォールバックしている
+ */
+
+import prisma from '@/lib/prisma';
+
+const API_URL = process.env.TASLINK_API_URL;
+const API_KEY = process.env.TASLINK_API_KEY;
+
+// --- 型定義 ---
+
+/** TasLink Worker APIに送信するペイロード */
+export interface TasLinkWorkerPayload {
+  externalId: string;
+  lastName: string;
+  firstName: string;
+  lastNameKana?: string;
+  firstNameKana?: string;
+  gender?: 'MALE' | 'FEMALE' | 'OTHER' | 'UNSPECIFIED';
+  dateOfBirth?: string;
+  phone?: string;
+  email?: string;
+  postalCode?: string;
+  prefecture?: string;
+  city?: string;
+  address?: string;
+  jobTypes?: string[];
+  qualifications?: string[];
+  availableDays?: string[];
+  workPreference?: 'ONE_TIME' | 'ONGOING' | 'BOTH';
+  workHistory?: string;
+  notes?: string;
+  registrationSource?: string;
+}
+
+/** TasLink API同期結果 */
+export interface TasLinkSyncResult {
+  success: boolean;
+  tasLinkId?: string;
+  error?: string;
+}
+
+/** Userモデルからマッピングに必要なフィールド */
+export interface UserDataForSync {
+  id: number;
+  name: string;
+  last_name_kana?: string | null;
+  first_name_kana?: string | null;
+  gender?: string | null;
+  birth_date?: Date | null;
+  phone_number?: string | null;
+  email?: string | null;
+  postal_code?: string | null;
+  prefecture?: string | null;
+  city?: string | null;
+  address_line?: string | null;
+  qualifications?: string[];
+  desired_work_days?: string[];
+  desired_work_style?: string | null;
+  work_histories?: string[];
+  self_pr?: string | null;
+}
+
+// --- マッピング定数 ---
+
+/**
+ * タスタス資格名 → TasLink職種マスタ (jobTypes)
+ * NOTE: TasLink側の職種マスタにないものは "その他" にフォールバック
+ */
+const JOB_TYPE_MAP: Record<string, string> = {
+  '看護師': '看護師',
+  '准看護師': '准看護師',
+  '介護士': '介護士',
+  '介護福祉士': '介護福祉士',
+  '初任者研修': '初任者研修',
+  '実務者研修': '実務者研修',
+  '理学療法士': '理学療法士',
+  '作業療法士': '作業療法士',
+};
+
+/**
+ * タスタス資格名 → TasLink資格マスタ (qualifications)
+ * NOTE: TasLink側の資格マスタと名称が異なるものは変換が必要
+ */
+const QUALIFICATION_MAP: Record<string, string> = {
+  '看護師': '看護師免許',
+  '准看護師': '准看護師免許',
+  '介護福祉士': '介護福祉士',
+  '初任者研修': '介護職員初任者研修',
+  '実務者研修': '介護職員実務者研修',
+  '社会福祉士': '社会福祉士',
+  '理学療法士': '理学療法士',
+  '作業療法士': '作業療法士',
+  '言語聴覚士': '言語聴覚士',
+  '管理栄養士': '管理栄養士',
+  '栄養士': '栄養士',
+  '保育士': '保育士',
+};
+
+// --- マッピング関数 ---
+
+/** 性別をTasLink形式に変換 */
+function mapGender(gender: string | null | undefined): TasLinkWorkerPayload['gender'] {
+  if (!gender) return 'UNSPECIFIED';
+  const mapping: Record<string, TasLinkWorkerPayload['gender']> = {
+    '男性': 'MALE',
+    '女性': 'FEMALE',
+    'その他': 'OTHER',
+    'MALE': 'MALE',
+    'FEMALE': 'FEMALE',
+    'OTHER': 'OTHER',
+  };
+  return mapping[gender] || 'UNSPECIFIED';
+}
+
+/** 就業形態希望をTasLink形式に変換 */
+function mapWorkPreference(style: string | null | undefined): TasLinkWorkerPayload['workPreference'] | undefined {
+  if (!style) return undefined;
+  const mapping: Record<string, TasLinkWorkerPayload['workPreference']> = {
+    '単発': 'ONE_TIME',
+    '単発希望': 'ONE_TIME',
+    '継続': 'ONGOING',
+    '継続希望': 'ONGOING',
+    'どちらも': 'BOTH',
+    'どちらも可': 'BOTH',
+  };
+  return mapping[style] || undefined;
+}
+
+/** タスタス資格配列 → TasLink jobTypes 配列に変換（重複排除） */
+function mapToJobTypes(qualifications: string[]): string[] {
+  const mapped = qualifications.map(q => JOB_TYPE_MAP[q] || 'その他');
+  return Array.from(new Set(mapped));
+}
+
+/** タスタス資格配列 → TasLink qualifications 配列に変換（重複排除） */
+function mapToQualifications(qualifications: string[]): string[] {
+  const mapped = qualifications.map(q => QUALIFICATION_MAP[q] || 'その他');
+  return Array.from(new Set(mapped));
+}
+
+/**
+ * nameフィールドを姓名に分割
+ * 全角・半角スペース両対応
+ */
+function splitName(name: string): { lastName: string; firstName: string } | null {
+  if (!name.trim()) return null;
+  const parts = name.trim().split(/\s+/);
+  if (parts.length >= 2) {
+    return { lastName: parts[0], firstName: parts.slice(1).join(' ') };
+  }
+  // 姓のみ（スペースなし）の場合
+  return { lastName: parts[0], firstName: '' };
+}
+
+/** Date → JST基準のISO 8601日付文字列 (YYYY-MM-DD) */
+function toJSTDateStr(date: Date): string {
+  const jst = new Date(date.getTime() + 9 * 60 * 60 * 1000);
+  return jst.toISOString().split('T')[0];
+}
+
+/** UserデータをTasLink APIペイロードに変換。名前が空の場合はnullを返す */
+export function mapUserToTasLinkPayload(user: UserDataForSync): TasLinkWorkerPayload | null {
+  const nameResult = splitName(user.name);
+  if (!nameResult || !nameResult.lastName) {
+    // lastName が空の場合、TasLink APIの必須フィールドを満たせないため同期スキップ
+    return null;
+  }
+
+  const payload: TasLinkWorkerPayload = {
+    externalId: String(user.id),
+    lastName: nameResult.lastName,
+    firstName: nameResult.firstName,
+  };
+
+  if (user.last_name_kana) payload.lastNameKana = user.last_name_kana;
+  if (user.first_name_kana) payload.firstNameKana = user.first_name_kana;
+  payload.gender = mapGender(user.gender);
+  if (user.birth_date) payload.dateOfBirth = toJSTDateStr(user.birth_date);
+  if (user.phone_number) payload.phone = user.phone_number;
+  if (user.email) payload.email = user.email;
+  if (user.postal_code) payload.postalCode = user.postal_code;
+  if (user.prefecture) payload.prefecture = user.prefecture;
+  if (user.city) payload.city = user.city;
+  if (user.address_line) payload.address = user.address_line;
+  if (user.qualifications && user.qualifications.length > 0) {
+    payload.jobTypes = mapToJobTypes(user.qualifications);
+    payload.qualifications = mapToQualifications(user.qualifications);
+  }
+  if (user.desired_work_days && user.desired_work_days.length > 0) {
+    payload.availableDays = user.desired_work_days;
+  }
+  const workPref = mapWorkPreference(user.desired_work_style);
+  if (workPref) payload.workPreference = workPref;
+  if (user.work_histories && user.work_histories.length > 0) {
+    payload.workHistory = user.work_histories.join('\n');
+  }
+  if (user.self_pr) payload.notes = user.self_pr;
+
+  return payload;
+}
+
+// --- API呼び出し ---
+
+/**
+ * ワーカー情報をTasLinkに同期
+ * POST /api/v1/external/workers（externalIdによるupsert）
+ *
+ * 成功時はtaslink_idとtaslink_synced_atをDBに保存する。
+ * エラー時はログ出力のみ、例外はスローしない。
+ * awaitで呼び出すため、TasLink APIの応答を待ってからレスポンスを返す。
+ */
+export async function syncWorkerToTasLink(
+  userId: number,
+  payload: TasLinkWorkerPayload,
+): Promise<TasLinkSyncResult> {
+  if (!API_URL || !API_KEY) {
+    console.warn('[TasLink] Not configured (TASLINK_API_URL or TASLINK_API_KEY missing), skipping sync');
+    return { success: false, error: 'TasLink not configured' };
+  }
+
+  try {
+    const response = await fetch(`${API_URL}/api/v1/external/workers`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': API_KEY,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (response.status === 200 || response.status === 201) {
+      const data = await response.json();
+      // NOTE: TasLink APIのレスポンス形式に応じてパスを調整すること
+      const tasLinkId = String(data.id ?? data.data?.id ?? '');
+
+      // DB に TasLink ID と同期日時を保存
+      if (tasLinkId) {
+        try {
+          await prisma.user.update({
+            where: { id: userId },
+            data: {
+              taslink_id: tasLinkId,
+              taslink_synced_at: new Date(),
+            },
+          });
+        } catch (dbError) {
+          console.error('[TasLink] DB update failed (API sync succeeded):', dbError instanceof Error ? dbError.message : String(dbError));
+          return { success: true, tasLinkId, error: 'API sync succeeded but DB update failed' };
+        }
+      }
+
+      console.log('[TasLink] Worker synced successfully:', { userId, tasLinkId });
+      return { success: true, tasLinkId };
+    }
+
+    if (response.status === 400) {
+      const errorBody = await response.text();
+      console.error('[TasLink] Validation error:', { userId, status: 400, body: errorBody.slice(0, 500) });
+      return { success: false, error: `Validation error (400): ${errorBody.slice(0, 200)}` };
+    }
+
+    if (response.status === 401) {
+      console.error('[TasLink] Authentication failed: invalid API key');
+      return { success: false, error: 'Authentication failed (401)' };
+    }
+
+    if (response.status === 429) {
+      console.warn('[TasLink] Rate limited:', { userId });
+      return { success: false, error: 'Rate limited (429)' };
+    }
+
+    const errorBody = await response.text();
+    console.error('[TasLink] Sync failed:', { userId, status: response.status, body: errorBody.slice(0, 500) });
+    return { success: false, error: `Sync failed (${response.status}): ${errorBody.slice(0, 200)}` };
+  } catch (error) {
+    console.error('[TasLink] Network error:', error instanceof Error ? error.message : String(error));
+    return { success: false, error: `Network error: ${error instanceof Error ? error.message : String(error)}` };
+  }
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -50,6 +50,15 @@ export default {
         'primary': '0 2px 8px rgba(255, 51, 51, 0.3)',
         'secondary': '0 2px 8px rgba(56, 149, 255, 0.3)',
       },
+      keyframes: {
+        'slide-up': {
+          '0%': { transform: 'translateY(100%)' },
+          '100%': { transform: 'translateY(0)' },
+        },
+      },
+      animation: {
+        'slide-up': 'slide-up 0.3s ease-out',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## 概要
直近の開発成果を本番へ反映するリリース PR。

## 含まれる主な変更

### 大きな機能追加
- **#532 新しい会員登録フロー**（8ステップUI + デュアル識別子ログイン）
- **#535 テスト用ワーカー完全削除機能**（開発者ポータル配下）
- **#537 強制削除モード** 追加（super_admin 限定）
- **#542 メール認証完了サンクスページ** + returnUrl 引き継ぎ
- **#547 利用規約同意後にSMS送信するフロー** + LINE URLフォールバック
- **#543 TasLink一括同期スクリプト** + registrationSource仕様反映

### バグ修正
- #533 CPaaS の expiration_minutes を仕様内（60分）に
- #534 登録500エラー診断改善 + チェックボックスのタップ領域拡大
- #536 ワーカー削除機能をサイドバーメニューに追加
- #538 登録ボタン文言短縮で改行崩れ解消
- #539 pg_advisory_xact_lock を executeRaw に
- #540 405エラー/パスワードフォーム未配置/エラー表示UX改善（4件）
- #541 応募時のメール未認証チェック発火
- #544 登録完了サンクスページのボタン整理
- #545 サンクスページの LINE URL を LP 設定から取得
- #531 利用規約/PP更新時の公開ページキャッシュ無効化
- #546 TasLink 401 時の診断ログ追加

## 本番反映前の確認事項
- [ ] ステージング (stg-share-worker.vercel.app) で動作確認済み
- [ ] DB スキーマ変更なし（Prisma マイグレーション不要）
- [ ] 環境変数 `ALLOW_DEV_USER_DELETE` は本番に設定しない運用
- [ ] CPaaS NOW / Resend API 本番キー有効確認

## リリース後の確認
- 登録フロー動作（新規ユーザー作成→メール認証→応募）
- SMS 送信（expiration_minutes=60 で正常動作）
- LINE ボタン表示（LP CTA URL または is_default=true タグから取得）

🤖 Generated with [Claude Code](https://claude.com/claude-code)