### PR TITLE
機能変更: ワーカー登録から STEP 2c（詳細な希望勤務条件）を一時的に非表示

### DIFF
--- a/app/register/worker/page.tsx
+++ b/app/register/worker/page.tsx
@@ -200,11 +200,11 @@ function WorkerRegisterPageInner() {
 
   // ステップ順序（条件付きで 2b を挿入）
   // sms ステップは step 8 の後に続く「認証コード入力」画面（利用規約同意後に SMS 送信）
-  // 2c は任意入力の追加項目（希望勤務期間・曜日・開始/終了時刻）
+  // 2c は任意入力の追加項目（希望勤務期間・曜日・開始/終了時刻）→ 一時的に非表示（復活時は '3' の前に '2c' を戻す）
   const stepSequence = useMemo<StepId[]>(() => {
     const base: StepId[] = ['1', '2'];
     if (shouldShowStep2b(form.desiredWorkStyle)) base.push('2b');
-    base.push('2c', '3', '4', '5', '6', '7', '8', 'sms');
+    base.push('3', '4', '5', '6', '7', '8', 'sms');
     return base;
   }, [form.desiredWorkStyle]);
 
@@ -250,8 +250,9 @@ function WorkerRegisterPageInner() {
   useEffect(() => {
     if (!shouldShowStep2b(form.desiredWorkStyle)) {
       if (form.workFrequency) setField('workFrequency', '');
-      // STEP 2b 表示中に条件から外れた場合、stepIndex=-1 回避のため 2c に退避
-      if (currentStep === '2b') setCurrentStep('2c');
+      // STEP 2b 表示中に条件から外れた場合、stepIndex=-1 回避のため次ステップへ退避
+      // （2c 非表示中は '3' に退避。2c 復活時は '2c' に戻す）
+      if (currentStep === '2b') setCurrentStep('3');
       return;
     }
     if (


### PR DESCRIPTION
## Summary
- ワーカー新規登録フローから STEP 2c（詳細な希望勤務条件：希望勤務期間・曜日・開始/終了時刻）を一時的に非表示
- STEP 2 または STEP 2b の直後が STEP 3（転職時期）に繋がる動線に変更

## 方針
- **一時的な非表示**: UI コード・form state・API 受け口・定数はすべて残存
- 復活時は `stepSequence.push('2c', '3', ...)` に戻すだけ（1 行）

## 変更内容
| 変更 | 修正前 | 修正後 |
|------|--------|--------|
| stepSequence から `'2c'` 除外 | `push('2c', '3', '4', ...)` | `push('3', '4', ...)` |
| STEP 2b 条件外の退避先 | `setCurrentStep('2c')` | `setCurrentStep('3')` |

## 影響範囲
- 登録済みユーザーの DB データに影響なし（関連カラムは存続）
- プロフィール編集画面からは引き続き該当項目を入力可能
- 登録時点では空のまま API に送信される（既存 API は空文字を許容済み）

## Test plan
- [ ] STEP 2 で「常勤・正社員のみ」選択 → 次へで STEP 3（転職時期）に直接進む
- [ ] STEP 2 で「単発・スポット」選択 → STEP 2b → 次へで STEP 3 に進む
- [ ] 登録完了まで進めてもエラーにならない
- [ ] DB に登録されたワーカーで `desired_work_period` 等が空文字なこと
- [ ] プログレスドットの総数が STEP 2c 分（1 個）減ることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)