### PR TITLE
バグ修正: 求人アナリティクスタブの 401 エラーを解消

### DIFF
--- a/app/api/funnel-analytics/route.ts
+++ b/app/api/funnel-analytics/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
+import { getSystemAdminSessionData } from '@/lib/system-admin-session-server';
 
 // JST日付文字列 (YYYY-MM-DD) を返す
 function toJSTDateStr(date: Date): string {
@@ -14,6 +15,12 @@ function toJSTMonthStr(date: Date): string {
 }
 
 export async function GET(request: NextRequest) {
+  // システム管理者認証チェック
+  const session = await getSystemAdminSessionData();
+  if (!session) {
+    return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+  }
+
   try {
     const { searchParams } = new URL(request.url);
     const startDate = searchParams.get('startDate');

--- a/app/api/job-analytics/route.ts
+++ b/app/api/job-analytics/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
+import { getSystemAdminSessionData } from '@/lib/system-admin-session-server';
 
 // JST日付文字列 (YYYY-MM-DD) を返す
 function toJSTDateStr(date: Date): string {
@@ -14,6 +15,12 @@ function toJSTMonthStr(date: Date): string {
 }
 
 export async function GET(request: NextRequest) {
+  // システム管理者認証チェック
+  const session = await getSystemAdminSessionData();
+  if (!session) {
+    return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+  }
+
   try {
     const { searchParams } = new URL(request.url);
     const startDate = searchParams.get('startDate');

--- a/app/system-admin/analytics/tabs/JobAnalytics.tsx
+++ b/app/system-admin/analytics/tabs/JobAnalytics.tsx
@@ -118,6 +118,7 @@ export default function JobAnalytics() {
   const [accessCustomBreakdown, setAccessCustomBreakdown] = useState<'daily' | 'monthly'>('daily');
   const [accessData, setAccessData] = useState<AnalyticsData | null>(null);
   const [accessLoading, setAccessLoading] = useState(true);
+  const [accessError, setAccessError] = useState<string | null>(null);
 
   // === 求人ランキングの状態 ===
   const [rankingMode, setRankingMode] = useState<RankingPeriodMode>('month');
@@ -125,6 +126,7 @@ export default function JobAnalytics() {
   const [rankingCustomEnd, setRankingCustomEnd] = useState('');
   const [rankingData, setRankingData] = useState<AnalyticsData | null>(null);
   const [rankingLoading, setRankingLoading] = useState(true);
+  const [rankingError, setRankingError] = useState<string | null>(null);
   const [activeOnly, setActiveOnly] = useState(false);
 
   // 求人ランキングソート
@@ -181,6 +183,7 @@ export default function JobAnalytics() {
   // === アクセス状況のデータ取得 ===
   const fetchAccessData = useCallback(async () => {
     setAccessLoading(true);
+    setAccessError(null);
     try {
       const { startDate, endDate, breakdown } = getAccessDateRange();
       if (!startDate || !endDate) {
@@ -189,10 +192,24 @@ export default function JobAnalytics() {
       }
       const params = new URLSearchParams({ startDate, endDate, breakdown });
       const res = await fetch(`/api/job-analytics?${params}`);
-      const json = await res.json();
-      setAccessData(json);
+      let json: unknown = null;
+      try {
+        json = await res.json();
+      } catch {
+        // 非JSONレスポンス（ログインHTML等）
+      }
+      const errorDetail = (json as { error?: string } | null)?.error;
+      if (!res.ok || errorDetail || !json) {
+        if (errorDetail) {
+          console.error('[job-analytics] API error detail:', errorDetail);
+        }
+        throw new Error(`求人アクセスデータの取得に失敗しました (HTTP ${res.status})`);
+      }
+      setAccessData(json as AnalyticsData);
     } catch (error) {
       console.error('Failed to fetch access data:', error);
+      setAccessError(error instanceof Error ? error.message : 'データの取得中に予期しないエラーが発生しました');
+      setAccessData(null);
     } finally {
       setAccessLoading(false);
     }
@@ -201,6 +218,7 @@ export default function JobAnalytics() {
   // === 求人ランキングのデータ取得 ===
   const fetchRankingData = useCallback(async () => {
     setRankingLoading(true);
+    setRankingError(null);
     try {
       const { startDate, endDate } = getRankingDateRange();
       if (!startDate || !endDate) {
@@ -210,10 +228,24 @@ export default function JobAnalytics() {
       const params = new URLSearchParams({ startDate, endDate });
       if (activeOnly) params.set('activeOnly', 'true');
       const res = await fetch(`/api/job-analytics?${params}`);
-      const json = await res.json();
-      setRankingData(json);
+      let json: unknown = null;
+      try {
+        json = await res.json();
+      } catch {
+        // 非JSONレスポンス（ログインHTML等）
+      }
+      const errorDetail = (json as { error?: string } | null)?.error;
+      if (!res.ok || errorDetail || !json) {
+        if (errorDetail) {
+          console.error('[job-analytics] API error detail:', errorDetail);
+        }
+        throw new Error(`求人ランキングデータの取得に失敗しました (HTTP ${res.status})`);
+      }
+      setRankingData(json as AnalyticsData);
     } catch (error) {
       console.error('Failed to fetch ranking data:', error);
+      setRankingError(error instanceof Error ? error.message : 'データの取得中に予期しないエラーが発生しました');
+      setRankingData(null);
     } finally {
       setRankingLoading(false);
     }
@@ -388,8 +420,22 @@ export default function JobAnalytics() {
           </div>
         )}
 
+        {/* エラー表示 */}
+        {!accessLoading && accessError && (
+          <div className="bg-red-50 border border-red-200 rounded-lg p-4 m-4">
+            <p className="text-sm font-medium text-red-800 mb-1">データを取得できませんでした</p>
+            <p className="text-sm text-red-700">{accessError}</p>
+            <button
+              onClick={fetchAccessData}
+              className="mt-3 px-3 py-1.5 text-sm font-medium text-red-700 bg-white border border-red-300 rounded-md hover:bg-red-50"
+            >
+              再読み込み
+            </button>
+          </div>
+        )}
+
         {/* アクセス状況テーブル */}
-        {!accessLoading && accessData && (
+        {!accessLoading && !accessError && accessData && (
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
@@ -513,7 +559,21 @@ export default function JobAnalytics() {
           </div>
         )}
 
-        {!rankingLoading && rankingData && (
+        {/* エラー表示 */}
+        {!rankingLoading && rankingError && (
+          <div className="bg-red-50 border border-red-200 rounded-lg p-4 m-4">
+            <p className="text-sm font-medium text-red-800 mb-1">データを取得できませんでした</p>
+            <p className="text-sm text-red-700">{rankingError}</p>
+            <button
+              onClick={fetchRankingData}
+              className="mt-3 px-3 py-1.5 text-sm font-medium text-red-700 bg-white border border-red-300 rounded-md hover:bg-red-50"
+            >
+              再読み込み
+            </button>
+          </div>
+        )}
+
+        {!rankingLoading && !rankingError && rankingData && (
           <>
             {sortedJobRanking.length === 0 ? (
               <div className="p-8 text-center text-slate-400 text-sm">
@@ -598,12 +658,6 @@ export default function JobAnalytics() {
         )}
       </div>
 
-      {/* データなし */}
-      {!accessLoading && !accessData && !rankingLoading && !rankingData && (
-        <div className="text-center py-12 text-slate-400">
-          データの取得に失敗しました
-        </div>
-      )}
     </div>
   );
 }

--- a/app/system-admin/analytics/tabs/MetricDefinitions.tsx
+++ b/app/system-admin/analytics/tabs/MetricDefinitions.tsx
@@ -1025,7 +1025,18 @@ export default function MetricDefinitions() {
             } else if (sectionId === 'jobAnalytics') {
                 const params = new URLSearchParams({ startDate, endDate, breakdown });
                 const res = await fetch(`/api/job-analytics?${params}`);
-                const json = await res.json();
+                let json: any = null; // eslint-disable-line @typescript-eslint/no-explicit-any
+                try {
+                    json = await res.json();
+                } catch {
+                    // 非JSONレスポンス（ログインHTML等）
+                }
+                if (!res.ok || json?.error || !json) {
+                    if (json?.error) {
+                        console.error('[job-analytics] API error detail:', json.error);
+                    }
+                    throw new Error(`求人分析データの取得に失敗しました (HTTP ${res.status})`);
+                }
 
                 if (json.breakdown && json.breakdown.length > 0) {
                     dateColumns = json.breakdown.map((r: Record<string, unknown>) => r.period as string);
@@ -1040,7 +1051,18 @@ export default function MetricDefinitions() {
                 const sourceParam = selectedSources.length === 0 ? 'all' : selectedSources.join(',');
                 const params = new URLSearchParams({ startDate, endDate, breakdown, source: sourceParam });
                 const res = await fetch(`/api/funnel-analytics?${params}`);
-                const json = await res.json();
+                let json: any = null; // eslint-disable-line @typescript-eslint/no-explicit-any
+                try {
+                    json = await res.json();
+                } catch {
+                    // 非JSONレスポンス（ログインHTML等）
+                }
+                if (!res.ok || json?.error || !json) {
+                    if (json?.error) {
+                        console.error('[funnel-analytics] API error detail:', json.error);
+                    }
+                    throw new Error(`登録動線データの取得に失敗しました (HTTP ${res.status})`);
+                }
 
                 // LP一覧をレスポンスから取得
                 if (json.lpSources && json.lpSources.length > 0) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -72,6 +72,9 @@ const ignoredPaths = [
   '/api/cron', // Cron API（Vercel CronがCRON_SECRET認証を使用）
   '/api/upload', // アップロードAPI（API側で独自認証を実施）
   '/api/sms', // SMS認証API（新規登録時に未ログインで使用）
+  '/api/job-analytics', // 求人アナリティクスAPI（API側で system-admin 認証を実施）
+  '/api/funnel-analytics', // 登録動線アナリティクスAPI（API側で system-admin 認証を実施）
+  '/api/ga-analytics', // GA4 アナリティクスAPI（API側で system-admin 認証を実施）
   '/rogo', // ロゴ画像
   '/images', // 画像ファイル
   '/icons', // アイコン


### PR DESCRIPTION
## 概要

system-admin の「アナリティクス → 求人」タブで `Unexpected token '<', '<!DOCTYPE...'` エラーが発生し、データが表示できない問題を修正します。

## 原因

- `/api/job-analytics` と `/api/funnel-analytics` は middleware の `ignoredPaths` にもなく、`/api/system-admin/*` バイパスにも該当しないため、NextAuth JWT を要求していた
- system-admin は独自セッション (`getSystemAdminSessionData`) を使うため JWT を持たず、middleware が `/login` へ 307 リダイレクト → HTML が返って `res.json()` が失敗
- さらに両ルートには内部認証チェックも無く、middleware に依存していたためセキュリティ上の穴にもなっていた

## 修正内容

### サーバー側
- **middleware.ts**: `ignoredPaths` に `/api/job-analytics`, `/api/funnel-analytics`, `/api/ga-analytics` を追加（既存 `/api/ga-analytics` の挙動と統一）
- **app/api/job-analytics/route.ts**, **app/api/funnel-analytics/route.ts**: `GET` 冒頭で `getSystemAdminSessionData()` による 401 チェックを追加

### クライアント側（401 を適切にハンドリング）
- **app/system-admin/analytics/tabs/JobAnalytics.tsx**: `res.ok` / `json.error` を確認し、エラー時は赤バナー + 再読み込みボタン（`FunnelAnalytics` と同パターン）
- **app/system-admin/analytics/tabs/MetricDefinitions.tsx**: jobAnalytics / funnel セクションの fetch にも `res.ok` / `json.error` チェック追加（以前は 401 が「全 0 件」として表示される沈黙の失敗だった）

## レビュー

Codex Code Reviewer による2ラウンド事前レビュー実施:
1. 1回目: REQUEST CHANGES — JobAnalytics と MetricDefinitions のクライアント側エラーハンドリング不足を指摘
2. 2回目: APPROVE — 修正後

## Test plan
- [ ] ステージング環境（develop マージ後）でログインし `/system-admin/analytics` の「求人」タブを開いてデータが表示されることを確認
- [ ] 「指標定義」タブの「求人分析」「登録動線」セクションがデータを表示することを確認
- [ ] 401 を強制した場合に赤バナーが表示され、再読み込みで復帰することを確認
- [ ] 既存の LP トラッキング・GA4・登録動線タブが引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)