### PR TITLE
バグ修正: おすすめ求人が公開停止・募集終了で非表示になる不具合を修正

### DIFF
--- a/app/api/public/recommended-jobs/route.ts
+++ b/app/api/public/recommended-jobs/route.ts
@@ -20,13 +20,10 @@ export async function GET(request: NextRequest) {
     const selectedJST = new Date(selectedDate.getTime() + JST_OFFSET);
     const selectedDateStr = selectedJST.toISOString().split('T')[0]; // YYYY-MM-DD
 
-    // おすすめ求人取得（公開中の求人のみ）
+    // おすすめ求人は求人の状態に関わらず登録されたものを表示する
+    // - 応募可能な募集枠（今日以降かつ is_recruitment_closed=false）がある日 → その日のタブに表示
+    // - 応募可能な募集枠がない求人 → 全日付で常時表示（LINE登録URLへ誘導）
     const recommendedJobs = await prisma.recommendedJob.findMany({
-      where: {
-        job: {
-          status: 'PUBLISHED',
-        },
-      },
       orderBy: { sort_order: 'asc' },
       include: {
         job: {
@@ -48,25 +45,35 @@ export async function GET(request: NextRequest) {
     const jobs = recommendedJobs.map((rec) => {
       const job = rec.job;
 
-      // 選択日のworkDateを見つける
-      const matchingWorkDate = job.workDates.find(wd => {
+      // 求人ステータスが公開中かどうか（ワーカーページに出ているか）
+      const isPublished = job.status === 'PUBLISHED';
+
+      // 「応募可能な募集枠」= 今日以降 かつ is_recruitment_closed=false の work_date
+      // ただし求人が公開中(PUBLISHED)でなければワーカーページには出ていないので
+      // 応募可能枠なしと同じ扱い（全日付で常時表示）にする
+      const activeWorkDates = isPublished
+        ? job.workDates.filter(wd => {
+            const wdJST = new Date(wd.work_date.getTime() + JST_OFFSET);
+            const wdStr = wdJST.toISOString().split('T')[0];
+            return wdStr >= todayStr && !wd.is_recruitment_closed;
+          })
+        : [];
+
+      // 選択日にマッチする応募可能な枠
+      const matchingWorkDate = activeWorkDates.find(wd => {
         const wdJST = new Date(wd.work_date.getTime() + JST_OFFSET);
         return wdJST.toISOString().split('T')[0] === selectedDateStr;
       });
 
-      // 今日以降の勤務日が1つもない求人 = 「勤務日なし」求人
-      const hasFutureWorkDates = job.workDates.some(wd => {
-        const wdJST = new Date(wd.work_date.getTime() + JST_OFFSET);
-        return wdJST.toISOString().split('T')[0] >= todayStr;
-      });
-      const noFutureWorkDates = !hasFutureWorkDates;
+      // 応募可能枠が1つもない → 常時表示対象（ケース②③）
+      const noFutureWorkDates = activeWorkDates.length === 0;
 
       // フィルタロジック:
-      // - 勤務日なし求人 → 全日付で常に表示（グレーアウトしない）
-      // - 選択日に勤務日がない求人 → 非表示（returnでnull）
-      // - 選択日に勤務日がある求人 → 表示（満員でもグレーアウトしない）
+      // - 応募可能枠なし → 全日付で常に表示（LINE登録URL誘導）
+      // - 応募可能枠ありで選択日にマッチしない → 非表示
+      // - 応募可能枠ありで選択日にマッチ → 表示
       if (!noFutureWorkDates && !matchingWorkDate) {
-        return null; // 選択日にマッチしない → 非表示
+        return null;
       }
 
       const hasMatchingDate = noFutureWorkDates || !!matchingWorkDate;

--- a/app/api/system-admin/recommended-jobs/route.ts
+++ b/app/api/system-admin/recommended-jobs/route.ts
@@ -72,11 +72,15 @@ export async function GET(request: NextRequest) {
 
   return NextResponse.json({
     jobs: recommendedJobs.map(r => {
-      // 今日以降の勤務日数を計算
-      const futureWorkDates = r.job.workDates.filter(wd => {
-        const wdJST = new Date(wd.work_date.getTime() + JST_OFFSET);
-        return wdJST.toISOString().split('T')[0] >= todayStr;
-      });
+      // 「応募可能な募集枠」= 求人が公開中 かつ 今日以降 かつ is_recruitment_closed=false
+      // これがLP側で「日付タブに表示される」条件と一致する
+      const isPublished = r.job.status === 'PUBLISHED';
+      const futureWorkDates = isPublished
+        ? r.job.workDates.filter(wd => {
+            const wdJST = new Date(wd.work_date.getTime() + JST_OFFSET);
+            return wdJST.toISOString().split('T')[0] >= todayStr && !wd.is_recruitment_closed;
+          })
+        : [];
 
       // 最も近い勤務日までの残り日数
       let remainingDays: number | null = null;

--- a/app/system-admin/lp/recommended-jobs/page.tsx
+++ b/app/system-admin/lp/recommended-jobs/page.tsx
@@ -359,8 +359,10 @@ export default function RecommendedJobsPage() {
               <h3 className="font-medium text-slate-800 mb-1">基本動作</h3>
               <ul className="list-disc list-inside space-y-1 ml-1">
                 <li>登録した求人はLP内の <code className="bg-slate-100 px-1 rounded text-xs">&lt;div data-tastas-jobs&gt;&lt;/div&gt;</code> の位置にiframeで表示されます</li>
-                <li>日付選択UI付き（デフォルトは3日後）で、選択日に勤務可能な求人のみ表示されます</li>
-                <li>公開中（PUBLISHED）の求人のみ表示されます。下書きや非公開の求人は表示されません</li>
+                <li>日付選択UI付き（デフォルトは3日後）で、応募可能な募集枠がある日付に求人が表示されます</li>
+                <li>登録したおすすめ求人は求人の状態に関わらず表示されます（公開停止・下書きを含む）</li>
+                <li>公開中かつ選択日に応募可能枠がある求人 → その日の日付タブに表示（求人詳細ページへ遷移）</li>
+                <li>それ以外（公開停止・全日程で応募枠なし等） → 全日付で常時表示（LINE登録URL等のCTAへ遷移）</li>
               </ul>
             </div>
 
@@ -381,7 +383,7 @@ export default function RecommendedJobsPage() {
             </div>
 
             <div>
-              <h3 className="font-medium text-slate-800 mb-1">今日以降の勤務日がない求人</h3>
+              <h3 className="font-medium text-slate-800 mb-1">応募可能枠がない求人（公開停止・掲載終了・全日募集終了など）</h3>
               <ul className="list-disc list-inside space-y-1 ml-1">
                 <li>全日程で常に表示されます（日付選択でフィルタされません）</li>
                 <li>クリックすると、そのLPに設定されたCTA URL（LINE登録URL等）に直接遷移します</li>
@@ -393,8 +395,8 @@ export default function RecommendedJobsPage() {
             <div>
               <h3 className="font-medium text-slate-800 mb-1">残り日数の警告</h3>
               <ul className="list-disc list-inside space-y-1 ml-1">
-                <li><span className="text-red-600 font-medium">赤</span>: 今日以降の勤務日がない（掲載終了の可能性）</li>
-                <li><span className="text-amber-600 font-medium">黄</span>: 最短の勤務日まで残り3日未満</li>
+                <li><span className="text-red-600 font-medium">赤</span>: 応募可能な募集枠がない（公開停止 or 全日程で満員/期限切れ）</li>
+                <li><span className="text-amber-600 font-medium">黄</span>: 最短の応募可能日まで残り3日未満</li>
                 <li>警告なし: 余裕あり</li>
               </ul>
             </div>


### PR DESCRIPTION
## 背景

LPの「おすすめ求人」機能について、管理画面の仕様説明と実装が食い違っていた。

画面には「募集枠が満員の求人もそのまま表示されます（非表示にはなりません）」と書かれているにも関わらず、求人が公開停止（`status != PUBLISHED`）になった瞬間にLPから完全に消えていた。

## 修正後の表示ルール

「登録したおすすめ求人は、求人の状態に関わらず LP に表示し続ける」に統一。

| 求人の状態 | LPでの表示 | リンク先 |
|---|---|---|
| 公開中 かつ 応募可能な募集枠ある日 | その日付タブにのみ表示 | 求人詳細ページ |
| 公開中だが応募可能枠なし（全日程満員・全日程過去等） | 全日付で常時表示 | LINE登録URL |
| **公開停止・募集終了（`status != PUBLISHED`）** ← 今回修正 | **全日付で常時表示** | **LINE登録URL** |

「応募可能枠」= `status=PUBLISHED` かつ `work_date >= 今日` かつ `is_recruitment_closed = false`

## 変更ファイル

- `app/api/public/recommended-jobs/route.ts` — `status=PUBLISHED` フィルタを撤廃、応募可能枠の判定ロジックを更新（`is_recruitment_closed` 考慮）
- `app/api/system-admin/recommended-jobs/route.ts` — 管理画面の警告判定を同ルールに統一
- `app/system-admin/lp/recommended-jobs/page.tsx` — 仕様説明文を実態に合わせて更新

## DB変更

なし（デプロイのみで反映されます）

## Test plan

- [ ] ステージング `/system-admin/lp/recommended-jobs` でおすすめ求人リストが表示される
- [ ] 公開中の求人を登録 → LP上で該当日付タブに表示、詳細ページへ遷移できる
- [ ] 求人を「公開停止」に変更 → LP上から消えず、全日付で常時表示され、LINE登録URLへ遷移する（**これまではここで消えていた**）
- [ ] 今日以降の勤務日がない求人 → 全日付で常時表示、LINE登録URLへ遷移する（挙動変わらず）
- [ ] 管理画面の警告表示（赤/黄）が応募可能枠の有無を正しく反映している

🤖 Generated with [Claude Code](https://claude.com/claude-code)