### PR TITLE
機能変更: 管理画面ワーカー一覧の本登録判定を SMS 認証基準に変更

### DIFF
--- a/app/system-admin/workers/page.tsx
+++ b/app/system-admin/workers/page.tsx
@@ -20,7 +20,7 @@ interface Worker {
     gender: string | null;
     birth_date: Date | null;
     isSuspended: boolean;
-    emailVerified: boolean;
+    phoneVerified: boolean;
     age: number | null;
     avgRating: number | null;
     reviewCount: number;
@@ -45,7 +45,7 @@ export default function SystemAdminWorkersPage() {
     const [prefectureFilter, setPrefectureFilter] = useState('');
     const [cityFilter, setCityFilter] = useState('');
     const [qualificationFilter, setQualificationFilter] = useState('');
-    const [emailVerifiedFilter, setEmailVerifiedFilter] = useState<'all' | 'verified' | 'unverified'>('all');
+    const [phoneVerifiedFilter, setPhoneVerifiedFilter] = useState<'all' | 'verified' | 'unverified'>('all');
 
     // 距離検索
     const [distanceSearchEnabled, setDistanceSearchEnabled] = useState(false);
@@ -81,7 +81,7 @@ export default function SystemAdminWorkersPage() {
                 prefecture: prefectureFilter || undefined,
                 city: cityFilter || undefined,
                 qualification: qualificationFilter || undefined,
-                emailVerified: emailVerifiedFilter,
+                phoneVerified: phoneVerifiedFilter,
             };
 
             // 距離検索が有効で座標がある場合
@@ -146,7 +146,7 @@ export default function SystemAdminWorkersPage() {
 
     const handleResetFilters = () => {
         setStatusFilter('all');
-        setEmailVerifiedFilter('all');
+        setPhoneVerifiedFilter('all');
         setPrefectureFilter('');
         setCityFilter('');
         setQualificationFilter('');
@@ -178,7 +178,7 @@ export default function SystemAdminWorkersPage() {
 
     const activeFilterCount = [
         statusFilter !== 'all',
-        emailVerifiedFilter !== 'all',
+        phoneVerifiedFilter !== 'all',
         prefectureFilter !== '',
         cityFilter !== '',
         qualificationFilter !== '',
@@ -273,10 +273,10 @@ export default function SystemAdminWorkersPage() {
 
                             {/* 本登録 */}
                             <div>
-                                <label className="block text-xs font-medium text-slate-600 mb-1">本登録（メール認証）</label>
+                                <label className="block text-xs font-medium text-slate-600 mb-1">本登録（SMS認証）</label>
                                 <select
-                                    value={emailVerifiedFilter}
-                                    onChange={(e) => setEmailVerifiedFilter(e.target.value as any)}
+                                    value={phoneVerifiedFilter}
+                                    onChange={(e) => setPhoneVerifiedFilter(e.target.value as any)}
                                     className="w-full px-3 py-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
                                 >
                                     <option value="all">すべて</option>
@@ -428,10 +428,10 @@ export default function SystemAdminWorkersPage() {
                             </button>
                         </span>
                     )}
-                    {emailVerifiedFilter !== 'all' && (
+                    {phoneVerifiedFilter !== 'all' && (
                         <span className="inline-flex items-center gap-1 px-2 py-1 bg-indigo-100 text-indigo-700 text-xs rounded-full">
-                            {emailVerifiedFilter === 'verified' ? '本登録済み' : '未登録'}
-                            <button onClick={() => { setEmailVerifiedFilter('all'); fetchWorkers(); }}>
+                            {phoneVerifiedFilter === 'verified' ? '本登録済み' : '未登録'}
+                            <button onClick={() => { setPhoneVerifiedFilter('all'); fetchWorkers(); }}>
                                 <X className="w-3 h-3" />
                             </button>
                         </span>
@@ -520,11 +520,11 @@ export default function SystemAdminWorkersPage() {
                                 <tr key={worker.id} className="hover:bg-slate-50 transition-colors">
                                     <td className="px-6 py-4">
                                         <div className="flex items-center gap-3">
-                                            <div className={`w-10 h-10 rounded-full flex items-center justify-center overflow-hidden ${worker.emailVerified ? 'bg-emerald-100' : 'bg-slate-200'}`}>
+                                            <div className={`w-10 h-10 rounded-full flex items-center justify-center overflow-hidden ${worker.phoneVerified ? 'bg-emerald-100' : 'bg-slate-200'}`}>
                                                 {worker.profile_image ? (
                                                     <img src={worker.profile_image} alt={worker.name} className="w-full h-full object-cover" />
                                                 ) : (
-                                                    <span className={`font-bold ${worker.emailVerified ? 'text-emerald-600' : 'text-slate-500'}`}>{(worker.name || '?').charAt(0)}</span>
+                                                    <span className={`font-bold ${worker.phoneVerified ? 'text-emerald-600' : 'text-slate-500'}`}>{(worker.name || '?').charAt(0)}</span>
                                                 )}
                                             </div>
                                             <div>

--- a/src/lib/system-actions.ts
+++ b/src/lib/system-actions.ts
@@ -197,7 +197,7 @@ export async function getSystemWorkers(
         prefecture?: string;
         city?: string;
         qualification?: string;
-        emailVerified?: 'all' | 'verified' | 'unverified';
+        phoneVerified?: 'all' | 'verified' | 'unverified';
         // 距離検索用
         distanceFrom?: {
             lat: number;
@@ -259,11 +259,11 @@ export async function getSystemWorkers(
             };
         }
 
-        // 本登録（メール認証）フィルター
-        if (filters.emailVerified === 'verified') {
-            where.email_verified = true;
-        } else if (filters.emailVerified === 'unverified') {
-            where.email_verified = false;
+        // 本登録（SMS認証）フィルター
+        if (filters.phoneVerified === 'verified') {
+            where.phone_verified = true;
+        } else if (filters.phoneVerified === 'unverified') {
+            where.phone_verified = false;
         }
     }
 
@@ -294,7 +294,7 @@ export async function getSystemWorkers(
                 gender: true,
                 birth_date: true,
                 is_suspended: true,
-                email_verified: true,
+                phone_verified: true,
                 lat: true,
                 lng: true,
                 notifications: false, // 負荷軽減のため除外
@@ -359,7 +359,7 @@ export async function getSystemWorkers(
                 totalWorkCount,
                 distance,
                 isSuspended: w.is_suspended || false,
-                emailVerified: w.email_verified || false,
+                phoneVerified: w.phone_verified || false,
                 age: null, // 後で計算
             };
         });
@@ -426,7 +426,7 @@ export async function getSystemWorkers(
                     gender: true,
                     birth_date: true,
                     is_suspended: true,
-                    email_verified: true,
+                    phone_verified: true,
                     lat: true,
                     lng: true,
                 },
@@ -487,7 +487,7 @@ export async function getSystemWorkers(
                 return {
                     ...w,
                     isSuspended: w.is_suspended || false,
-                    emailVerified: w.email_verified || false,
+                    phoneVerified: w.phone_verified || false,
                     age: calculateAge(w.birth_date),
                     avgRating: stat ? stat.sum / stat.count : null,
                     reviewCount: stat?.count || 0,


### PR DESCRIPTION
## Summary
- 管理画面ワーカー一覧のアバター緑色表示を「メール認証完了」から「SMS 認証完了」へ変更
- フィルタ「本登録（メール認証）」→「本登録（SMS認証）」にリネーム
- メール認証の可視化は管理画面から除外（ユーザー要望）

## 背景
ユーザーの多くは SMS 認証で登録フローを完走するが、メール認証リンクを踏まない。現状の「本登録」判定（メール認証ベース）だと「登録完了」と言えないユーザーが大量に発生し、管理上の実態とかけ離れていた。SMS 認証完了 = 登録フロー完走のため、こちらを本登録扱いに変更する。

## 変更内容

### `src/lib/system-actions.ts`
- フィルター型 `emailVerified` → `phoneVerified`
- Prisma `where.email_verified` → `where.phone_verified`
- `select: email_verified` → `select: phone_verified`（2 箇所）
- レスポンス `emailVerified: w.email_verified` → `phoneVerified: w.phone_verified`（2 箇所）

### `app/system-admin/workers/page.tsx`
- 型定義 `emailVerified` → `phoneVerified`
- state / setter `emailVerifiedFilter` → `phoneVerifiedFilter`
- UI ラベル「本登録（メール認証）」→「本登録（SMS認証）」
- アバター色判定 `worker.emailVerified` → `worker.phoneVerified`
- API リクエスト body のキー `emailVerified` → `phoneVerified`

## 影響範囲外（意図的に据え置き）
- `src/lib/actions/csv-export.ts` の `email_verified` フィルタ
- `app/api/funnel-analytics/route.ts` の `email_verified_at` 集計
- メール認証フロー自体（`src/lib/auth/email-verification.ts`）
- ログイン時の `phone_verified = true` 条件（独立したロジック）

## Test plan
- [ ] 管理画面 → 「本登録（SMS認証）」フィルタが表示される
- [ ] 「本登録済み」選択で `phone_verified = true` のユーザーのみ表示
- [ ] 「未登録」選択で `phone_verified = false` のユーザーのみ表示
- [ ] 緑色アバターが SMS 認証済みユーザーに表示される
- [ ] 登録フロー完走したユーザーは即座に緑色になる
- [ ] Prisma クエリにエラーなし（TypeScript ビルド成功済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)