### PR TITLE
UI改善: ログイン画面にID種別のヒント追加

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -131,9 +131,12 @@ function WorkerLoginInner() {
                   value={identifier}
                   onChange={(e) => setIdentifier(e.target.value)}
                   className="w-full pl-10 pr-4 py-3 border-0 rounded-lg focus:outline-none focus:ring-2 focus:ring-white/50 bg-white"
-                  placeholder="メールアドレス または 電話番号"
+                  placeholder="例: you@example.com / 090-1234-5678"
                 />
               </div>
+              <p className="text-xs text-white/80 mt-1.5">
+                SMS認証が完了している場合、電話番号でもログインできます
+              </p>
             </div>
 
             {/* パスワード */}


### PR DESCRIPTION
## Summary
- ログイン ID 欄にメール/電話番号の具体例を placeholder として表示
- 「SMS認証が完了している場合、電話番号でもログインできます」の補足文を追加

## 背景
現状ラベル・placeholder ともに「メールアドレス または 電話番号」とあるが、電話番号ログインは `phone_verified = true` のアカウントに限定されている（`lib/auth.ts` L114）。未認証ユーザーがエラー理由を把握しづらい UX を改善する。

## Test plan
- [ ] ログイン画面で placeholder が「例: you@example.com / 090-1234-5678」と表示される
- [ ] 入力欄下に補足文が表示される
- [ ] 既存のログイン動作（メール/電話どちらも）に回帰なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)