### PR TITLE
バグ修正: 管理画面のメールアドレス検証を厳密化

### DIFF
--- a/app/system-admin/content/notifications/page.tsx
+++ b/app/system-admin/content/notifications/page.tsx
@@ -198,9 +198,11 @@ export default function NotificationManagementPage() {
         }
     };
 
+    // ドメイン先頭は英数字必須: `user@+domain.com` のような Resend が400を返す形式を事前に弾く
+    // （sendNotification の低レベルガードと同一パターン）
     const isValidEmail = (email: string): boolean => {
-        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-        return emailRegex.test(email);
+        const emailRegex = /^[^\s@]+@[a-zA-Z0-9][^\s@]*\.[^\s@]+$/;
+        return emailRegex.test(email.trim());
     };
 
     const startEditAdmin = (item: SystemAdminItem) => {

--- a/app/system-admin/settings/admins/page.tsx
+++ b/app/system-admin/settings/admins/page.tsx
@@ -86,17 +86,19 @@ export default function SystemAdminsPage() {
             toast.error('名前を入力してください');
             return;
         }
-        if (!newAdmin.email?.trim()) {
+        const trimmedEmail = newAdmin.email?.trim() ?? '';
+        if (!trimmedEmail) {
             toast.error('メールアドレスを入力してください');
             return;
         }
-        if (!isValidEmail(newAdmin.email)) {
+        if (!isValidEmail(trimmedEmail)) {
             toast.error('メールアドレスの形式が正しくありません');
             return;
         }
 
         try {
-            const result = await createSystemAdmin(newAdmin);
+            // trim 済みのアドレスを渡して、空白入りデータがDBに保存されるのを防ぐ
+            const result = await createSystemAdmin({ ...newAdmin, email: trimmedEmail });
             if (result.success && result.initialPassword) {
                 toast.success('管理者を作成しました');
                 setCreatedCredentials({ password: result.initialPassword });

--- a/app/system-admin/settings/admins/page.tsx
+++ b/app/system-admin/settings/admins/page.tsx
@@ -71,9 +71,11 @@ export default function SystemAdminsPage() {
     }, []);
 
     // メールアドレス形式チェック
+    // ドメイン先頭は英数字必須: `user@+domain.com` のような Resend が400を返す形式を事前に弾く
+    // （sendNotification の低レベルガードと同一パターン）
     const isValidEmail = (email: string): boolean => {
-        const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-        return emailRegex.test(email);
+        const emailRegex = /^[^\s@]+@[a-zA-Z0-9][^\s@]*\.[^\s@]+$/;
+        return emailRegex.test(email.trim());
     };
 
     const handleCreate = async (e: React.FormEvent) => {


### PR DESCRIPTION
## Summary

管理画面フォームのメールアドレス検証を、PR #549 の \`sendNotification\` 低レベルガードと同じ強度に揃える。不正なアドレスがDBに入る前に入力段階で弾く予防策。

## 背景

- PR #549 で \`sendNotification\` に email 形式ガードを追加（運用時の保険）
- しかし **管理画面の入力フォームは緩い正規表現のまま** で、\`user@+domain.com\` のような Resend が拒否する形式を保存できてしまう
- Codex レビューからの指摘: 「送信側だけ保護しても、入力側で弾かなければバッドデータが入り続ける」
- 実際に stg DB に \`editor@+tastas.com\` が存在していた（フォーム検証をすり抜けて登録されていた）

## 変更内容

\`\`\`diff
 const isValidEmail = (email: string): boolean => {
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    return emailRegex.test(email);
+    const emailRegex = /^[^\s@]+@[a-zA-Z0-9][^\s@]*\.[^\s@]+$/;
+    return emailRegex.test(email.trim());
 };
\`\`\`

変更箇所（2ファイル）:
- \`app/system-admin/settings/admins/page.tsx\` (L74) — 管理者作成フォーム + 通知メール編集
- \`app/system-admin/content/notifications/page.tsx\` (L201) — 通知メール編集

変更ポイント:
1. **ドメイン先頭を英数字必須に** — \`user@+domain.com\` や \`user@-domain.com\` を弾く
2. **trim() を検証前に呼ぶ** — 末尾空白入り値がバリデーションを素通りして保存される問題の予防

## 影響範囲

- **影響を受ける操作**: 管理画面での「管理者の新規作成」「通知メールアドレス編集」のUI入力バリデーション
- **影響なし**: ワーカー登録フロー（\`register/route.ts\`）、ログイン時のメール判定（\`src/lib/auth/identifier.ts\`） — 別用途なので今回は対象外
- **既存データ**: DB 上の既存不正レコードはこのPRでは触らない（別途SQL対応）

## 互換性

- 新規の入力には厳密な検証が適用される
- 既存の正しいメール（\`user@domain.com\`, \`user.name+tag@sub.example.co.jp\` 等）は引き続き通る
- IDN（日本語ドメイン等）は punycode 前提で運用されているため影響なし

## Test plan

- [ ] stg で管理者作成時に \`test@+bad.com\` を入力 → 「形式が正しくありません」エラー出ることを確認
- [ ] 有効なアドレス (\`admin@example.com\`, \`user+tag@sub.example.co.jp\`) は通ることを確認
- [ ] 通知メール編集画面でも同様に動作することを確認
- [ ] 末尾空白入り (\`admin@example.com \`) が入力されても、trim されて保存されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)