### PR TITLE
UI改善: テンプレート編集画面の募集時間入力欄を求人作成画面と統一

### DIFF
--- a/components/admin/JobTemplateForm.tsx
+++ b/components/admin/JobTemplateForm.tsx
@@ -926,19 +926,26 @@ export default function JobTemplateForm({ mode, templateId, initialData }: JobTe
                                     </select>
                                 </div>
 
-                                {formData.recruitmentStartDay !== 0 && formData.recruitmentStartDay !== -1 && (
-                                    <div>
-                                        <label className="block text-sm font-medium text-gray-700 mb-2">
-                                            募集開始時間 <span className="text-red-500">*</span>
-                                        </label>
+                                <div>
+                                    <label className="block text-sm font-medium text-gray-700 mb-2">
+                                        募集開始時間 <span className="text-red-500">*</span>
+                                    </label>
+                                    {formData.recruitmentStartDay === 0 || formData.recruitmentStartDay === -1 ? (
+                                        <input
+                                            type="text"
+                                            value="--:--"
+                                            readOnly
+                                            className="w-full px-3 py-2 text-sm border border-gray-300 rounded bg-gray-100 text-gray-500"
+                                        />
+                                    ) : (
                                         <input
                                             type="time"
                                             value={formData.recruitmentStartTime}
                                             onChange={(e) => handleInputChange('recruitmentStartTime', e.target.value)}
                                             className="w-full px-3 py-2 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-600"
                                         />
-                                    </div>
-                                )}
+                                    )}
+                                </div>
                             </div>
 
                             <div className="grid grid-cols-2 gap-4">
@@ -957,19 +964,26 @@ export default function JobTemplateForm({ mode, templateId, initialData }: JobTe
                                     </select>
                                 </div>
 
-                                {formData.recruitmentEndDay !== 0 && formData.recruitmentEndDay !== -1 && (
-                                    <div>
-                                        <label className="block text-sm font-medium text-gray-700 mb-2">
-                                            募集終了時間 <span className="text-red-500">*</span>
-                                        </label>
+                                <div>
+                                    <label className="block text-sm font-medium text-gray-700 mb-2">
+                                        募集終了時間 <span className="text-red-500">*</span>
+                                    </label>
+                                    {formData.recruitmentEndDay === 0 || formData.recruitmentEndDay === -1 ? (
+                                        <input
+                                            type="text"
+                                            value="--:--"
+                                            readOnly
+                                            className="w-full px-3 py-2 text-sm border border-gray-300 rounded bg-gray-100 text-gray-500"
+                                        />
+                                    ) : (
                                         <input
                                             type="time"
                                             value={formData.recruitmentEndTime}
                                             onChange={(e) => handleInputChange('recruitmentEndTime', e.target.value)}
                                             className="w-full px-3 py-2 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-600"
                                         />
-                                    </div>
-                                )}
+                                    )}
+                                </div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
## 概要

テンプレート編集画面で「勤務当日」「公開時/勤務開始時」を選択した際、募集時間の入力欄が完全に消えてしまい、ユーザーが「枠が消えた」と不安を感じる問題があった。

求人作成画面（`JobForm.tsx`）では同条件で `--:--` のグレーアウト表示となっているため、テンプレート編集画面（`JobTemplateForm.tsx`）も同じUIに統一する。

## 背景

PR #567 のステージング動作確認中、クライアントから「勤務当日を選択した場合、時間の入力枠が消える」との指摘あり。  
コード調査の結果、ロジック自体は両画面とも同じ（時刻指定不要のケースでは時間入力をdisable）だが、UI表現だけが異なっていた。

| 画面 | 「勤務当日」選択時の表示（修正前） |
|---|---|
| 求人作成画面（JobForm.tsx） | `--:--` のグレーアウト読み取り専用フィールド |
| テンプレート編集画面（JobTemplateForm.tsx） | **入力欄ごと非表示**（不整合） |

## 変更内容

`components/admin/JobTemplateForm.tsx`:
- 募集開始時間（行929付近）の条件レンダリングを書き換え
- 募集終了時間（行960付近）の条件レンダリングを書き換え
- 条件成立時は `--:--` のグレーアウト表示、それ以外は通常の `type="time"` 入力に統一

`JobForm.tsx` 行2040〜2090と同じパターンにした。

## Test plan

- [x] `npm run build` 通過
- [ ] ステージングで「勤務当日」選択時に `--:--` グレーアウト表示が出ることを確認
- [ ] 「勤務1日前」など選択時には通常の時刻入力が表示されることを確認
- [ ] 求人作成画面とテンプレート編集画面の見た目が一致することを確認

## デプロイ手順

DB変更なし。develop マージ後にステージングへ自動デプロイ → 動作確認 → main へマージ → 本番反映 のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)