### PR TITLE
機能追加: システム管理画面ワーカー詳細に通帳・キャッシュカード画像を表示

### DIFF
--- a/app/system-admin/workers/[id]/page.tsx
+++ b/app/system-admin/workers/[id]/page.tsx
@@ -621,6 +621,36 @@ export default function SystemAdminWorkerDetailPage({ params }: { params: { id: 
                             ) : (
                                 <p className="text-sm text-gray-400 italic">銀行口座情報は未登録です</p>
                             )}
+                            {worker.bank_book_image && (
+                                <div className="mt-4 pt-4 border-t border-gray-100">
+                                    <p className="text-xs text-gray-500 mb-2">登録された通帳・キャッシュカード画像</p>
+                                    {/\.pdf(\?|$)/i.test(worker.bank_book_image) ? (
+                                        <a
+                                            href={worker.bank_book_image}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="inline-flex items-center gap-2 px-3 py-2 bg-gray-100 hover:bg-gray-200 rounded-lg text-sm text-gray-700 transition-colors"
+                                        >
+                                            <FileText className="w-4 h-4" />
+                                            PDFファイルを開く
+                                        </a>
+                                    ) : (
+                                        <a
+                                            href={worker.bank_book_image}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            className="block bg-gray-100 rounded-lg overflow-hidden hover:opacity-90 transition-opacity"
+                                            title="クリックで拡大表示"
+                                        >
+                                            <img
+                                                src={worker.bank_book_image}
+                                                alt="通帳・キャッシュカード画像"
+                                                className="w-full h-auto max-h-64 object-contain"
+                                            />
+                                        </a>
+                                    )}
+                                </div>
+                            )}
                         </div>
 
                         {/* Qualification Certificates */}

--- a/src/lib/system-actions.ts
+++ b/src/lib/system-actions.ts
@@ -665,6 +665,7 @@ export async function getSystemWorkerDetail(id: number) {
         branch_name: worker.branch_name,
         account_name: worker.account_name,
         account_number: worker.account_number,
+        bank_book_image: worker.bank_book_image,
         pension_number: worker.pension_number,
         created_at: worker.created_at,
         isSuspended: worker.is_suspended || false,


### PR DESCRIPTION
## 背景

振込時に口座番号の不一致で振込できない事象が発生。応募時に必須で登録させている通帳・キャッシュカード画像（`bank_book_image`）が、これまで管理画面のどこからも閲覧できなかった。

## 変更内容

システム管理画面 ＞ ワーカー管理 ＞ ワーカー詳細画面の「銀行口座情報（振込用）」カード内、テキスト情報の下に登録済みの通帳・キャッシュカード画像を表示する。

### 対象画面
- URL: \`/system-admin/workers/[id]\`

### 実装詳細
- \`getSystemWorkerDetail\` のレスポンスに \`bank_book_image\` を追加（\`src/lib/system-actions.ts\`）
- 銀行口座情報カードの既存テキスト表示はそのまま残し、その下に画像を表示
- 拡張子で表示を分岐：
  - 画像（jpg/png/heic 等）: サムネイル表示、クリックで新規タブで拡大表示
  - PDF: 「PDFファイルを開く」ボタン（クリックで新規タブ）
- 画像未登録時は何も表示しない（既存の空状態と整合）

### スコープ外
- \`/admin/workers/[id]\`（施設管理者向け）への画像表示は権限設計の観点から含めず。必要であれば別途対応。

## Test plan

- [ ] \`/system-admin/workers/[id]\` を開いて、通帳画像が登録されているワーカーで画像が表示されること
- [ ] 画像をクリックすると新規タブで拡大表示されること
- [ ] PDFが登録されている場合、「PDFファイルを開く」ボタンが表示され、クリックでPDFが開くこと
- [ ] 通帳画像未登録のワーカーで画像エリアが表示されないこと
- [ ] 既存の銀行口座情報のテキスト表示（銀行名／支店名／口座名義／口座番号）が変わらないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)