### PR TITLE
バグ修正: ワーカー登録 STEP 2b 勤務頻度の状態同期

### DIFF
--- a/app/register/worker/page.tsx
+++ b/app/register/worker/page.tsx
@@ -246,6 +246,23 @@ function WorkerRegisterPageInner() {
     });
   };
 
+  // desiredWorkStyle 変更時に workFrequency を同期クリア（ゴーストデータ防止）
+  useEffect(() => {
+    if (!shouldShowStep2b(form.desiredWorkStyle)) {
+      if (form.workFrequency) setField('workFrequency', '');
+      // STEP 2b 表示中に条件から外れた場合、stepIndex=-1 回避のため 2c に退避
+      if (currentStep === '2b') setCurrentStep('2c');
+      return;
+    }
+    if (
+      !form.desiredWorkStyle.includes('単発・スポット') &&
+      form.workFrequency === '不定期/決まっていない'
+    ) {
+      setField('workFrequency', '');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [form.desiredWorkStyle]);
+
   // 各ステップのバリデーション
   const isStepValid = (): boolean => {
     switch (currentStep) {


### PR DESCRIPTION
## Summary
- STEP 2（希望の働き方）の選択を変更しても `form.workFrequency` が残り、UI に表示されない値が登録 API に送信されるゴーストデータ問題を修正
- STEP 2b 表示中に条件から外れると `stepIndex === -1` になる孤立状態を予防

## 修正内容
`app/register/worker/page.tsx` に `form.desiredWorkStyle` を監視する `useEffect` を追加:

| シナリオ | 修正前 | 修正後 |
|---------|--------|--------|
| STEP 2 を「常勤・正社員のみ」に変更 | `workFrequency === '週1回'` が API 送信される | クリアされる |
| 「単発・スポット」を外す | `workFrequency === '不定期/決まっていない'` が残る | クリアされる |
| STEP 2b 画面で条件から外れた（エッジ） | `stepIndex === -1` で UI 崩壊 | `'2c'` に自動退避 |

## 設計判断
- Codex（Code Reviewer）で advisory レビュー済み → **APPROVE**
- プログレスドット仕様は現状維持（`stepSequence` に追従）
- サーバーサイドの整合性チェック追加は別 PR で対応予定

## Test plan
- [ ] STEP 2 で「単発・スポット」選択 → STEP 2b で「週1回」選択 → 戻って「常勤・正社員」のみに変更 → STEP 2c で `workFrequency` が空であることを DevTools で確認
- [ ] 「単発・スポット」+「派遣」選択 → STEP 2b で「不定期/決まっていない」→ 戻って「単発・スポット」だけ外す → STEP 2b で何も選択されておらず「次へ」disabled
- [ ] 「単発・スポット」のみ選択 → STEP 2b で「週1回」選択 → 最後まで進んで登録 → DB に `desired_work_days_week = '週1回'` で保存されること
- [ ] ドット数が STEP 2 選択によって増減することを回帰確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)