### PR TITLE
バグ修正: アナリティクスの不整合解消（指標定義/離脱率表示/エラーハンドリング）

### DIFF
--- a/app/system-admin/analytics/tabs/FacilityAnalytics.tsx
+++ b/app/system-admin/analytics/tabs/FacilityAnalytics.tsx
@@ -11,7 +11,7 @@ const METRIC_LABELS: Record<keyof Omit<FacilityMetrics, 'date'>, string> = {
     withdrawnCount: '退会施設数',
     reviewCount: 'レビュー数',
     reviewAvg: 'レビュー平均点',
-    dropoutRate: '登録離脱率(%)',
+    dropoutRate: '登録離脱率(%) (未実装)',
     withdrawalRate: '退会率(%)',
     parentJobCount: '親求人数',
     parentJobInterviewCount: '親求人数(審査あり)',
@@ -137,7 +137,7 @@ export default function FacilityAnalytics() {
                                             </td>
                                             {Object.keys(METRIC_LABELS).map(key => (
                                                 <td key={key} className="px-4 py-3 text-sm text-slate-700 text-right">
-                                                    {row[key as keyof FacilityMetrics]}
+                                                    {key === 'dropoutRate' ? '-' : row[key as keyof FacilityMetrics]}
                                                 </td>
                                             ))}
                                         </tr>

--- a/app/system-admin/analytics/tabs/FunnelAnalytics.tsx
+++ b/app/system-admin/analytics/tabs/FunnelAnalytics.tsx
@@ -134,6 +134,7 @@ export default function FunnelAnalytics() {
   const [selectedSources, setSelectedSources] = useState<string[]>([]); // 空=全選択
   const [data, setData] = useState<ApiResponse | null>(null);
   const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
   const [lpOptions, setLpOptions] = useState<Array<{ value: string; label: string }>>([]);
   const [showFilterDropdown, setShowFilterDropdown] = useState(false);
   const [showDataNotes, setShowDataNotes] = useState(false);
@@ -158,6 +159,7 @@ export default function FunnelAnalytics() {
 
   const fetchData = useCallback(async () => {
     setLoading(true);
+    setFetchError(null);
     try {
       const { startDate, endDate, breakdown } = getDateRange();
       if (!startDate || !endDate) {
@@ -168,6 +170,14 @@ export default function FunnelAnalytics() {
       const params = new URLSearchParams({ startDate, endDate, breakdown, source: sourceParam });
       const res = await fetch(`/api/funnel-analytics?${params}`);
       const json = await res.json();
+      if (!res.ok || json?.error) {
+        // API の error フィールドは英語のことがあるため、ユーザー向けには日本語のみ表示し、
+        // 詳細は console に残す
+        if (json?.error) {
+          console.error('[funnel-analytics] API error detail:', json.error);
+        }
+        throw new Error(`登録動線データの取得に失敗しました (HTTP ${res.status})`);
+      }
       setData(json);
       // LP一覧をレスポンスから取得
       if (json.lpSources && json.lpSources.length > 0) {
@@ -175,6 +185,8 @@ export default function FunnelAnalytics() {
       }
     } catch (error) {
       console.error('Failed to fetch funnel data:', error);
+      setFetchError(error instanceof Error ? error.message : 'データの取得中に予期しないエラーが発生しました');
+      setData(null);
     } finally {
       setLoading(false);
     }
@@ -678,10 +690,24 @@ export default function FunnelAnalytics() {
         </>
       )}
 
-      {/* データなし */}
-      {!loading && !data && (
+      {/* エラー表示 */}
+      {!loading && fetchError && (
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4 my-4">
+          <p className="text-sm font-medium text-red-800 mb-1">データを取得できませんでした</p>
+          <p className="text-sm text-red-700">{fetchError}</p>
+          <button
+            onClick={fetchData}
+            className="mt-3 px-3 py-1.5 text-sm font-medium text-red-700 bg-white border border-red-300 rounded-md hover:bg-red-50"
+          >
+            再読み込み
+          </button>
+        </div>
+      )}
+
+      {/* データなし（エラーではないが data が無い場合） */}
+      {!loading && !fetchError && !data && (
         <div className="text-center py-12 text-slate-400">
-          データの取得に失敗しました
+          表示するデータがありません
         </div>
       )}
     </div>

--- a/app/system-admin/analytics/tabs/LpTracking.tsx
+++ b/app/system-admin/analytics/tabs/LpTracking.tsx
@@ -178,6 +178,7 @@ export default function LpTracking() {
   const [trackingData, setTrackingData] = useState<TrackingData | null>(null);
   const [lpConfig, setLpConfig] = useState<LPConfig | null>(null);
   const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
   const [dateRange, setDateRange] = useState({
     startDate: '',
     endDate: '',
@@ -309,15 +310,31 @@ export default function LpTracking() {
 
   const fetchData = async () => {
     setLoading(true);
+    setFetchError(null);
     try {
       // Fetch LP config (no-store to always get fresh data)
       const configRes = await fetch('/api/lp-config', { cache: 'no-store' });
+      if (!configRes.ok) {
+        throw new Error(`LP設定の取得に失敗しました (HTTP ${configRes.status})`);
+      }
       const configData = await configRes.json();
+      // /api/lp-config の正常レスポンスは LP 番号キー（"0", "1", ...）と "genres" を持つオブジェクト。
+      // 500 等の致命エラーは `res.ok` で既に弾く。ここではアプリ層の失敗（`{ error: '...' }`
+      // を 200 で返すケース）を検出する用途で `error` キーの有無を見る。
+      if (!configData || typeof configData !== 'object' || configData.error) {
+        throw new Error(configData?.error || 'LP設定のレスポンスが不正です');
+      }
       setLpConfig(configData);
 
       // Fetch genres (no-store to always get fresh data)
       const genresRes = await fetch('/api/lp-code-genres', { cache: 'no-store' });
+      if (!genresRes.ok) {
+        throw new Error(`ジャンル一覧の取得に失敗しました (HTTP ${genresRes.status})`);
+      }
       const genresData = await genresRes.json();
+      if (genresData?.error) {
+        throw new Error(genresData.error);
+      }
       if (genresData.genres) {
         setGenres(genresData.genres);
       }
@@ -328,6 +345,9 @@ export default function LpTracking() {
       if (dateRange.endDate) params.set('endDate', dateRange.endDate);
 
       const trackingRes = await fetch(`/api/lp-tracking?${params.toString()}`, { cache: 'no-store' });
+      if (!trackingRes.ok) {
+        throw new Error(`トラッキングデータの取得に失敗しました (HTTP ${trackingRes.status})`);
+      }
       const trackingJson = await trackingRes.json();
       setTrackingData(trackingJson);
 
@@ -337,10 +357,17 @@ export default function LpTracking() {
       if (dateRange.endDate) publicJobsParams.set('endDate', dateRange.endDate);
 
       const publicJobsRes = await fetch(`/api/lp-tracking/public-jobs?${publicJobsParams.toString()}`, { cache: 'no-store' });
+      if (!publicJobsRes.ok) {
+        throw new Error(`公開求人サマリーの取得に失敗しました (HTTP ${publicJobsRes.status})`);
+      }
       const publicJobsJson = await publicJobsRes.json();
+      if (publicJobsJson?.error) {
+        throw new Error(publicJobsJson.error);
+      }
       setPublicJobsSummary(publicJobsJson);
     } catch (error) {
       console.error('Failed to fetch tracking data:', error);
+      setFetchError(error instanceof Error ? error.message : 'データの取得中に予期しないエラーが発生しました');
     } finally {
       setLoading(false);
     }
@@ -1186,6 +1213,17 @@ export default function LpTracking() {
           <div className="text-center py-12">
             <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-slate-900 mx-auto"></div>
             <p className="mt-2 text-slate-600">読み込み中...</p>
+          </div>
+        ) : fetchError ? (
+          <div className="bg-red-50 border border-red-200 rounded-lg p-4 my-4">
+            <p className="text-sm font-medium text-red-800 mb-1">データを取得できませんでした</p>
+            <p className="text-sm text-red-700">{fetchError}</p>
+            <button
+              onClick={fetchData}
+              className="mt-3 px-3 py-1.5 text-sm font-medium text-red-700 bg-white border border-red-300 rounded-md hover:bg-red-50"
+            >
+              再読み込み
+            </button>
           </div>
         ) : (
           <>

--- a/app/system-admin/analytics/tabs/MetricDefinitions.tsx
+++ b/app/system-admin/analytics/tabs/MetricDefinitions.tsx
@@ -75,10 +75,10 @@ export const METRIC_DEFINITIONS = {
             },
             {
                 key: 'dropoutRate',
-                label: '離脱率',
-                definition: '登録後に実質的な活動がないまま離脱したワーカーの割合（将来実装予定）',
-                calculation: '現在は0を返す（将来実装予定）',
-                usedIn: ['ワーカー分析', '施設分析']
+                label: '登録離脱率（未実装）',
+                definition: '登録後に実質的な活動がないまま離脱したワーカーの割合。現在は未実装のため、UI上は「-」で表示される',
+                calculation: '未実装。サーバー側は -1 をセンチネル値として返し、UI 側は「-」を表示する',
+                usedIn: ['ワーカー分析（未実装表示）', '施設分析（未実装表示）']
             }
         ]
     },
@@ -582,21 +582,21 @@ export const METRIC_DEFINITIONS = {
                 label: '平均評価閾値',
                 definition: 'この値以下の平均評価でアラートが発動する',
                 calculation: '通知設定で設定可能（デフォルト: 2.5）',
-                usedIn: ['ダッシュボード アラート']
+                usedIn: ['Dev Portal: 計算式管理（閾値設定）']
             },
             {
                 key: 'cancelRateThreshold',
                 label: 'キャンセル率閾値',
                 definition: 'この値を超えるキャンセル率でアラートが発動する',
                 calculation: '通知設定で設定可能（デフォルト: 30%）',
-                usedIn: ['ダッシュボード アラート']
+                usedIn: ['Dev Portal: 計算式管理（閾値設定）']
             },
             {
                 key: 'consecutiveLowRatingCount',
                 label: '連続低評価回数',
                 definition: 'この回数連続で低評価を受けるとアラートが発動する',
                 calculation: '通知設定で設定可能（デフォルト: 3回）',
-                usedIn: ['ダッシュボード アラート']
+                usedIn: ['Dev Portal: 計算式管理（閾値設定）']
             }
         ]
     }

--- a/app/system-admin/analytics/tabs/WorkerAnalytics.tsx
+++ b/app/system-admin/analytics/tabs/WorkerAnalytics.tsx
@@ -13,7 +13,7 @@ const METRIC_LABELS: Record<keyof Omit<WorkerMetrics, 'date'>, string> = {
     reviewAvg: 'レビュー平均点',
     cancelRate: 'キャンセル率(%)',
     lastMinuteCancelRate: '直前キャンセル率(%)',
-    dropoutRate: '登録離脱率(%)',
+    dropoutRate: '登録離脱率(%) (未実装)',
     withdrawalRate: '退会率(%)'
 };
 
@@ -137,7 +137,7 @@ export default function WorkerAnalytics() {
                                             </td>
                                             {Object.keys(METRIC_LABELS).map(key => (
                                                 <td key={key} className="px-4 py-3 text-sm text-slate-700 text-right">
-                                                    {row[key as keyof WorkerMetrics]}
+                                                    {key === 'dropoutRate' ? '-' : row[key as keyof WorkerMetrics]}
                                                 </td>
                                             ))}
                                         </tr>

--- a/src/lib/analytics-actions.ts
+++ b/src/lib/analytics-actions.ts
@@ -400,7 +400,7 @@ export async function getWorkerAnalyticsData(filter: AnalyticsFilter): Promise<W
             reviewAvg: Math.round(reviewAvg * 100) / 100,
             cancelRate: Math.round(cancelRate * 100) / 100,
             lastMinuteCancelRate: Math.round(lastMinuteCancelRate * 100) / 100,
-            dropoutRate: 0, // 将来実装
+            dropoutRate: -1, // 未実装。-1 を「データ未取得（UI 上は - 表示）」のセンチネル値として使用
             withdrawalRate: Math.round(withdrawalRate * 100) / 100
         };
     });
@@ -534,7 +534,7 @@ export async function getFacilityAnalyticsData(filter: AnalyticsFilter): Promise
             withdrawnCount,
             reviewCount,
             reviewAvg: Math.round(reviewAvg * 100) / 100,
-            dropoutRate: 0,
+            dropoutRate: -1, // 未実装。-1 を「データ未取得（UI 上は - 表示）」のセンチネル値として使用
             withdrawalRate: Math.round(withdrawalRate * 100) / 100,
             parentJobCount,
             parentJobInterviewCount,


### PR DESCRIPTION
## Summary
システム管理者のアナリティクスページで、「全指標一覧にはデータがあるが、その他のページでデータが空になっている箇所が多数ある」というレビュー依頼を受けて、コードベース全体の整合性を監査し、実際にバグだったものに絞って修正。

## 変更内容

### A. `MetricDefinitions` の `usedIn` フィールドを実態と一致させる
3つのアラート閾値指標が `usedIn: ['ダッシュボード アラート']` と書かれていたが、実際は \`app/system-admin/dev-portal/formulas/page.tsx\` でしか使われていなかったため、`['Dev Portal: 計算式管理（閾値設定）']` に更新。

### B. 離脱率 (`dropoutRate`) を「未実装」として明示
- `src/lib/analytics-actions.ts`: 戻り値を `0` → `-1` に変更（既存の `isUnavailable === -1` センチネル規約に準拠）
- `MetricDefinitions.tsx`: ラベル/説明を「未実装」明示に更新（データ表示は -1 → 自動で「-」表示）
- `WorkerAnalytics.tsx` / `FacilityAnalytics.tsx`: 列ヘッダーに「(未実装)」を付与、値を「-」表示

これまで全タブで「離脱率: 0%」と表示され、ユーザーが「データが0なのか未実装なのか」判別不能だった問題を解消。

### C. 沈黙の失敗を解消（LpTracking / FunnelAnalytics）
両タブとも catch ブロックが console.error のみで UI に何も表示せず、API失敗時にユーザーが「データが空」と誤認する状態だった。

- `LpTracking`: 4 本の fetch (`/api/lp-config`, `/api/lp-code-genres`, `/api/lp-tracking`, `/api/lp-tracking/public-jobs`) すべてで `res.ok` / `json.error` チェックを追加
- `FunnelAnalytics`: 同様にエラー検出 + setData(null) で残存データのクリア
- いずれも赤バナー + 再読み込みボタンを表示
- GA4Analytics は既に十分なエラー表示があるため変更なし

## Codex レビュー
事前レビュー実施済み。1stレビューで指摘された 2 critical（LpTrackingの残りfetchエラー処理 / dropoutRate の MetricDefinitions タブ表示）と 2 recommendation を全て解消。**最終評定: APPROVE**

## ユーザー向け効果
| 状況 | Before | After |
|---|---|---|
| 離脱率を見る | 「0%」と表示（実装済み？データなし？不明） | 「-」「(未実装)」明示 |
| LpTracking でAPI失敗 | 沈黙の空テーブル | 赤バナーで原因表示 + 再読み込みボタン |
| FunnelAnalytics でAPI失敗 | 「データの取得に失敗しました」のみ | エラー詳細 + 再読み込みボタン |
| 「全指標一覧」の usedIn | 一部が実態と不一致 | 修正済み |

## 影響範囲
6ファイル / +80 -16 行。型エラーなし（`npx tsc --noEmit -p .` で確認）。

## Test plan
- [ ] ステージング (https://stg-share-worker.vercel.app/system-admin/analytics) で全タブを表示し、レイアウト崩れなし
- [ ] ワーカー分析 / 施設分析 タブで「登録離脱率(%) (未実装)」列の値が「-」になっていること
- [ ] 全指標一覧タブのデータ表示でも離脱率が「-」になっていること
- [ ] 全指標一覧タブの離脱率ツールチップで「未実装」「UI上は -」が表示されていること
- [ ] 全指標一覧タブのアラート判定セクションで `usedIn` が「Dev Portal: 計算式管理（閾値設定）」になっていること
- [ ] LpTracking で意図的にネットワーク失敗 (DevTools の Offline) を起こし、赤バナーが表示されること
- [ ] FunnelAnalytics でも同様

🤖 Generated with [Claude Code](https://claude.com/claude-code)