### PR TITLE
機能追加: プロフィール項目の新旧値統合 + 登録フォームに step 2c 追加

### DIFF
--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -11,6 +11,7 @@ import { validatePhoneVerificationToken } from '@/src/lib/auth/phone-verificatio
 import { syncWorkerToTasLink, mapUserToTasLinkPayload } from '@/src/lib/taslink';
 import { issueSessionCookie } from '@/src/lib/auth/session-cookie';
 import { normalizePhoneDigits, phoneLockKey } from '@/src/lib/auth/identifier';
+import { normalizeDesiredWorkDays } from '@/src/lib/normalize-desired-work-days';
 
 interface RegisterBody {
   email: string;
@@ -36,6 +37,11 @@ interface RegisterBody {
   // 新登録フロー（モック8ステップ）項目
   desiredWorkStyle?: string[];     // 希望の働き方（複数選択）
   workFrequency?: string;           // 週の頻度（step 2b）
+  // step 2c（任意入力）
+  desiredWorkPeriod?: string;       // 希望勤務期間
+  desiredWorkDays?: string[];       // 希望勤務曜日（「特になし」排他）
+  desiredStartTime?: string;        // 希望開始時刻
+  desiredEndTime?: string;          // 希望終了時刻
   jobTiming?: string;               // いつ頃探しているか
   employmentStatus?: string;        // 現在の就業状況
   // LP経由登録情報
@@ -79,6 +85,10 @@ export async function POST(request: NextRequest) {
       qualificationCertificates,
       desiredWorkStyle,
       workFrequency,
+      desiredWorkPeriod,
+      desiredWorkDays,
+      desiredStartTime,
+      desiredEndTime,
       jobTiming,
       employmentStatus,
       registrationLpId,
@@ -246,6 +256,11 @@ export async function POST(request: NextRequest) {
             desired_work_days_week: workFrequency || null,
             job_change_desire: jobTiming || null,
             current_work_style: employmentStatus || null,
+            // step 2c（任意入力）
+            desired_work_period: desiredWorkPeriod || null,
+            desired_work_days: normalizeDesiredWorkDays(desiredWorkDays),
+            desired_start_time: desiredStartTime || null,
+            desired_end_time: desiredEndTime || null,
             // LP経由登録情報（フォールバックチェーン適用済み）
             registration_lp_id: resolvedLpId,
             registration_campaign_code: resolvedCampaignCode,

--- a/app/mypage/profile/ProfileEditClient.tsx
+++ b/app/mypage/profile/ProfileEditClient.tsx
@@ -14,6 +14,7 @@ import toast from 'react-hot-toast';
 import AddressSelector from '@/components/ui/AddressSelector';
 import { KatakanaInput, KatakanaWithSpaceInput } from '@/components/ui/KatakanaInput';
 import { PhoneNumberInput } from '@/components/ui/PhoneNumberInput';
+import { HOUR_TIME_OPTIONS } from '@/constants/time-options';
 import { SmsVerification } from '@/components/ui/SmsVerification';
 import { QUALIFICATION_GROUPS } from '@/constants/qualifications';
 import { useDebugError, extractDebugInfo } from '@/components/debug/DebugErrorBanner';
@@ -247,6 +248,9 @@ export default function ProfileEditClient({ userProfile }: ProfileEditClientProp
   const [isSaving, setIsSaving] = useState(false);
   // バリデーションエラー表示用（送信時にtrueになる）
   const [showErrors, setShowErrors] = useState(false);
+  // 希望の働き方をユーザーが明示的に変更したか（CSV 保持判定用）
+  // 初期マウント時は false、ドロップダウン onChange で true
+  const [desiredWorkStyleDirty, setDesiredWorkStyleDirty] = useState(false);
   // 電話番号SMS認証トークン
   const [phoneVerificationToken, setPhoneVerificationToken] = useState<string | null>(null);
   // 電話番号が変更されたかどうか
@@ -341,10 +345,7 @@ export default function ProfileEditClient({ userProfile }: ProfileEditClientProp
 
   const weekDays = ['月', '火', '水', '木', '金', '土', '日', '特になし'];
 
-  const timeOptions = Array.from({ length: 24 }, (_, i) => {
-    const hour = i.toString().padStart(2, '0');
-    return `${hour}:00`;
-  });
+  const timeOptions = HOUR_TIME_OPTIONS;
 
   const handleCheckboxChange = (field: 'qualifications' | 'experienceFields' | 'desiredWorkDays', value: string) => {
     setFormData(prev => {
@@ -646,6 +647,9 @@ export default function ProfileEditClient({ userProfile }: ProfileEditClientProp
       // 働き方・希望
       form.append('currentWorkStyle', formData.currentWorkStyle);
       form.append('desiredWorkStyle', formData.desiredWorkStyle);
+      // ユーザーが desiredWorkStyle を明示的に触った場合のフラグ
+      // （CSV 複数値を単一値に潰す意思の有無を区別するため）
+      form.append('desiredWorkStyleChanged', desiredWorkStyleDirty ? 'true' : 'false');
       form.append('jobChangeDesire', formData.jobChangeDesire);
       form.append('desiredWorkDaysPerWeek', formData.desiredWorkDaysPerWeek);
       form.append('desiredWorkPeriod', formData.desiredWorkPeriod);
@@ -938,6 +942,13 @@ export default function ProfileEditClient({ userProfile }: ProfileEditClientProp
                   className={`w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent ${showErrors && !formData.currentWorkStyle ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
                 >
                   <option value="">選択してください</option>
+                  {/* 新登録フォームの値（優先表示） */}
+                  <option value="就業中（常勤・正社員）">就業中（常勤・正社員）</option>
+                  <option value="就業中（非常勤・パート）">就業中（非常勤・パート）</option>
+                  <option value="離職中">離職中</option>
+                  <option value="学生">学生</option>
+                  {/* 既存ユーザーの値（seed / 旧フォーム） */}
+                  <option value="単発">単発</option>
                   <option value="正社員">正社員</option>
                   <option value="パート・アルバイト">パート・アルバイト</option>
                   <option value="派遣">派遣</option>
@@ -952,13 +963,24 @@ export default function ProfileEditClient({ userProfile }: ProfileEditClientProp
                 <label className="block text-sm font-medium mb-2">希望の働き方 <span className="text-red-500">*</span></label>
                 <select
                   value={formData.desiredWorkStyle}
-                  onChange={(e) => setFormData({ ...formData, desiredWorkStyle: e.target.value })}
+                  onChange={(e) => {
+                    setFormData({ ...formData, desiredWorkStyle: e.target.value });
+                    setDesiredWorkStyleDirty(true);
+                  }}
                   className={`w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent ${showErrors && !formData.desiredWorkStyle ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
                 >
                   <option value="">選択してください</option>
+                  {/* 新登録フォームの値（優先表示） */}
+                  <option value="単発・スポット">単発・スポット</option>
+                  <option value="常勤・正社員">常勤・正社員</option>
+                  <option value="非常勤・パート（扶養内）">非常勤・パート（扶養内）</option>
+                  <option value="非常勤・パート（扶養外）">非常勤・パート（扶養外）</option>
+                  <option value="派遣">派遣</option>
+                  <option value="こだわらない">こだわらない</option>
+                  {/* 既存ユーザーの値（重複する「派遣」を除外） */}
+                  <option value="単発">単発</option>
                   <option value="正社員">正社員</option>
                   <option value="パート・アルバイト">パート・アルバイト</option>
-                  <option value="派遣">派遣</option>
                   <option value="契約社員">契約社員</option>
                   <option value="その他">その他</option>
                 </select>
@@ -976,6 +998,12 @@ export default function ProfileEditClient({ userProfile }: ProfileEditClientProp
                 className={`w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent ${showErrors && !formData.jobChangeDesire ? 'border-red-500 bg-red-50' : 'border-gray-300'}`}
               >
                 <option value="">選択してください</option>
+                {/* 新登録フォームの値（優先表示） */}
+                <option value="いますぐ">いますぐ</option>
+                <option value="1ヶ月以内">1ヶ月以内</option>
+                <option value="3ヶ月以内">3ヶ月以内</option>
+                <option value="いまは情報収集のみ">いまは情報収集のみ</option>
+                {/* 既存ユーザーの値 */}
                 <option value="今はない">今はない</option>
                 <option value="いい仕事があれば">いい仕事があれば</option>
                 <option value="転職したい">転職したい</option>
@@ -994,6 +1022,13 @@ export default function ProfileEditClient({ userProfile }: ProfileEditClientProp
                   className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent"
                 >
                   <option value="">特になし</option>
+                  {/* 新登録フォームの値（優先表示） */}
+                  <option value="週1回">週1回</option>
+                  <option value="週2〜3回">週2〜3回</option>
+                  <option value="週4〜5回">週4〜5回</option>
+                  <option value="週5回">週5回</option>
+                  <option value="不定期/決まっていない">不定期/決まっていない</option>
+                  {/* 既存ユーザーの値 */}
                   <option value="週1〜2日">週1〜2日</option>
                   <option value="週3〜4日">週3〜4日</option>
                   <option value="週5日以上">週5日以上</option>

--- a/app/register/worker/page.tsx
+++ b/app/register/worker/page.tsx
@@ -10,10 +10,12 @@ import { getLegalDocument } from '@/src/lib/content-actions';
 import { trackGA4Event } from '@/src/lib/ga4-events';
 import RegistrationPageTracker from '@/components/tracking/RegistrationPageTracker';
 import { isValidPhoneNumber } from '@/utils/inputValidation';
+import { HOUR_TIME_OPTIONS } from '@/constants/time-options';
+import { normalizeDesiredWorkDays } from '@/src/lib/normalize-desired-work-days';
 
 // フォーム入力ステップ (1〜8) + SMS認証ステップ (sms)
 // PP 同意後に SMS を送信するため、認証は step 8 の後に別画面で行う
-type StepId = '1' | '2' | '2b' | '3' | '4' | '5' | '6' | '7' | '8' | 'sms';
+type StepId = '1' | '2' | '2b' | '2c' | '3' | '4' | '5' | '6' | '7' | '8' | 'sms';
 
 // 資格オプション：表示ラベルとDB保存値のマッピング
 const QUALIFICATION_OPTIONS: { label: string; value: string }[] = [
@@ -35,6 +37,19 @@ const DESIRED_WORK_STYLE_OPTIONS = [
 ];
 
 const WORK_FREQUENCY_OPTIONS = ['週1回', '週2〜3回', '週4〜5回', '週5回'];
+
+// step 2c: 希望勤務期間
+const DESIRED_WORK_PERIOD_OPTIONS = [
+  '1週間以内',
+  '3週間以内',
+  '1〜2ヶ月',
+  '3〜6ヶ月',
+  '6ヶ月以上',
+  '未定',
+];
+
+// step 2c: 希望勤務曜日（月〜日 + 特になし）
+const DESIRED_WORK_DAY_OPTIONS = ['月', '火', '水', '木', '金', '土', '日', '特になし'];
 const JOB_TIMING_OPTIONS = ['いますぐ', '1ヶ月以内', '3ヶ月以内', 'いまは情報収集のみ'];
 const EMPLOYMENT_STATUS_OPTIONS = [
   '就業中（常勤・正社員）',
@@ -109,6 +124,11 @@ function WorkerRegisterPageInner() {
     qualificationOther: '',                // その他自由記述
     desiredWorkStyle: [] as string[],     // 複数選択
     workFrequency: '',                     // step 2b（条件付き）
+    // step 2c（任意入力）
+    desiredWorkPeriod: '',                 // 希望勤務期間
+    desiredWorkDays: [] as string[],       // 希望勤務曜日（「特になし」排他）
+    desiredStartTime: '',                  // 希望開始時刻
+    desiredEndTime: '',                    // 希望終了時刻
     jobTiming: '',
     employmentStatus: '',
     postalCode: '',
@@ -180,10 +200,11 @@ function WorkerRegisterPageInner() {
 
   // ステップ順序（条件付きで 2b を挿入）
   // sms ステップは step 8 の後に続く「認証コード入力」画面（利用規約同意後に SMS 送信）
+  // 2c は任意入力の追加項目（希望勤務期間・曜日・開始/終了時刻）
   const stepSequence = useMemo<StepId[]>(() => {
     const base: StepId[] = ['1', '2'];
     if (shouldShowStep2b(form.desiredWorkStyle)) base.push('2b');
-    base.push('3', '4', '5', '6', '7', '8', 'sms');
+    base.push('2c', '3', '4', '5', '6', '7', '8', 'sms');
     return base;
   }, [form.desiredWorkStyle]);
 
@@ -204,6 +225,27 @@ function WorkerRegisterPageInner() {
     });
   };
 
+  // 希望勤務曜日の排他選択（「特になし」と月〜日の排他）
+  const toggleDesiredWorkDay = (value: string) => {
+    setForm(prev => {
+      const curr = prev.desiredWorkDays;
+      const isSelected = curr.includes(value);
+      // 既選択を外す
+      if (isSelected) {
+        return { ...prev, desiredWorkDays: curr.filter(v => v !== value) };
+      }
+      // 「特になし」を選択 → 他を全部外す
+      if (value === '特になし') {
+        return { ...prev, desiredWorkDays: ['特になし'] };
+      }
+      // 月〜日のいずれかを選択 → 「特になし」を外す
+      return {
+        ...prev,
+        desiredWorkDays: [...curr.filter(v => v !== '特になし'), value],
+      };
+    });
+  };
+
   // 各ステップのバリデーション
   const isStepValid = (): boolean => {
     switch (currentStep) {
@@ -216,6 +258,9 @@ function WorkerRegisterPageInner() {
         return form.desiredWorkStyle.length > 0;
       case '2b':
         return !!form.workFrequency;
+      case '2c':
+        // すべて任意入力（スキップ可）
+        return true;
       case '3':
         return !!form.jobTiming;
       case '4':
@@ -432,6 +477,11 @@ function WorkerRegisterPageInner() {
           city: form.city,
           desiredWorkStyle: form.desiredWorkStyle,
           workFrequency: form.workFrequency || undefined,
+          // step 2c (任意入力、空文字はサーバー側で null 扱い)
+          desiredWorkPeriod: form.desiredWorkPeriod || undefined,
+          desiredWorkDays: normalizeDesiredWorkDays(form.desiredWorkDays),
+          desiredStartTime: form.desiredStartTime || undefined,
+          desiredEndTime: form.desiredEndTime || undefined,
           jobTiming: form.jobTiming,
           employmentStatus: form.employmentStatus,
           registrationLpId: lpInfo.lpId,
@@ -575,6 +625,78 @@ function WorkerRegisterPageInner() {
                     onClick={() => setField('workFrequency', '不定期/決まっていない')}
                   />
                 )}
+              </div>
+            </StepContainer>
+          )}
+
+          {currentStep === '2c' && (
+            <StepContainer question="詳細な希望勤務条件" hint="任意入力。「次へ」で空欄のままスキップできます">
+              <div className="mb-5">
+                <FieldLabel>希望勤務期間</FieldLabel>
+                <select
+                  value={form.desiredWorkPeriod}
+                  onChange={e => setField('desiredWorkPeriod', e.target.value)}
+                  className="w-full px-4 py-3 border-2 border-gray-200 rounded-[10px] focus:border-[#2AADCF] focus:outline-none"
+                >
+                  <option value="">特になし</option>
+                  {DESIRED_WORK_PERIOD_OPTIONS.map(opt => (
+                    <option key={opt} value={opt}>{opt}</option>
+                  ))}
+                </select>
+              </div>
+              <div className="mb-5">
+                <FieldLabel>希望勤務曜日</FieldLabel>
+                <div className="flex flex-wrap gap-2">
+                  {DESIRED_WORK_DAY_OPTIONS.map(opt => {
+                    const selected = form.desiredWorkDays.includes(opt);
+                    return (
+                      <button
+                        key={opt}
+                        type="button"
+                        onClick={() => toggleDesiredWorkDay(opt)}
+                        aria-pressed={selected}
+                        className={`px-4 py-2 rounded-full border-2 text-sm font-semibold select-none transition-all ${
+                          selected
+                            ? 'bg-[#2AADCF] text-white border-[#2AADCF]'
+                            : 'bg-white text-gray-700 border-gray-200'
+                        }`}
+                      >
+                        {opt}
+                      </button>
+                    );
+                  })}
+                </div>
+                <p className="text-xs text-gray-500 mt-1">
+                  「特になし」を選ぶと、他の曜日は自動的に外れます
+                </p>
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <FieldLabel>希望開始時刻</FieldLabel>
+                  <select
+                    value={form.desiredStartTime}
+                    onChange={e => setField('desiredStartTime', e.target.value)}
+                    className="w-full px-3 py-3 border-2 border-gray-200 rounded-[10px] focus:border-[#2AADCF] focus:outline-none"
+                  >
+                    <option value="">特になし</option>
+                    {HOUR_TIME_OPTIONS.map(t => (
+                      <option key={t} value={t}>{t}</option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <FieldLabel>希望終了時刻</FieldLabel>
+                  <select
+                    value={form.desiredEndTime}
+                    onChange={e => setField('desiredEndTime', e.target.value)}
+                    className="w-full px-3 py-3 border-2 border-gray-200 rounded-[10px] focus:border-[#2AADCF] focus:outline-none"
+                  >
+                    <option value="">特になし</option>
+                    {HOUR_TIME_OPTIONS.map(t => (
+                      <option key={t} value={t}>{t}</option>
+                    ))}
+                  </select>
+                </div>
               </div>
             </StepContainer>
           )}

--- a/constants/time-options.ts
+++ b/constants/time-options.ts
@@ -1,0 +1,11 @@
+/**
+ * 共通時刻セレクト option（1 時間刻み 00:00 〜 23:00）
+ *
+ * 登録フォーム（/register/worker）とプロフィール編集画面（/mypage/profile）の
+ * 「希望開始/終了時刻」で同じ値セットを参照することで、文字列不一致による
+ * 「選択してください」問題の再発を防ぐ。
+ */
+export const HOUR_TIME_OPTIONS: string[] = Array.from({ length: 24 }, (_, i) => {
+  const hour = i.toString().padStart(2, '0');
+  return `${hour}:00`;
+});

--- a/src/lib/actions/user-profile.ts
+++ b/src/lib/actions/user-profile.ts
@@ -10,6 +10,7 @@ import { generateBankAccountName } from '@/lib/string-utils';
 import { validatePhoneVerificationToken } from '@/src/lib/auth/phone-verification';
 import { syncWorkerToTasLink, mapUserToTasLinkPayload } from '@/src/lib/taslink';
 import { normalizePhoneDigits, phoneLockKey as computePhoneLockKey } from '@/src/lib/auth/identifier';
+import { normalizeDesiredWorkDays } from '@/src/lib/normalize-desired-work-days';
 
 /**
  * SMS認証成功時に電話番号を即座にDBに保存する
@@ -368,6 +369,8 @@ export async function updateUserProfile(formData: FormData) {
         // 働き方・希望
         const currentWorkStyle = formData.get('currentWorkStyle') as string | null;
         const desiredWorkStyle = formData.get('desiredWorkStyle') as string | null;
+        // ユーザーが明示的に希望の働き方を変更したか（'true' 文字列を期待）
+        const desiredWorkStyleChanged = (formData.get('desiredWorkStyleChanged') as string | null) === 'true';
         const jobChangeDesire = formData.get('jobChangeDesire') as string | null;
         const desiredWorkDaysPerWeek = formData.get('desiredWorkDaysPerWeek') as string | null;
         const desiredWorkPeriod = formData.get('desiredWorkPeriod') as string | null;
@@ -408,8 +411,19 @@ export async function updateUserProfile(formData: FormData) {
             }
         }
 
-        // 希望曜日は配列に変換
-        const desiredWorkDays = desiredWorkDaysStr ? desiredWorkDaysStr.split(',').filter(d => d.trim()) : [];
+        // 希望曜日は配列に変換 + 「特になし」排他制御で正規化
+        const desiredWorkDaysRaw = desiredWorkDaysStr ? desiredWorkDaysStr.split(',').filter(d => d.trim()) : [];
+        const desiredWorkDays = normalizeDesiredWorkDays(desiredWorkDaysRaw);
+
+        // desired_work_style の CSV 保持ロジック:
+        // 編集画面は単一選択（初期値は DB CSV の先頭値）。
+        //   - ユーザーが明示的に変更していない（desiredWorkStyleChanged=false）場合は CSV 全体を保持
+        //   - ユーザーが明示的に触った場合は、送信された値（単一）で上書き（複数値→単一に潰す意思を尊重）
+        // これにより「別項目だけ更新」では CSV を保持しつつ、「希望の働き方を変えたい」は正しく反映される。
+        const existingDesiredCsv = user.desired_work_style || '';
+        const desiredWorkStyleToSave = desiredWorkStyleChanged
+          ? (desiredWorkStyle || null)
+          : (existingDesiredCsv || desiredWorkStyle || null);
 
         // 職歴は配列に変換（|||で区切り）
         const workHistories = workHistoriesStr ? workHistoriesStr.split('|||').filter(h => h.trim()) : [];
@@ -610,7 +624,7 @@ export async function updateUserProfile(formData: FormData) {
                 emergency_phone: emergencyPhone || null,
                 emergency_address: emergencyAddress || null,
                 current_work_style: currentWorkStyle || null,
-                desired_work_style: desiredWorkStyle || null,
+                desired_work_style: desiredWorkStyleToSave,
                 job_change_desire: jobChangeDesire || null,
                 desired_work_days_week: desiredWorkDaysPerWeek,
                 desired_work_period: desiredWorkPeriod || null,

--- a/src/lib/normalize-desired-work-days.ts
+++ b/src/lib/normalize-desired-work-days.ts
@@ -1,0 +1,30 @@
+/**
+ * 希望勤務曜日の正規化
+ *
+ * DB カラム `User.desired_work_days` は String[]。
+ * 「特になし」と曜日（月〜日）が混在した場合は「特になし」を優先して ['特になし'] を返す。
+ *
+ * - UI 側（登録フォーム / プロフィール編集）の排他制御と同じルール
+ * - 登録 API と updateUserProfile の両方で呼ぶことで、API 層での整合性を担保
+ */
+
+const NONE_LABEL = '特になし';
+const WEEK_DAY_LABELS = ['月', '火', '水', '木', '金', '土', '日'] as const;
+const VALID_LABELS = new Set<string>([...WEEK_DAY_LABELS, NONE_LABEL]);
+
+export function normalizeDesiredWorkDays(
+  raw: readonly string[] | null | undefined
+): string[] {
+  if (!raw || raw.length === 0) return [];
+
+  // 入力を有効ラベルだけに絞る（未知の文字列を捨てる）
+  const filtered = raw.filter((v) => VALID_LABELS.has(v));
+  if (filtered.length === 0) return [];
+
+  // 「特になし」が含まれていれば、他をすべて捨てる（排他制御）
+  if (filtered.includes(NONE_LABEL)) return [NONE_LABEL];
+
+  // 曜日の順序を月〜日に揃え、重複も排除
+  const seen = new Set(filtered);
+  return WEEK_DAY_LABELS.filter((d) => seen.has(d));
+}

--- a/src/lib/taslink.ts
+++ b/src/lib/taslink.ts
@@ -122,18 +122,36 @@ function mapGender(gender: string | null | undefined): TasLinkWorkerPayload['gen
   return mapping[gender] || 'UNSPECIFIED';
 }
 
-/** 就業形態希望をTasLink形式に変換 */
+/** 就業形態希望をTasLink形式に変換（旧値・新値・CSV すべて対応） */
 function mapWorkPreference(style: string | null | undefined): TasLinkWorkerPayload['workPreference'] | undefined {
   if (!style) return undefined;
+  // CSV 形式（複数選択）の場合は先頭値を採用
+  const first = style.split(',')[0]?.trim() ?? '';
+  if (!first) return undefined;
+
   const mapping: Record<string, TasLinkWorkerPayload['workPreference']> = {
+    // 旧値
     '単発': 'ONE_TIME',
     '単発希望': 'ONE_TIME',
     '継続': 'ONGOING',
     '継続希望': 'ONGOING',
+    '非常勤': 'ONGOING',
     'どちらも': 'BOTH',
     'どちらも可': 'BOTH',
+    // プロフィール編集の既存 option
+    '正社員': 'ONGOING',
+    'パート・アルバイト': 'ONGOING',
+    '派遣': 'ONGOING',
+    '契約社員': 'ONGOING',
+    'その他': undefined as unknown as TasLinkWorkerPayload['workPreference'],
+    // 新登録フォームの値
+    '単発・スポット': 'ONE_TIME',
+    '常勤・正社員': 'ONGOING',
+    '非常勤・パート（扶養内）': 'ONGOING',
+    '非常勤・パート（扶養外）': 'ONGOING',
+    'こだわらない': 'BOTH',
   };
-  return mapping[style] || undefined;
+  return mapping[first] || undefined;
 }
 
 /** タスタス資格配列 → TasLink jobTypes 配列に変換（重複排除） */

--- a/tests/e2e/fixtures/test-accounts.ts
+++ b/tests/e2e/fixtures/test-accounts.ts
@@ -8,6 +8,12 @@ export type TestAccount = {
 
 export type TestAccounts = {
   worker: TestAccount;
+  /**
+   * CSV 保持テスト用: desired_work_style に CSV 値（複数選択）を持つワーカー。
+   * global-setup で `desired_work_style='単発・スポット,派遣'` を seed する。
+   * プロフィール編集で別項目だけ更新したとき CSV が潰れないことを検証する E2E で使用。
+   */
+  workerWithCsv: TestAccount;
   facilityAdmin: TestAccount;
   systemAdmin: TestAccount;
 };
@@ -16,6 +22,10 @@ export const DEFAULT_TEST_ACCOUNTS: TestAccounts = {
   worker: {
     email: process.env.TEST_WORKER_EMAIL || 'tanaka@example.com',
     password: process.env.TEST_WORKER_PASSWORD || 'password123',
+  },
+  workerWithCsv: {
+    email: process.env.TEST_WORKER_WITH_CSV_EMAIL || 'tanaka.csv@example.com',
+    password: process.env.TEST_WORKER_WITH_CSV_PASSWORD || 'password123',
   },
   facilityAdmin: {
     email: process.env.TEST_FACILITY_ADMIN_EMAIL || 'admin1@facility.com',
@@ -47,6 +57,10 @@ export function loadTestAccounts(): TestAccounts {
         parsed.worker?.email && parsed.worker?.password
           ? parsed.worker
           : DEFAULT_TEST_ACCOUNTS.worker,
+      workerWithCsv:
+        parsed.workerWithCsv?.email && parsed.workerWithCsv?.password
+          ? parsed.workerWithCsv
+          : DEFAULT_TEST_ACCOUNTS.workerWithCsv,
       facilityAdmin:
         parsed.facilityAdmin?.email && parsed.facilityAdmin?.password
           ? parsed.facilityAdmin
@@ -66,6 +80,10 @@ export function saveTestAccounts(next: Partial<TestAccounts>): TestAccounts {
   const merged: TestAccounts = {
     worker:
       next.worker?.email && next.worker?.password ? next.worker : current.worker,
+    workerWithCsv:
+      next.workerWithCsv?.email && next.workerWithCsv?.password
+        ? next.workerWithCsv
+        : current.workerWithCsv,
     facilityAdmin:
       next.facilityAdmin?.email && next.facilityAdmin?.password
         ? next.facilityAdmin

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -49,6 +49,49 @@ async function ensureWorker(
   return account;
 }
 
+/**
+ * CSV 保持テスト用の worker を作成/更新。
+ * `desired_work_style` に CSV 値（複数選択相当）を設定する。
+ */
+async function ensureWorkerWithCsv(
+  prisma: PrismaClient,
+  account: ExistingAccount
+): Promise<ExistingAccount> {
+  const existing = await prisma.user.findUnique({
+    where: { email: account.email },
+    select: { id: true, password_hash: true },
+  });
+
+  const passwordHash = await bcrypt.hash(account.password, 10);
+  const CSV_VALUE = '単発・スポット,派遣';
+
+  if (!existing) {
+    await prisma.user.create({
+      data: {
+        email: account.email,
+        password_hash: passwordHash,
+        name: 'E2E CSV Worker',
+        phone_number: '09099999999',
+        qualifications: ['介護福祉士'],
+        desired_work_style: CSV_VALUE,
+      },
+    });
+    return account;
+  }
+
+  const isValid = await bcrypt.compare(account.password, existing.password_hash);
+  await prisma.user.update({
+    where: { id: existing.id },
+    data: {
+      ...(isValid ? {} : { password_hash: passwordHash }),
+      // 毎回 seed の CSV 値にリセット（テストの前提条件を確定させる）
+      desired_work_style: CSV_VALUE,
+    },
+  });
+
+  return account;
+}
+
 async function ensureFacilityAdmin(
   prisma: PrismaClient,
   account: ExistingAccount
@@ -154,6 +197,10 @@ export default async function globalSetup() {
       email: `e2e-worker-${timestamp}@example.com`,
       password: DEFAULT_TEST_ACCOUNTS.worker.password,
     },
+    workerWithCsv: {
+      email: `e2e-worker-csv-${timestamp}@example.com`,
+      password: DEFAULT_TEST_ACCOUNTS.workerWithCsv.password,
+    },
     facilityAdmin: {
       email: `e2e-admin-${timestamp}@example.com`,
       password: DEFAULT_TEST_ACCOUNTS.facilityAdmin.password,
@@ -165,20 +212,23 @@ export default async function globalSetup() {
   };
 
   const hasWorkerAccount = !!(accounts?.worker?.email && accounts?.worker?.password);
+  const hasWorkerWithCsvAccount = !!(accounts?.workerWithCsv?.email && accounts?.workerWithCsv?.password);
   const hasFacilityAccount = !!(accounts?.facilityAdmin?.email && accounts?.facilityAdmin?.password);
   const hasSystemAdminAccount = !!(accounts?.systemAdmin?.email && accounts?.systemAdmin?.password);
 
   const resolvedAccounts: TestAccounts = {
     worker: hasWorkerAccount ? accounts!.worker! : fallbackAccounts.worker,
+    workerWithCsv: hasWorkerWithCsvAccount ? accounts!.workerWithCsv! : fallbackAccounts.workerWithCsv,
     facilityAdmin: hasFacilityAccount ? accounts!.facilityAdmin! : fallbackAccounts.facilityAdmin,
     systemAdmin: hasSystemAdminAccount ? accounts!.systemAdmin! : fallbackAccounts.systemAdmin,
   };
 
   try {
     const worker = await ensureWorker(prisma, resolvedAccounts.worker);
+    const workerWithCsv = await ensureWorkerWithCsv(prisma, resolvedAccounts.workerWithCsv);
     const facilityAdmin = await ensureFacilityAdmin(prisma, resolvedAccounts.facilityAdmin);
     const systemAdmin = await ensureSystemAdmin(prisma, resolvedAccounts.systemAdmin);
-    const finalAccounts: TestAccounts = { worker, facilityAdmin, systemAdmin };
+    const finalAccounts: TestAccounts = { worker, workerWithCsv, facilityAdmin, systemAdmin };
 
     fs.mkdirSync(path.dirname(ACCOUNTS_PATH), { recursive: true });
     fs.writeFileSync(ACCOUNTS_PATH, JSON.stringify(finalAccounts, null, 2));


### PR DESCRIPTION
## 背景
新登録フォーム (`/register/worker`) の選択肢と既存プロフィール編集画面 (`/mypage/profile`) のドロップダウン option が文字列不一致で、新規登録直後に編集画面で「選択してください」状態になる問題の解消。**既存ユーザーの DB 値は維持**する方針。

## 主要変更

### 1. プロフィール編集 — ドロップダウン union 拡張
4 項目（現在の働き方 / 希望の働き方 / 転職意欲 / 希望勤務日数）に新登録の値と既存値の両方を列挙。新値を優先表示。
- `単発` など legacy seed データも option に追加
- desired_work_style の CSV 保持ロジック: **dirty flag** 導入
  - ユーザーが明示的に変更した場合のみ単一値で上書き
  - 別項目だけ更新した場合は CSV を保持

### 2. 登録フォーム — step 2c 新設
`希望勤務期間 / 希望勤務曜日 / 希望開始時刻 / 希望終了時刻` の 4 項目を任意入力として step 2b の直後に追加。
- 「特になし」排他制御（UI + API 両方、共通ヘルパー normalizeDesiredWorkDays）
- 時刻 option は ProfileEdit と共通化（HOUR_TIME_OPTIONS）

### 3. TasLink 連携拡張
mapWorkPreference に新登録値・legacy 値を追加。CSV 形式は先頭値を採用。

### 4. 新規共通ファイル
- `src/lib/normalize-desired-work-days.ts`
- `constants/time-options.ts`

### 5. E2E フィクスチャ
workerWithCsv テストアカウント + seed 追加。実 spec は別 PR。

## DB スキーマ
変更なし。既存カラム流用。

## Codex レビュー
Plan フェーズ 5 + 実装フェーズ 3 の REQUEST CHANGES を解消後最終 SHIP。

🤖 Generated with [Claude Code](https://claude.com/claude-code)