### PR TITLE
機能追加: ワーカー詳細に登録元LP情報を表示（system-admin 限定）

### DIFF
--- a/app/system-admin/workers/[id]/page.tsx
+++ b/app/system-admin/workers/[id]/page.tsx
@@ -7,7 +7,7 @@ import { getSystemWorkerDetail, toggleWorkerSuspension, generateWorkerMasquerade
 import {
     ChevronLeft, Ban, CheckCircle, Mail, Phone, MapPin, Calendar, Briefcase,
     FileText, Star, User, Clock, AlertTriangle, LogIn, Shield, CreditCard,
-    Building, Users, History
+    Building, Users, History, Link2
 } from 'lucide-react';
 import { format } from 'date-fns';
 import toast from 'react-hot-toast';
@@ -353,6 +353,38 @@ export default function SystemAdminWorkerDetailPage({ params }: { params: { id: 
                                 </div>
                             ) : (
                                 <p className="text-sm text-gray-400 italic">緊急連絡先は未登録です</p>
+                            )}
+                        </div>
+
+                        {/* Registration Source (LP) — system-admin only */}
+                        <div className="bg-white rounded-xl border border-gray-200 p-5 shadow-sm">
+                            <h3 className="text-xs font-bold text-gray-400 uppercase tracking-wider mb-3 flex items-center gap-2">
+                                <Link2 className="w-4 h-4" /> 登録元LP
+                            </h3>
+                            {worker.registrationLp ? (
+                                <div className="space-y-2 text-sm text-gray-600">
+                                    <div>
+                                        <span className="text-gray-400">LP:</span>{' '}
+                                        <span className="font-medium text-gray-800">
+                                            {worker.registrationLp.lpName ?? `LP ${worker.registrationLp.lpId}`}
+                                        </span>
+                                        <span className="text-xs text-gray-400 ml-1.5">（番号: {worker.registrationLp.lpId}）</span>
+                                    </div>
+                                    {worker.registrationLp.campaignCode && (
+                                        <div>
+                                            <span className="text-gray-400">キャンペーンコード:</span>{' '}
+                                            <span className="font-mono text-xs">{worker.registrationLp.campaignCode}</span>
+                                        </div>
+                                    )}
+                                    {worker.registrationLp.genrePrefix && (
+                                        <div>
+                                            <span className="text-gray-400">ジャンル:</span>{' '}
+                                            <span className="font-mono text-xs">{worker.registrationLp.genrePrefix}</span>
+                                        </div>
+                                    )}
+                                </div>
+                            ) : (
+                                <p className="text-sm text-gray-400 italic">登録元LP情報はありません（直接登録など）</p>
                             )}
                         </div>
                     </div>

--- a/src/lib/system-actions.ts
+++ b/src/lib/system-actions.ts
@@ -539,6 +539,30 @@ export async function getSystemWorkerDetail(id: number) {
 
     if (!worker) return null;
 
+    // 登録元LP情報（LandingPage マスタから name を取得）
+    // registration_lp_id は String、LandingPage.lp_number は Int のため parseInt で突合
+    let registrationLp: {
+        lpId: string;
+        lpName: string | null;
+        campaignCode: string | null;
+        genrePrefix: string | null;
+    } | null = null;
+    if (worker.registration_lp_id) {
+        const lpNumber = Number.parseInt(worker.registration_lp_id, 10);
+        const lpMaster = Number.isFinite(lpNumber)
+            ? await prisma.landingPage.findUnique({
+                  where: { lp_number: lpNumber },
+                  select: { name: true },
+              })
+            : null;
+        registrationLp = {
+            lpId: worker.registration_lp_id,
+            lpName: lpMaster?.name ?? null,
+            campaignCode: worker.registration_campaign_code,
+            genrePrefix: worker.registration_genre_prefix,
+        };
+    }
+
     // 勤務実績を集計（COMPLETED_PENDING または COMPLETED_RATED を完了とみなす）
     const completedApplications = worker.applications.filter(app =>
         app.status === 'COMPLETED_PENDING' || app.status === 'COMPLETED_RATED'
@@ -661,6 +685,7 @@ export async function getSystemWorkerDetail(id: number) {
             reviewerName: r.facility?.facility_name || '匿名',
         })),
         qualificationCertificates: worker.qualification_certificates,
+        registrationLp,
     };
 }
 


### PR DESCRIPTION
## Summary
- システム管理者のワーカー詳細ページ（`/system-admin/workers/[id]`）に「登録元LP」セクションを追加
- LP番号（`registration_lp_id`）に紐づく LP名（`LandingPage.name`）を JOIN して表示
- キャンペーンコード・ジャンルプレフィックスも併記
- 施設管理者（`/admin/*`）からは**一切見えない**ことを確認済み

## 表示内容
- **LP**: LP名（`LandingPage.name`） + 括弧内に「番号: 0」等の補足
- **キャンペーンコード**: `AAA-X4Y5Z6` 形式（保存されている場合のみ）
- **ジャンル**: `AAA` 等（保存されている場合のみ）
- LP 情報がないユーザー（直接登録等）には「登録元LP情報はありません（直接登録など）」を表示

## セキュリティ（施設管理者には非公開）
- `getSystemWorkerDetail` は `requireSystemAdminAuth()` で保護済み
- 施設管理者の API (`app/api/admin/*`) および UI (`app/admin/*`) には `registration_lp_id` / `registration_campaign_code` / `registration_genre_prefix` を返すコードが**存在しないこと**を grep で確認
- 新規で施設管理者側に LP 情報を追加していないため、漏洩経路なし

## 変更ファイル
- `src/lib/system-actions.ts`: `getSystemWorkerDetail` に LP 情報取得ロジック追加（25 行）
- `app/system-admin/workers/[id]/page.tsx`: 表示カード追加 + `Link2` アイコン import（34 行）

## 実装詳細
- `User.registration_lp_id` は `String?` 型、`LandingPage.lp_number` は `Int` 型のため `Number.parseInt` で変換後 JOIN
- `parseInt` が NaN を返した場合は LP 名なし (`lpName: null`) で表示（安全側）
- DB マイグレーション不要（既存カラムを参照するのみ）

## Test plan
- [ ] LP 経由で登録したワーカーの詳細ページで LP 名が正しく表示される
- [ ] LP 名が設定されていない番号のワーカーは「LP 0」等の ID のみ表示
- [ ] 直接登録のワーカーは「登録元LP情報はありません」が表示
- [ ] 施設管理者（/admin）からは該当ワーカーの詳細ページに LP 情報が表示されない
- [ ] TypeScript ビルドエラーなし（検証済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)