### PR TITLE
セキュリティ/バグ修正: アナリティクス各タブの認証ゲート追加とエラーハンドリング統一

### DIFF
--- a/app/api/lp-code-genres/route.ts
+++ b/app/api/lp-code-genres/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
+import { getSystemAdminSessionData } from '@/lib/system-admin-session-server';
 
 // デフォルトジャンル（初回シード用）
 const DEFAULT_GENRES = [
@@ -39,6 +40,12 @@ function getNextPrefix(lastPrefix: string | null): string {
 
 // GET: ジャンル一覧を取得
 export async function GET() {
+  // システム管理者認証チェック
+  const session = await getSystemAdminSessionData();
+  if (!session) {
+    return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+  }
+
   try {
     let genres = await prisma.lpCodeGenre.findMany({
       orderBy: { sort_order: 'asc' },
@@ -66,6 +73,12 @@ export async function GET() {
 
 // POST: ジャンルの作成・更新・削除
 export async function POST(request: NextRequest) {
+  // システム管理者認証チェック
+  const session = await getSystemAdminSessionData();
+  if (!session) {
+    return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+  }
+
   try {
     const body = await request.json();
     const { action, id, name, prefix } = body;

--- a/app/api/lp-tracking/public-jobs/route.ts
+++ b/app/api/lp-tracking/public-jobs/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import prisma from '@/lib/prisma';
+import { getSystemAdminSessionData } from '@/lib/system-admin-session-server';
 
 const LP_ID = '0';
 
@@ -16,6 +17,12 @@ function toJSTMonthStr(date: Date): string {
 }
 
 export async function GET(request: NextRequest) {
+  // システム管理者認証チェック
+  const session = await getSystemAdminSessionData();
+  if (!session) {
+    return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+  }
+
   try {
     const { searchParams } = new URL(request.url);
     const startDate = searchParams.get('startDate');

--- a/app/system-admin/analytics/tabs/FacilityAnalytics.tsx
+++ b/app/system-admin/analytics/tabs/FacilityAnalytics.tsx
@@ -23,11 +23,13 @@ export default function FacilityAnalytics() {
     const { showDebugError } = useDebugError();
     const [data, setData] = useState<FacilityMetrics[]>([]);
     const [loading, setLoading] = useState(true);
+    const [fetchError, setFetchError] = useState<string | null>(null);
     const [viewMode, setViewMode] = useState<'daily' | 'monthly'>('daily');
     const [currentFilters, setCurrentFilters] = useState<any>({});
 
     const fetchData = async (filterValues?: any) => {
         setLoading(true);
+        setFetchError(null);
         const filtersToUse = filterValues || currentFilters;
         if (filterValues) {
             setCurrentFilters(filterValues);
@@ -54,6 +56,8 @@ export default function FacilityAnalytics() {
                 context: { viewMode, filtersToUse }
             });
             console.error('Failed to fetch facility analytics:', error);
+            setFetchError(error instanceof Error ? error.message : '施設分析データの取得に失敗しました');
+            setData([]);
         } finally {
             setLoading(false);
         }
@@ -106,6 +110,17 @@ export default function FacilityAnalytics() {
                 {loading ? (
                     <div className="flex justify-center py-20">
                         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600"></div>
+                    </div>
+                ) : fetchError ? (
+                    <div className="bg-red-50 border border-red-200 rounded-lg p-4 m-4">
+                        <p className="text-sm font-medium text-red-800 mb-1">データを取得できませんでした</p>
+                        <p className="text-sm text-red-700">{fetchError}</p>
+                        <button
+                            onClick={() => fetchData()}
+                            className="mt-3 px-3 py-1.5 text-sm font-medium text-red-700 bg-white border border-red-300 rounded-md hover:bg-red-50"
+                        >
+                            再読み込み
+                        </button>
                     </div>
                 ) : (
                     <div className="overflow-x-auto">

--- a/app/system-admin/analytics/tabs/GA4Analytics.tsx
+++ b/app/system-admin/analytics/tabs/GA4Analytics.tsx
@@ -49,11 +49,16 @@ export default function GA4Analytics() {
     const res = await fetch(
       `/api/ga-analytics?reportType=${reportType}&startDate=${startDate}&endDate=${endDate}`
     );
-    if (!res.ok) {
-      const err = await res.json().catch(() => ({}));
-      throw new Error(err.error || `GA4 API error: ${res.status}`);
+    let json: any = null; // eslint-disable-line @typescript-eslint/no-explicit-any
+    try {
+      json = await res.json();
+    } catch {
+      // 非JSONレスポンス（ログインHTML等）
     }
-    return res.json();
+    if (!res.ok || json?.error || !json) {
+      throw new Error(json?.error || `GA4 API error: ${res.status}`);
+    }
+    return json;
   }, [getDateRange]);
 
   const loadData = useCallback(async () => {
@@ -163,7 +168,15 @@ export default function GA4Analytics() {
       {error && (
         <div className="bg-red-50 border border-red-200 rounded-lg p-4 flex items-start gap-2">
           <AlertTriangle className="w-4 h-4 text-red-500 mt-0.5 shrink-0" />
-          <p className="text-sm text-red-700">{error}</p>
+          <div className="flex-1">
+            <p className="text-sm text-red-700">{error}</p>
+            <button
+              onClick={loadData}
+              className="mt-2 px-3 py-1 text-xs font-medium text-red-700 bg-white border border-red-300 rounded-md hover:bg-red-50"
+            >
+              再読み込み
+            </button>
+          </div>
         </div>
       )}
 

--- a/app/system-admin/analytics/tabs/MatchingAnalytics.tsx
+++ b/app/system-admin/analytics/tabs/MatchingAnalytics.tsx
@@ -38,12 +38,14 @@ export default function MatchingAnalytics() {
         avgJobMatchingPeriod: number;
     } | null>(null);
     const [loading, setLoading] = useState(true);
+    const [fetchError, setFetchError] = useState<string | null>(null);
     const [viewMode, setViewMode] = useState<'daily' | 'monthly'>('daily');
     const [visibleMetrics, setVisibleMetrics] = useState({ worker: true, facility: true });
     const [currentFilters, setCurrentFilters] = useState<any>({});
 
     const fetchData = async (filterValues?: any) => {
         setLoading(true);
+        setFetchError(null);
         const filtersToUse = filterValues || currentFilters;
         if (filterValues) {
             setCurrentFilters(filterValues);
@@ -89,6 +91,9 @@ export default function MatchingAnalytics() {
                 context: { viewMode, filtersToUse }
             });
             console.error('Failed to fetch matching analytics:', error);
+            setFetchError(error instanceof Error ? error.message : 'マッチング分析データの取得に失敗しました');
+            setData([]);
+            setPeriodStats(null);
         } finally {
             setLoading(false);
         }
@@ -183,6 +188,17 @@ export default function MatchingAnalytics() {
                 {loading ? (
                     <div className="flex justify-center py-20">
                         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600"></div>
+                    </div>
+                ) : fetchError ? (
+                    <div className="bg-red-50 border border-red-200 rounded-lg p-4 m-4">
+                        <p className="text-sm font-medium text-red-800 mb-1">データを取得できませんでした</p>
+                        <p className="text-sm text-red-700">{fetchError}</p>
+                        <button
+                            onClick={() => fetchData()}
+                            className="mt-3 px-3 py-1.5 text-sm font-medium text-red-700 bg-white border border-red-300 rounded-md hover:bg-red-50"
+                        >
+                            再読み込み
+                        </button>
                     </div>
                 ) : (
                     <div className="overflow-x-auto">

--- a/app/system-admin/analytics/tabs/PublicJobsTracking.tsx
+++ b/app/system-admin/analytics/tabs/PublicJobsTracking.tsx
@@ -146,6 +146,7 @@ export default function PublicJobsTracking() {
   const [accessCustomBreakdown, setAccessCustomBreakdown] = useState<'daily' | 'monthly'>('daily');
   const [accessData, setAccessData] = useState<TrackingData | null>(null);
   const [accessLoading, setAccessLoading] = useState(true);
+  const [accessError, setAccessError] = useState<string | null>(null);
   const [expandedCodes, setExpandedCodes] = useState(false);
 
   // === 求人ランキングの状態 ===
@@ -154,6 +155,7 @@ export default function PublicJobsTracking() {
   const [rankingCustomEnd, setRankingCustomEnd] = useState('');
   const [rankingData, setRankingData] = useState<TrackingData | null>(null);
   const [rankingLoading, setRankingLoading] = useState(true);
+  const [rankingError, setRankingError] = useState<string | null>(null);
 
   // ジャンルフィルター
   const [genres, setGenres] = useState<Genre[]>([]);
@@ -165,12 +167,24 @@ export default function PublicJobsTracking() {
 
   // ジャンル一覧を取得
   useEffect(() => {
-    fetch('/api/lp-code-genres')
-      .then(res => res.json())
-      .then(data => {
+    (async () => {
+      try {
+        const res = await fetch('/api/lp-code-genres');
+        let data: any = null; // eslint-disable-line @typescript-eslint/no-explicit-any
+        try {
+          data = await res.json();
+        } catch {
+          // 非JSONレスポンス（ログインHTML等）
+        }
+        if (!res.ok || data?.error || !data) {
+          console.error('[lp-code-genres] failed to fetch:', data?.error || res.status);
+          return;
+        }
         if (data.genres) setGenres(data.genres);
-      })
-      .catch(() => {});
+      } catch (error) {
+        console.error('Failed to fetch genres:', error);
+      }
+    })();
   }, []);
 
   // === アクセス状況の日付範囲計算 ===
@@ -223,6 +237,7 @@ export default function PublicJobsTracking() {
   // === アクセス状況のデータ取得 ===
   const fetchAccessData = useCallback(async () => {
     setAccessLoading(true);
+    setAccessError(null);
     try {
       const { startDate, endDate, breakdown } = getAccessDateRange();
       if (!startDate || !endDate) {
@@ -232,10 +247,23 @@ export default function PublicJobsTracking() {
       const params = new URLSearchParams({ startDate, endDate, breakdown });
       if (selectedGenre) params.set('genrePrefix', selectedGenre);
       const res = await fetch(`/api/lp-tracking/public-jobs?${params}`);
-      const json = await res.json();
+      let json: any = null; // eslint-disable-line @typescript-eslint/no-explicit-any
+      try {
+        json = await res.json();
+      } catch {
+        // 非JSONレスポンス（ログインHTML等）
+      }
+      if (!res.ok || json?.error || !json) {
+        if (json?.error) {
+          console.error('[public-jobs] API error detail:', json.error);
+        }
+        throw new Error(`公開求人アクセスデータの取得に失敗しました (HTTP ${res.status})`);
+      }
       setAccessData(json);
     } catch (error) {
       console.error('Failed to fetch access data:', error);
+      setAccessError(error instanceof Error ? error.message : 'データの取得中に予期しないエラーが発生しました');
+      setAccessData(null);
     } finally {
       setAccessLoading(false);
     }
@@ -244,6 +272,7 @@ export default function PublicJobsTracking() {
   // === 求人ランキングのデータ取得 ===
   const fetchRankingData = useCallback(async () => {
     setRankingLoading(true);
+    setRankingError(null);
     try {
       const { startDate, endDate } = getRankingDateRange();
       if (!startDate || !endDate) {
@@ -253,10 +282,23 @@ export default function PublicJobsTracking() {
       const params = new URLSearchParams({ startDate, endDate });
       if (selectedGenre) params.set('genrePrefix', selectedGenre);
       const res = await fetch(`/api/lp-tracking/public-jobs?${params}`);
-      const json = await res.json();
+      let json: any = null; // eslint-disable-line @typescript-eslint/no-explicit-any
+      try {
+        json = await res.json();
+      } catch {
+        // 非JSONレスポンス（ログインHTML等）
+      }
+      if (!res.ok || json?.error || !json) {
+        if (json?.error) {
+          console.error('[public-jobs] API error detail:', json.error);
+        }
+        throw new Error(`公開求人ランキングデータの取得に失敗しました (HTTP ${res.status})`);
+      }
       setRankingData(json);
     } catch (error) {
       console.error('Failed to fetch ranking data:', error);
+      setRankingError(error instanceof Error ? error.message : 'データの取得中に予期しないエラーが発生しました');
+      setRankingData(null);
     } finally {
       setRankingLoading(false);
     }
@@ -464,8 +506,22 @@ export default function PublicJobsTracking() {
           </div>
         )}
 
+        {/* エラー表示 */}
+        {!accessLoading && accessError && (
+          <div className="bg-red-50 border border-red-200 rounded-lg p-4 m-4">
+            <p className="text-sm font-medium text-red-800 mb-1">データを取得できませんでした</p>
+            <p className="text-sm text-red-700">{accessError}</p>
+            <button
+              onClick={fetchAccessData}
+              className="mt-3 px-3 py-1.5 text-sm font-medium text-red-700 bg-white border border-red-300 rounded-md hover:bg-red-50"
+            >
+              再読み込み
+            </button>
+          </div>
+        )}
+
         {/* アクセス状況テーブル */}
-        {!accessLoading && accessData && (
+        {!accessLoading && !accessError && accessData && (
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
               <thead>
@@ -626,7 +682,21 @@ export default function PublicJobsTracking() {
           </div>
         )}
 
-        {!rankingLoading && rankingData && (
+        {/* エラー表示 */}
+        {!rankingLoading && rankingError && (
+          <div className="bg-red-50 border border-red-200 rounded-lg p-4 m-4">
+            <p className="text-sm font-medium text-red-800 mb-1">データを取得できませんでした</p>
+            <p className="text-sm text-red-700">{rankingError}</p>
+            <button
+              onClick={fetchRankingData}
+              className="mt-3 px-3 py-1.5 text-sm font-medium text-red-700 bg-white border border-red-300 rounded-md hover:bg-red-50"
+            >
+              再読み込み
+            </button>
+          </div>
+        )}
+
+        {!rankingLoading && !rankingError && rankingData && (
           <>
             {sortedJobRanking.length === 0 ? (
               <div className="p-8 text-center text-slate-400 text-sm">
@@ -698,12 +768,6 @@ export default function PublicJobsTracking() {
         )}
       </div>
 
-      {/* データなし */}
-      {!accessLoading && !accessData && !rankingLoading && !rankingData && (
-        <div className="text-center py-12 text-slate-400">
-          データの取得に失敗しました
-        </div>
-      )}
     </div>
   );
 }

--- a/app/system-admin/analytics/tabs/WorkerAnalytics.tsx
+++ b/app/system-admin/analytics/tabs/WorkerAnalytics.tsx
@@ -21,11 +21,13 @@ export default function WorkerAnalytics() {
     const { showDebugError } = useDebugError();
     const [data, setData] = useState<WorkerMetrics[]>([]);
     const [loading, setLoading] = useState(true);
+    const [fetchError, setFetchError] = useState<string | null>(null);
     const [viewMode, setViewMode] = useState<'daily' | 'monthly'>('daily');
     const [currentFilters, setCurrentFilters] = useState<any>({});
 
     const fetchData = async (filterValues?: any) => {
         setLoading(true);
+        setFetchError(null);
         const filtersToUse = filterValues || currentFilters;
         if (filterValues) {
             setCurrentFilters(filterValues);
@@ -54,6 +56,8 @@ export default function WorkerAnalytics() {
                 context: { viewMode, filtersToUse }
             });
             console.error('Failed to fetch worker analytics:', error);
+            setFetchError(error instanceof Error ? error.message : 'ワーカー分析データの取得に失敗しました');
+            setData([]);
         } finally {
             setLoading(false);
         }
@@ -106,6 +110,17 @@ export default function WorkerAnalytics() {
                 {loading ? (
                     <div className="flex justify-center py-20">
                         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600"></div>
+                    </div>
+                ) : fetchError ? (
+                    <div className="bg-red-50 border border-red-200 rounded-lg p-4 m-4">
+                        <p className="text-sm font-medium text-red-800 mb-1">データを取得できませんでした</p>
+                        <p className="text-sm text-red-700">{fetchError}</p>
+                        <button
+                            onClick={() => fetchData()}
+                            className="mt-3 px-3 py-1.5 text-sm font-medium text-red-700 bg-white border border-red-300 rounded-md hover:bg-red-50"
+                        >
+                            再読み込み
+                        </button>
                     </div>
                 ) : (
                     <div className="overflow-x-auto">

--- a/src/lib/analytics-actions.ts
+++ b/src/lib/analytics-actions.ts
@@ -1,6 +1,7 @@
 'use server';
 
 import { prisma } from '@/lib/prisma';
+import { requireSystemAdminAuth } from '@/lib/system-admin-session-server';
 import {
     startOfMonth, endOfMonth, startOfYear, endOfYear,
     format, eachDayOfInterval, eachMonthOfInterval, differenceInHours
@@ -239,6 +240,7 @@ async function getRegionWhere(regionId: number | undefined) {
 // ========== ワーカー分析 ==========
 
 export async function getWorkerAnalyticsData(filter: AnalyticsFilter): Promise<WorkerMetrics[]> {
+    await requireSystemAdminAuth();
     const { dateList, dateFormat } = getDateRanges(filter);
     const periodWhere = getPeriodWhere(filter);
     const regionWhere = await getRegionWhere(filter.regionId);
@@ -411,6 +413,7 @@ export async function getWorkerAnalyticsData(filter: AnalyticsFilter): Promise<W
 // ========== 施設分析 ==========
 
 export async function getFacilityAnalyticsData(filter: AnalyticsFilter): Promise<FacilityMetrics[]> {
+    await requireSystemAdminAuth();
     const { dateList, dateFormat } = getDateRanges(filter);
     const periodWhere = getPeriodWhere(filter);
     const regionWhere = await getRegionWhere(filter.regionId);
@@ -549,6 +552,7 @@ export async function getFacilityAnalyticsData(filter: AnalyticsFilter): Promise
 // ========== 応募・マッチング分析 ==========
 
 export async function getMatchingAnalyticsData(filter: AnalyticsFilter): Promise<MatchingMetrics[]> {
+    await requireSystemAdminAuth();
     const { dateList, dateFormat } = getDateRanges(filter);
     const periodWhere = getPeriodWhere(filter);
     const regionWhere = await getRegionWhere(filter.regionId);

--- a/src/lib/system-actions.ts
+++ b/src/lib/system-actions.ts
@@ -1459,6 +1459,7 @@ export async function sendPasswordResetEmail(facilityAdminId: number) {
  * マッチング期間統計を取得（アナリティクス用）
  */
 export async function getMatchingPeriodStats(facilityId?: number) {
+    await requireSystemAdminAuth();
     const whereClause = facilityId ? { facility_id: facilityId } : {};
 
     // Applicationベース（応募マッチング期間）


### PR DESCRIPTION
## 概要

Codex Code Reviewer による監査の結果、アナリティクス各タブ（Worker / Facility / Matching / GA4 / PublicJobsTracking）に以下の問題が見つかったため一括で修正します。

1. **セキュリティ**: 各タブを支える Server Action / API ルートに system-admin 認証チェックが無く、未認証で分析データが取得できる状態だった
2. **沈黙の失敗**: クライアント側は失敗時に dev-only debug バナーしか出さず、本番では空テーブル/「データがありません」表示でユーザーが原因に気づけなかった
3. **クラッシュリスク**: PublicJobsTracking はエラー JSON を成功データとして state に格納しており、`.toLocaleString()` 等の参照で実行時クラッシュしうる状態だった

## 修正内容

### サーバーアクションの認証ゲート追加
- `src/lib/analytics-actions.ts`: `requireSystemAdminAuth()` を import し、`getWorkerAnalyticsData` / `getFacilityAnalyticsData` / `getMatchingAnalyticsData` の冒頭で呼び出し
- `src/lib/system-actions.ts`: `getMatchingPeriodStats` の冒頭で呼び出し

### API ルートの内部認証チェック追加
- `app/api/lp-tracking/public-jobs/route.ts`: GET 冒頭で `getSystemAdminSessionData()` 401 ガード
- `app/api/lp-code-genres/route.ts`: GET / POST 両方に同 401 ガード（呼び出し元はすべて system-admin 配下のため公開 API への影響なし）

### クライアント側エラー UI 統一（FunnelAnalytics の赤バナー + 再読み込みパターン）
- **WorkerAnalytics / FacilityAnalytics / MatchingAnalytics**: `fetchError` state を追加し、catch でセット + 古いデータをクリア。読み込み失敗時は赤バナー + 再読み込みボタン
- **GA4Analytics**: `fetchReport` で `json.error || !json` も検査。既存のエラーバナーに再読み込みボタンを追加
- **PublicJobsTracking**:
  - ジャンル fetch も `res.ok` / `json.error` / 非JSON を判定
  - アクセス / ランキング両方に `accessError` / `rankingError` を追加し、エラー時は per-section 赤バナー + 再読み込み
  - エラー JSON を state に入れない（クラッシュ防止）

## レビュー

Codex Code Reviewer による2ラウンド事前レビュー実施:
- 1回目（監査）: 4ファイル REJECT、1ファイル REQUEST CHANGES
- 2回目（修正後）: **9ファイル全 APPROVE**

## スコープ外（別PR候補）

- Stale-response protection (`AbortController` / request-id token) — Codex から推奨されたが、変更が広範になるため本PRでは見送り

## Test plan
- [ ] ステージング環境で各タブ（求人 / ワーカー / 施設 / マッチング / GA4 / 公開求人 / 登録動線 / LP / 指標定義）が正しく表示されることを確認
- [ ] system-admin セッションが切れた状態で各 API を直接叩き、401 が返ることを確認
- [ ] 各タブで意図的にエラーを起こし、赤バナー + 再読み込みボタンが機能することを確認
- [ ] LP 管理画面（`/system-admin/lp`）の `/api/lp-code-genres` 利用箇所（LPList / GenreEditModal / GenreSelectModal / DBLPList / genres ページ）が引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)