### PR TITLE
修正: SMS認証のJWTトークン有効期限を60分に統一

### DIFF
--- a/src/lib/auth/phone-verification.ts
+++ b/src/lib/auth/phone-verification.ts
@@ -9,7 +9,7 @@
 import { SignJWT, jwtVerify } from 'jose';
 import { normalizePhoneDigits } from '@/src/lib/auth/identifier';
 
-const TOKEN_EXPIRY = '7d'; // 7日間有効
+const TOKEN_EXPIRY = '60m'; // 60分有効（CPaaS NOW認証コードと同じ有効期限）
 
 function getSecret(): Uint8Array {
   const secret = process.env.NEXTAUTH_SECRET;

--- a/src/lib/cpaasnow.ts
+++ b/src/lib/cpaasnow.ts
@@ -13,7 +13,7 @@ const SMS_TEMPLATE = '【タスタス】認証コード: {{verification_code}}\r
 
 // CPaaS NOW の API 制約により 5-60 分のみ有効。
 // SMS コード自体の有効期限（コード検証はこの時間内に実施する必要がある）。
-// 検証成功後に発行する JWT（src/lib/auth/phone-verification.ts）は 7 日間有効。
+// 検証成功後に発行する JWT（src/lib/auth/phone-verification.ts）も同じ 60 分有効。
 const SMS_EXPIRATION_MINUTES = 60;
 
 export interface SendCodeResult {


### PR DESCRIPTION
## Summary
- 認証成功後のJWTトークン有効期限を7日間→60分に変更
- CPaaS NOWの認証コード有効期限（最大60分）と統一
- cpaasnow.tsのコメントを実態に合わせて修正

## 変更ファイル
- `src/lib/auth/phone-verification.ts` — `TOKEN_EXPIRY: '7d'` → `'60m'`
- `src/lib/cpaasnow.ts` — コメント修正のみ（コードは既にdevelopで60分設定済み）

## 補足
- DB変更なし（デプロイのみで反映）
- 環境変数変更なし

## Test plan
- [ ] SMS認証コード送信が成功することを確認
- [ ] 認証成功後、60分以内に登録完了できることを確認
- [ ] SMSメッセージに「有効期限: 60分」と表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)