### PR TITLE
機能追加: プールスタッフCSVに登録元LP情報を追加（48→50項目）

### DIFF
--- a/app/api/system-admin/staff-csv/route.ts
+++ b/app/api/system-admin/staff-csv/route.ts
@@ -5,7 +5,7 @@ import { getSystemAdminSessionData } from '@/lib/system-admin-session-server';
 
 export const dynamic = 'force-dynamic';
 
-// CROSSNAVI仕様の48項目ヘッダー
+// CROSSNAVI仕様の48項目 + 登録元LP情報2項目 = 50項目ヘッダー
 const HEADERS = [
   '自社スタッフ番号',
   '事業所',
@@ -55,6 +55,8 @@ const HEADERS = [
   '住民票住所－アパート・マンション',
   '住民票住所カナ',
   '住民票住所カナ２',
+  '登録元LP番号',
+  '登録元LP名',
 ];
 
 const BATCH_SIZE = 100;
@@ -92,8 +94,23 @@ function convertAccountType(accountType: string | null): string {
   return '0';
 }
 
-function staffToRow(staff: any, bankAccount: any): (string | number)[] {
+// 厳密な整数文字列のみを LP 番号として受理する（"5abc" → null）
+function parseLpNumberStrict(value: string | null | undefined): number | null {
+  if (!value || !/^\d+$/.test(value)) return null;
+  const n = Number.parseInt(value, 10);
+  return Number.isNaN(n) ? null : n;
+}
+
+function staffToRow(
+  staff: any,
+  bankAccount: any,
+  lpNameMap: Map<number, string>,
+): (string | number)[] {
   const [lastName, firstName] = splitName(staff.name);
+
+  const lpNumber = parseLpNumberStrict(staff.registration_lp_id);
+  const lpId = lpNumber !== null ? String(lpNumber) : '';
+  const lpName = lpNumber !== null ? (lpNameMap.get(lpNumber) ?? '') : '';
 
   return [
     staff.id,
@@ -144,6 +161,8 @@ function staffToRow(staff: any, bankAccount: any): (string | number)[] {
     staff.building || '',
     '',
     '',
+    lpId,
+    lpName,
   ];
 }
 
@@ -208,9 +227,28 @@ export async function GET(request: NextRequest) {
           });
           const bankAccountMap = new Map(bankAccounts.map((ba) => [ba.userId, ba]));
 
+          // バッチ内のregistration_lp_idでLPマスタを一括取得
+          const lpNumbers = Array.from(
+            new Set(
+              batch
+                .map((u) => parseLpNumberStrict(u.registration_lp_id))
+                .filter((n): n is number => n !== null),
+            ),
+          );
+          const lpNameMap = new Map<number, string>();
+          if (lpNumbers.length > 0) {
+            const lps = await prisma.landingPage.findMany({
+              where: { lp_number: { in: lpNumbers } },
+              select: { lp_number: true, name: true },
+            });
+            for (const lp of lps) {
+              lpNameMap.set(lp.lp_number, lp.name);
+            }
+          }
+
           for (const staff of batch) {
             const bankAccount = bankAccountMap.get(staff.id);
-            controller.enqueue(encoder.encode(formatRow(staffToRow(staff, bankAccount))));
+            controller.enqueue(encoder.encode(formatRow(staffToRow(staff, bankAccount, lpNameMap))));
           }
 
           processed += batch.length;

--- a/app/system-admin/csv-export/staff-info/StaffInfoExport.tsx
+++ b/app/system-admin/csv-export/staff-info/StaffInfoExport.tsx
@@ -215,11 +215,12 @@ export default function StaffInfoExport() {
       <div className="bg-slate-50 rounded-xl p-4 text-sm text-slate-600">
         <p className="font-medium text-slate-700 mb-2">CSV出力仕様</p>
         <ul className="list-disc list-inside space-y-1">
-          <li>CROSSNAVI連携用フォーマット（48項目）</li>
+          <li>CROSSNAVI連携用フォーマット（50項目）</li>
           <li>文字コード: UTF-8（BOM付き）</li>
           <li>メール認証済みワーカーのみ対象</li>
           <li>連絡先住所・住民票住所は現住所を引用</li>
           <li>固定値: 事業所=渋谷事業所、配偶者有無=不明、扶養対象者=0</li>
+          <li>末尾2列に登録元LP情報（LP番号・LP名）を含む</li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- プールスタッフ情報 CSV（`/system-admin/csv-export` の「プールスタッフ情報」タブ）の末尾に **登録元LP番号 / 登録元LP名** の2列を追加（CROSSNAVI 48項目の並びは維持）
- LandingPage マスタはバッチ単位で一括取得（N+1なし、既存の bankAccount と同じパターン）
- 厳密な整数文字列のみを LP 番号として受理（`"5abc"` のような不正値で誤った LP 名が出力されるのを防止）
- UI の「CSV出力仕様」欄を 50項目表記に更新し、登録元LP情報を含む旨を追記

## レビュー
Codex Code Reviewer による事前レビュー実施済み（**APPROVE**）。
- 1stレビューで指摘された「`Number.parseInt` の緩い解析」を `parseLpNumberStrict` ヘルパー（`/^\d+$/` 検証）で修正済み
- 50ヘッダー / 50カラムで整合確認済み

## Test plan
- [ ] `/system-admin/csv-export` → 「プールスタッフ情報」タブ → 「CSV出力」ボタン
- [ ] ダウンロードCSVのヘッダー末尾2列が `登録元LP番号,登録元LP名` であること
- [ ] 既存48列の順序・内容が変わっていないこと
- [ ] LP経由登録ワーカーで LP番号・LP名が正しく出力されること
- [ ] LP経由でないワーカー（registration_lp_id が NULL）で末尾2列が空文字であること
- [ ] `registration_lp_id` はあるが `LandingPage` に該当レコードがないケースで LP番号は出るが LP名は空であること

## CROSSNAVI 互換性に関する確認事項
- 本変更は 48列固定のCROSSNAVI仕様に対し末尾追記している。CROSSNAVI 側が「余剰列を無視」する仕様であることを **本番リリース前に運用側で確認** する必要があります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)