### PR TITLE
機能変更: 求人作成時の交通費を勤務時間から自動計算する仕様に変更

### DIFF
--- a/components/admin/JobForm.tsx
+++ b/components/admin/JobForm.tsx
@@ -12,7 +12,7 @@ import AddressSelector from '@/components/ui/AddressSelector';
 import { JobConfirmModal } from '@/components/admin/JobConfirmModal';
 import { JobPreviewModal } from '@/components/admin/JobPreviewModal';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
-import { calculateDailyWage, calculateWorkingHours, getFilteredTransportationFeeOptions, calculateMinTransportationFee } from '@/utils/salary';
+import { calculateDailyWage, calculateWorkingHours, calculateTransportationFee } from '@/utils/salary';
 import { getCurrentTime } from '@/utils/debugTime';
 import { validateImageFiles, validateAttachmentFiles } from '@/utils/fileValidation';
 import { directUploadMultiple } from '@/utils/directUpload';
@@ -26,7 +26,6 @@ import {
     WORK_CONTENT_OPTIONS,
     ICON_OPTIONS,
     BREAK_HOUR_OPTIONS,
-    TRANSPORTATION_FEE_OPTIONS,
     TRANSPORTATION_FEE_MAX,
     RECRUITMENT_START_DAY_OPTIONS,
     RECRUITMENT_END_DAY_OPTIONS,
@@ -190,7 +189,7 @@ export default function JobForm({ mode, jobId, initialData, isOfferMode = false,
         endTime: '15:00',
         breakTime: 60,
         hourlyWage: 1200,
-        transportationFee: 500,
+        transportationFee: 0,
         workContent: [] as string[],
         jobDescription: '',
         qualifications: [] as string[],
@@ -244,32 +243,22 @@ export default function JobForm({ mode, jobId, initialData, isOfferMode = false,
         formData.breakTime
     );
 
-    // 実働時間（分）を計算して、交通費選択肢をフィルタリング
+    // 実働時間（分）を計算して交通費を自動算出
     const workingMinutes = workingHours * 60;
-    const filteredTransportationFeeOptions = getFilteredTransportationFeeOptions(
-        workingMinutes,
-        TRANSPORTATION_FEE_OPTIONS
-    );
-    const minTransportationFee = calculateMinTransportationFee(workingMinutes);
+    const autoTransportationFee = calculateTransportationFee(workingMinutes);
+    const isTransportationFeeMaxed = autoTransportationFee >= TRANSPORTATION_FEE_MAX;
 
     // 最低賃金チェック
     const isBelowMinimumWage = minimumWage !== null
         && formData.hourlyWage > 0
         && formData.hourlyWage < minimumWage;
 
-    // 勤務時間変更時に、交通費が選択肢外になった場合は自動調整
+    // 勤務時間変更時に交通費を自動再計算（既存求人の編集時も新ルールで上書き）
     useEffect(() => {
-        if (workingMinutes <= 0) return;
-
-        const currentFee = formData.transportationFee;
-        // 0円（なし）は常にOK
-        if (currentFee === 0) return;
-
-        // 現在の値が最低額を下回っている場合は自動調整
-        if (currentFee < minTransportationFee) {
-            handleInputChange('transportationFee', minTransportationFee);
+        if (formData.transportationFee !== autoTransportationFee) {
+            handleInputChange('transportationFee', autoTransportationFee);
         }
-    }, [workingMinutes, minTransportationFee]);
+    }, [autoTransportationFee]);
 
     // 実働時間を「X時間Y分」形式でフォーマット
     const formatWorkingHours = (hours: number): string => {
@@ -962,7 +951,8 @@ export default function JobForm({ mode, jobId, initialData, isOfferMode = false,
             endTime: template.endTime,
             breakTime: template.breakTime,
             hourlyWage: template.hourlyWage,
-            transportationFee: template.transportationFee,
+            // 交通費はテンプレートの保存値を使わず、勤務時間から自動再計算（useEffectで反映）
+            transportationFee: 0,
             workContent: template.workContent || [],
             jobDescription: template.description || '',
             qualifications: template.qualifications || [],
@@ -1067,6 +1057,11 @@ export default function JobForm({ mode, jobId, initialData, isOfferMode = false,
 
             // 実働時間 = 拘束時間 - 休憩時間
             const workMinutes = grossMinutes - formData.breakTime;
+
+            // 実働時間が0以下の場合は公開不可
+            if (workMinutes <= 0) {
+                errors.push('実働時間が0分以下です。勤務時間または休憩時間を見直してください');
+            }
 
             // 実働8時間（480分）を超える場合 → 60分以上の休憩が必要
             if (workMinutes > 480 && formData.breakTime < 60) {
@@ -2135,25 +2130,22 @@ export default function JobForm({ mode, jobId, initialData, isOfferMode = false,
 
                             <div>
                                 <label className="block text-sm font-medium text-gray-700 mb-2">
-                                    交通費（円） <span className="text-red-500">*</span>
+                                    交通費（円）
                                 </label>
-                                <select
-                                    value={formData.transportationFee}
-                                    onChange={(e) => handleInputChange('transportationFee', Number(e.target.value))}
-                                    className="w-full px-3 py-2 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-600"
-                                >
-                                    {filteredTransportationFeeOptions.map(option => (
-                                        <option key={option.value} value={option.value}>{option.label}</option>
-                                    ))}
-                                </select>
-                                {workingMinutes > 0 && minTransportationFee > 0 && (
-                                    <p className="text-xs text-gray-500 mt-1">
-                                        {minTransportationFee >= TRANSPORTATION_FEE_MAX
-                                            ? `※ 実働${formatWorkingHours(workingHours)}の場合、交通費は上限の${TRANSPORTATION_FEE_MAX.toLocaleString()}円となります`
-                                            : `※ 実働${formatWorkingHours(workingHours)}の場合、最低${minTransportationFee}円以上`
-                                        }
-                                    </p>
-                                )}
+                                <input
+                                    type="text"
+                                    value={`${autoTransportationFee.toLocaleString()}円`}
+                                    readOnly
+                                    className="w-full px-3 py-2 text-sm border border-gray-300 rounded bg-gray-100"
+                                />
+                                <p className="text-xs text-gray-500 mt-1">
+                                    {workingMinutes <= 0
+                                        ? '※ 勤務時間を入力すると自動計算されます（1時間あたり100円、上限800円）'
+                                        : isTransportationFeeMaxed
+                                            ? `※ 実働${formatWorkingHours(workingHours)}のため、交通費は上限の${TRANSPORTATION_FEE_MAX.toLocaleString()}円となります`
+                                            : `※ 実働${formatWorkingHours(workingHours)}に応じて自動計算（1時間あたり100円、上限${TRANSPORTATION_FEE_MAX.toLocaleString()}円）`
+                                    }
+                                </p>
                             </div>
 
                             <div>

--- a/components/admin/JobTemplateForm.tsx
+++ b/components/admin/JobTemplateForm.tsx
@@ -7,7 +7,7 @@ import { useSWRConfig } from 'swr';
 import { useAuth } from '@/contexts/AuthContext';
 import { Upload, X, AlertTriangle } from 'lucide-react';
 import { TemplatePreviewModal } from '@/components/admin/TemplatePreviewModal';
-import { calculateDailyWage, calculateWorkingHours, getFilteredTransportationFeeOptions, calculateMinTransportationFee } from '@/utils/salary';
+import { calculateDailyWage, calculateWorkingHours } from '@/utils/salary';
 import { validateImageFiles, validateAttachmentFiles } from '@/utils/fileValidation';
 import toast from 'react-hot-toast';
 import { directUploadMultiple } from '@/utils/directUpload';
@@ -19,7 +19,6 @@ import {
     WORK_CONTENT_OPTIONS,
     ICON_OPTIONS,
     BREAK_HOUR_OPTIONS,
-    TRANSPORTATION_FEE_OPTIONS,
     RECRUITMENT_START_DAY_OPTIONS,
     RECRUITMENT_END_DAY_OPTIONS,
     HOUR_OPTIONS,
@@ -290,27 +289,8 @@ export default function JobTemplateForm({ mode, templateId, initialData }: JobTe
         formData.breakTime
     );
 
-    // 実働時間（分）を計算して、交通費選択肢をフィルタリング
+    // テンプレートでは交通費は確定させず、実求人作成時に勤務時間から自動計算する
     const workingMinutes = workingHours * 60;
-    const filteredTransportationFeeOptions = getFilteredTransportationFeeOptions(
-        workingMinutes,
-        TRANSPORTATION_FEE_OPTIONS
-    );
-    const minTransportationFee = calculateMinTransportationFee(workingMinutes);
-
-    // 勤務時間変更時に、交通費が選択肢外になった場合は自動調整
-    useEffect(() => {
-        if (workingMinutes <= 0) return;
-
-        const currentFee = formData.transportationFee;
-        // 0円（なし）は常にOK
-        if (currentFee === 0) return;
-
-        // 現在の値が最低額を下回っている場合は自動調整
-        if (currentFee < minTransportationFee) {
-            setFormData(prev => ({ ...prev, transportationFee: minTransportationFee }));
-        }
-    }, [workingMinutes, minTransportationFee]);
 
     // 実働時間を「X時間Y分」形式でフォーマット
     const formatWorkingHours = (hours: number): string => {
@@ -480,7 +460,8 @@ export default function JobTemplateForm({ mode, templateId, initialData }: JobTe
                 endTime: formData.endTime,
                 breakTime: formData.breakTime,
                 hourlyWage: formData.hourlyWage,
-                transportationFee: formData.transportationFee,
+                // テンプレートでは交通費は固定値0で保存（実求人作成時に勤務時間から自動計算する）
+                transportationFee: 0,
                 recruitmentCount: formData.recruitmentCount,
                 qualifications: formData.qualifications,
                 workContent: formData.workContent,
@@ -997,22 +978,19 @@ export default function JobTemplateForm({ mode, templateId, initialData }: JobTe
 
                             <div>
                                 <label className="block text-sm font-medium text-gray-700 mb-2">
-                                    交通費（円） <span className="text-red-500">*</span>
+                                    交通費（円）
                                 </label>
-                                <select
-                                    value={formData.transportationFee}
-                                    onChange={(e) => handleInputChange('transportationFee', Number(e.target.value))}
-                                    className="w-full px-3 py-2 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-600"
-                                >
-                                    {filteredTransportationFeeOptions.map(option => (
-                                        <option key={option.value} value={option.value}>{option.label}</option>
-                                    ))}
-                                </select>
-                                {workingMinutes > 0 && minTransportationFee > 0 && (
-                                    <p className="text-xs text-gray-500 mt-1">
-                                        ※ 実働{formatWorkingHours(workingHours)}の場合、最低{minTransportationFee}円以上
-                                    </p>
-                                )}
+                                <input
+                                    type="text"
+                                    value=""
+                                    placeholder="実求人作成時に確定"
+                                    readOnly
+                                    disabled
+                                    className="w-full px-3 py-2 text-sm border border-gray-200 rounded bg-gray-100 text-gray-400 cursor-not-allowed"
+                                />
+                                <p className="text-xs text-gray-500 mt-1">
+                                    ※ 交通費は実求人作成時に勤務時間から自動計算されます（1時間あたり100円、上限800円）
+                                </p>
                             </div>
 
                             <div>

--- a/components/admin/TemplatePreviewModal.tsx
+++ b/components/admin/TemplatePreviewModal.tsx
@@ -2,7 +2,7 @@
 
 import { X } from 'lucide-react';
 import { JobDetailClient } from '@/components/job/JobDetailClient';
-import { calculateDailyWage } from '@/utils/salary';
+import { calculateDailyWage, calculateWorkingHours, calculateTransportationFee } from '@/utils/salary';
 
 interface TemplatePreviewModalProps {
   isOpen: boolean;
@@ -44,13 +44,18 @@ interface TemplatePreviewModalProps {
 export function TemplatePreviewModal({ isOpen, onClose, templateData, facilityData }: TemplatePreviewModalProps) {
   if (!isOpen) return null;
 
+  // テンプレートでは交通費は確定しないため、プレビュー用に勤務時間から自動計算した値を表示
+  const previewWorkingMinutes =
+    calculateWorkingHours(templateData.startTime, templateData.endTime, templateData.breakTime) * 60;
+  const previewTransportationFee = calculateTransportationFee(previewWorkingMinutes);
+
   // 日給計算
   const dailyWage = calculateDailyWage(
     templateData.startTime,
     templateData.endTime,
     templateData.breakTime,
     templateData.hourlyWage,
-    templateData.transportationFee
+    previewTransportationFee
   );
 
   // プレビュー用のダミーデータを構築（JobPreviewModalと同じ形式）
@@ -62,7 +67,7 @@ export function TemplatePreviewModal({ isOpen, onClose, templateData, facilityDa
     end_time: templateData.endTime,
     break_time: templateData.breakTime,
     hourly_wage: templateData.hourlyWage,
-    transportation_fee: templateData.transportationFee,
+    transportation_fee: previewTransportationFee,
     recruitment_count: templateData.recruitmentCount,
     work_content: templateData.workContent,
     dresscode_images: templateData.dresscodeImages || [],
@@ -71,7 +76,7 @@ export function TemplatePreviewModal({ isOpen, onClose, templateData, facilityDa
     endTime: templateData.endTime,
     breakTime: templateData.breakTime,
     hourlyWage: templateData.hourlyWage,
-    transportationFee: templateData.transportationFee,
+    transportationFee: previewTransportationFee,
     recruitmentCount: templateData.recruitmentCount,
     workContent: templateData.workContent,
     dresscodeImages: templateData.dresscodeImages || [],

--- a/constants/salary.ts
+++ b/constants/salary.ts
@@ -4,23 +4,15 @@
 
 /**
  * 交通費の上限（円）
- * 長時間勤務でも交通費は最大1,000円まで
+ * 長時間勤務でも交通費は最大800円まで
  */
-export const TRANSPORTATION_FEE_MAX = 1000;
-
-export const TRANSPORTATION_FEE_OPTIONS = [
-  { value: 0, label: 'なし' },
-  ...Array.from({ length: TRANSPORTATION_FEE_MAX / 25 }, (_, i) => ({
-    value: (i + 1) * 25,
-    label: `${(i + 1) * 25}円`
-  }))
-] as const;
+export const TRANSPORTATION_FEE_MAX = 800;
 
 /**
- * 交通費の最低レート（1時間あたり）
- * 15分25円 = 1時間100円
+ * 交通費のレート（1時間あたり）
+ * 1時間100円
  */
-export const TRANSPORTATION_FEE_MIN_RATE_PER_HOUR = 100;
+export const TRANSPORTATION_FEE_RATE_PER_HOUR = 100;
 
 export const HOURLY_WAGE_MIN = 1000;
 export const HOURLY_WAGE_MAX = 5000;

--- a/src/lib/actions/job-management.ts
+++ b/src/lib/actions/job-management.ts
@@ -11,6 +11,27 @@ import { logActivity, getErrorMessage, getErrorStack } from '@/lib/logger';
 import { getFacilityAdminSessionData } from '@/lib/admin-session-server';
 import { getMinimumWageForPrefecture } from '@/src/lib/actions/minimumWage';
 import { notifyJobUpdated, notifyJobsUpdated, notifyJobsDeleted } from '@/src/lib/google-indexing';
+import { calculateTransportationFee } from '@/utils/salary';
+
+/**
+ * 開始時刻・終了時刻・休憩時間から実働時間（分）を計算
+ */
+function computeWorkingMinutes(startTime: string, endTime: string, breakMinutes: number): number {
+    if (!startTime || !endTime) return 0;
+    const [startHour, startMin] = startTime.split(':').map(Number);
+    const isNextDay = endTime.startsWith('翌');
+    const endTimePart = isNextDay ? endTime.slice(1) : endTime;
+    const [endHour, endMin] = endTimePart.split(':').map(Number);
+
+    const startMinutes = startHour * 60 + startMin;
+    let endMinutes = endHour * 60 + endMin;
+    if (isNextDay) endMinutes += 24 * 60;
+
+    let totalMinutes = endMinutes - startMinutes;
+    if (totalMinutes < 0) totalMinutes += 24 * 60;
+
+    return totalMinutes - breakMinutes;
+}
 
 /**
  * ローカル用の日付フォーマット関数 (M/D形式)
@@ -331,6 +352,13 @@ export async function createJobs(input: CreateJobInput) {
         }
     }
 
+    // 実働時間バリデーション・交通費の自動再計算（クライアント送信値は信用しない）
+    const workingMinutes = computeWorkingMinutes(input.startTime, input.endTime, input.breakTime);
+    if (workingMinutes <= 0) {
+        return { success: false, error: '実働時間が0分以下です。勤務時間または休憩時間を見直してください' };
+    }
+    const transportationFee = calculateTransportationFee(workingMinutes);
+
     const calculateWage = (startTime: string, endTime: string, breakMinutes: number, hourlyWage: number, transportFee: number) => {
         const [startHour, startMin] = startTime.split(':').map(Number);
         const isNextDay = endTime.startsWith('翌');
@@ -358,7 +386,7 @@ export async function createJobs(input: CreateJobInput) {
         input.endTime,
         input.breakTime,
         input.hourlyWage,
-        input.transportationFee
+        transportationFee
     );
 
     const breakTimeStr = `${input.breakTime}分`;
@@ -447,7 +475,7 @@ export async function createJobs(input: CreateJobInput) {
             break_time: breakTimeStr,
             wage: wage,
             hourly_wage: input.hourlyWage,
-            transportation_fee: input.transportationFee,
+            transportation_fee: transportationFee,
             deadline_days_before: input.recruitmentEndDay ?? -2,
             recruitment_start_day: input.recruitmentStartDay,
             recruitment_start_time: input.recruitmentStartTime || null,
@@ -948,6 +976,13 @@ export async function updateJob(
 
         const breakTimeMinutes = data.breakTime;
 
+        // 実働時間バリデーション・交通費の自動再計算（クライアント送信値は信用しない）
+        const workingMinutes = computeWorkingMinutes(data.startTime, data.endTime, breakTimeMinutes);
+        if (workingMinutes <= 0) {
+            return { success: false, error: '実働時間が0分以下です。勤務時間または休憩時間を見直してください' };
+        }
+        const transportationFee = calculateTransportationFee(workingMinutes);
+
         const calculateWage = (startTime: string, endTime: string, breakMinutes: number, hourlyWage: number, transportFee: number) => {
             const [startHour, startMin] = startTime.split(':').map(Number);
             const isNextDay = endTime.startsWith('翌');
@@ -968,7 +1003,7 @@ export async function updateJob(
             data.endTime,
             breakTimeMinutes,
             data.hourlyWage,
-            data.transportationFee
+            transportationFee
         );
 
         await prisma.job.update({
@@ -979,7 +1014,7 @@ export async function updateJob(
                 end_time: data.endTime,
                 break_time: `${breakTimeMinutes}分`,
                 hourly_wage: data.hourlyWage,
-                transportation_fee: data.transportationFee,
+                transportation_fee: transportationFee,
                 wage: wage,
                 recruitment_count: data.recruitmentCount,
                 work_content: data.workContent,

--- a/src/lib/actions/job-template.ts
+++ b/src/lib/actions/job-template.ts
@@ -121,7 +121,8 @@ export async function createJobTemplate(
                 end_time: data.endTime,
                 break_time: data.breakTime,
                 hourly_wage: data.hourlyWage,
-                transportation_fee: data.transportationFee,
+                // テンプレートでは交通費は固定値0で保存（実求人作成時に勤務時間から自動計算する）
+                transportation_fee: 0,
                 recruitment_count: data.recruitmentCount,
                 qualifications: data.qualifications,
                 work_content: data.workContent || [],
@@ -338,7 +339,8 @@ export async function updateJobTemplate(
                 end_time: data.endTime,
                 break_time: data.breakTime,
                 hourly_wage: data.hourlyWage,
-                transportation_fee: data.transportationFee,
+                // テンプレートでは交通費は固定値0で保存（実求人作成時に勤務時間から自動計算する）
+                transportation_fee: 0,
                 recruitment_count: data.recruitmentCount,
                 qualifications: data.qualifications,
                 work_content: data.workContent || [],

--- a/utils/salary.ts
+++ b/utils/salary.ts
@@ -9,7 +9,7 @@
  */
 
 import { calculateSalary } from '@/src/lib/salary-calculator';
-import { TRANSPORTATION_FEE_MAX } from '@/constants/salary';
+import { TRANSPORTATION_FEE_MAX, TRANSPORTATION_FEE_RATE_PER_HOUR } from '@/constants/salary';
 
 /**
  * 時刻をパースする（翌日プレフィックス対応）
@@ -185,37 +185,22 @@ export const calculateWorkingHours = (
 };
 
 /**
- * 実働時間から最低交通費を計算
- * 1時間あたり100円（15分あたり25円）
- * 上限は1,000円
+ * 実働時間から交通費を自動計算
+ * - 1時間あたり100円（TRANSPORTATION_FEE_RATE_PER_HOUR）
+ * - 1円未満の端数は切り上げ
+ * - 上限は800円（TRANSPORTATION_FEE_MAX）
  * @param workingMinutes - 実働時間（分）
- * @returns 最低交通費（円）、25円刻みに切り上げ、上限1,000円
+ * @returns 交通費（円）
  */
-export const calculateMinTransportationFee = (workingMinutes: number): number => {
+export const calculateTransportationFee = (workingMinutes: number): number => {
   if (workingMinutes <= 0) return 0;
 
   // 1時間100円 = 1分あたり100/60円
-  const minFee = (workingMinutes * 100) / 60;
+  const fee = (workingMinutes * TRANSPORTATION_FEE_RATE_PER_HOUR) / 60;
 
-  // 25円刻みに切り上げ
-  const roundedFee = Math.ceil(minFee / 25) * 25;
+  // 1円未満を切り上げて整数円に
+  const roundedFee = Math.ceil(fee);
 
   // 上限を適用
   return Math.min(roundedFee, TRANSPORTATION_FEE_MAX);
-};
-
-/**
- * 勤務時間に応じてフィルタリングされた交通費選択肢を取得
- * @param workingMinutes - 実働時間（分）
- * @param options - 元の交通費選択肢
- * @returns フィルタリングされた選択肢
- */
-export const getFilteredTransportationFeeOptions = <T extends { value: number; label: string }>(
-  workingMinutes: number,
-  options: readonly T[]
-): T[] => {
-  const minFee = calculateMinTransportationFee(workingMinutes);
-
-  // 0円（なし）は常に表示、それ以外は最低額以上のものを表示
-  return options.filter(option => option.value === 0 || option.value >= minFee);
 };


### PR DESCRIPTION
## 概要

求人作成時の交通費を施設管理者が任意選択する方式から、勤務時間（実働時間）から一意に決まる値を自動表示する方式に変更します。クライアント要望に基づく改修です。

## 変更内容

### 計算ルール
- 計算式: 切り上げ(実働分 × 100 ÷ 60)
- 上限: 800円（旧: 1,000円）
- 1円未満の端数は切り上げて整数円
- 「なし(0円)」の選択肢を削除
- 計算対象は実働時間（休憩控除後）

### UI
- 求人作成・編集フォーム: プルダウン → 読み取り専用の自動計算表示
- 求人テンプレート編集フォーム: 交通費欄をグレーアウト＋「実求人作成時に確定」と注記
- 実働8時間以上の場合は「上限800円」の注記を表示
- 実働0分以下の入力はバリデーションエラーで公開不可

### 既存データの取り扱い（A1方針）
- 既存求人のDB値は変更しない
- 施設管理者が編集画面を開いた時点で UI 上は新ルールの値が表示され、保存時に新値で上書き
- 編集されない限り過去の値（旧上限1,000円や0円）はそのまま保持

### サーバー側の対応
- `createJobs` / `updateJob` でクライアント送信値を信用せず、実働時間から再計算してDB保存
- テンプレート保存時は `transportation_fee = 0` で固定
- 実働0分以下のケースをサーバー側でも弾く

## 計算例

- 1分 → 2円
- 15分 → 25円
- 31分 → 52円
- 59分 → 99円
- 1時間 → 100円
- 7時間59分 → 799円
- 8時間以降 → 800円（上限）

## 変更ファイル

- `constants/salary.ts` — 上限値変更、不要な定数削除
- `utils/salary.ts` — `calculateTransportationFee` 追加、旧フィルタ関数削除
- `components/admin/JobForm.tsx` — UI改修・自動再計算useEffect・実働0分バリデーション
- `components/admin/JobTemplateForm.tsx` — UI改修（グレーアウト）
- `components/admin/TemplatePreviewModal.tsx` — プレビューでも自動計算した値で表示
- `src/lib/actions/job-management.ts` — サーバー側再計算・バリデーション
- `src/lib/actions/job-template.ts` — テンプレート保存値を0固定

## テスト

- TypeScript 型チェック: 通過
- `npx next build` でビルド成功
- ロジック単体テスト（`prisma/test-transportation-fee.ts`）で17ケース全合格
  - 境界値: 0分/1分/15分/30分/31分/59分/60分/7時間59分/8時間/8時間1分/12時間など

## Test plan

- [ ] 求人新規作成: 勤務時間に応じて交通費が自動表示される
- [ ] 勤務時間変更時: 交通費が即座に再計算される
- [ ] 実働8時間以上: 800円固定で「上限到達」注記が表示される
- [ ] 実働0分(開始=終了 or 休憩過多): バリデーションエラーで公開不可
- [ ] 既存求人を編集: 開いた時点で新ルール値に上書きされる
- [ ] テンプレート編集: 交通費欄がグレーアウトで「実求人作成時に確定」表示
- [ ] テンプレートからの求人作成: 勤務時間から自動計算された値で確定する
- [ ] テンプレートプレビュー: 自動計算値が表示される

## 既知の残作業

- E2E テスト（`tests/e2e/job-creation.spec.ts`, `tests/e2e/fixes-2026-01/display-text.spec.ts`）の交通費関連ケースは旧仕様（プルダウン・「なし」選択）に依存しているため、別途更新が必要です。

## 関連

- クライアント要望に基づく仕様変更（2026-04 確認）
- 確定仕様の議事録は実装計画として記録済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)