### PR TITLE
バグ修正: プールスタッフCSVが空ファイルになる問題を修正

### DIFF
--- a/app/api/system-admin/staff-csv/route.ts
+++ b/app/api/system-admin/staff-csv/route.ts
@@ -182,7 +182,9 @@ export async function GET(request: NextRequest) {
   const dateFrom = url.searchParams.get('dateFrom');
   const dateTo = url.searchParams.get('dateTo');
 
-  const where: any = { role: 'worker' };
+  // UI側 (buildStaffInfoWhere) と一致させる: 削除されていない & メール認証済みのワーカー
+  // ※User モデルに role フィールドは存在しないため、role での絞り込みは不可
+  const where: any = { deleted_at: null, email_verified: true };
   if (search) {
     where.OR = [
       { name: { contains: search, mode: 'insensitive' } },


### PR DESCRIPTION
## Summary
プールスタッフ情報CSV (`/api/system-admin/staff-csv`) が **ヘッダー50列のみ・データ0件** で出力される不具合を修正。

## 原因
\`app/api/system-admin/staff-csv/route.ts:185\` の where 条件:
\`\`\`ts
const where: any = { role: 'worker' };
\`\`\`
\`User\` モデルに \`role\` フィールドは存在せず、Prisma が \`Unknown argument 'role'\` validationエラーを投げる。catch ブロックで \`controller.error()\` が呼ばれるが、その時点でヘッダー行は既にストリームに書き込まれているため、ブラウザは「BOM + ヘッダー50列」の小さなCSV（1,309バイト）を保存していた。

## バグの導入
2026-01-30 commit \`076b8c90\` (\`feat: 全CSVエクスポート機能をストリーミング対応に改修\`) で導入された既存バグ。UI の件数表示は別関数 \`buildStaffInfoWhere\` (\`src/lib/actions/csv-export.ts\`) を使っており、そちらは \`deleted_at: null, email_verified: true\` で絞り込んでいたため件数とCSVの齟齬に気付かれにくかった。

## 修正内容
where 条件を UI 側と一致させる:
\`\`\`diff
- const where: any = { role: 'worker' };
+ const where: any = { deleted_at: null, email_verified: true };
\`\`\`

これにより:
- UI の件数 = CSV 出力件数 で整合
- UI 説明文「メール認証済みワーカーのみ対象」とも一致
- Prisma validationエラー解消

## 影響範囲
- 修正対象: \`/api/system-admin/staff-csv\` のみ
- worker-csv ほか他のCSVエンドポイントは別の where 条件のため影響なし（grep で確認済み）

## Test plan
- [ ] ステージング (https://stg-share-worker.vercel.app/system-admin/csv-export) でプールスタッフ情報タブから CSV出力 → ヘッダー50列 + データ行が複数件出力されること
- [ ] UI に表示されている件数と CSV のデータ行数が一致すること
- [ ] 既存の検索フィルター（氏名・メール・電話番号・登録日）が CSV 出力にも反映されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)