### PR TITLE
バグ修正: 求人テンプレートの削除がDBに反映されない問題を修正

### DIFF
--- a/app/admin/jobs/templates/page.tsx
+++ b/app/admin/jobs/templates/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useAuth } from '@/contexts/AuthContext';
-import { getAdminJobTemplates, duplicateJobTemplate } from '@/src/lib/actions';
+import { getAdminJobTemplates, duplicateJobTemplate, deleteJobTemplate } from '@/src/lib/actions';
 import { Plus, Edit, Trash2, Copy } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { useDebugError, extractDebugInfo } from '@/components/debug/DebugErrorBanner';
@@ -174,9 +174,26 @@ export default function TemplatesPage() {
                         <Copy className="w-4 h-4" />
                       </button>
                       <button
-                        onClick={() => {
-                          if (confirm('このテンプレートを削除しますか？')) {
-                            toast.success('テンプレートを削除しました');
+                        onClick={async () => {
+                          if (!admin?.facilityId) {
+                            toast.error('施設情報が取得できませんでした。再ログインしてください');
+                            return;
+                          }
+                          if (!confirm(`「${template.name}」を削除しますか？\nこのテンプレートから作成済みの求人は残りますが、テンプレートとの紐付けは解除されます。`)) {
+                            return;
+                          }
+                          try {
+                            const result = await deleteJobTemplate(template.id, admin.facilityId);
+                            if (result.success) {
+                              toast.success('テンプレートを削除しました');
+                              const data = await getAdminJobTemplates(admin.facilityId);
+                              setTemplates(data);
+                            } else {
+                              toast.error(result.error || 'テンプレートの削除に失敗しました');
+                            }
+                          } catch (error) {
+                            console.error('Failed to delete template:', error);
+                            toast.error('テンプレートの削除に失敗しました');
                           }
                         }}
                         className="p-2 text-red-600 hover:bg-red-50 rounded transition-colors"

--- a/src/lib/actions/job-template.ts
+++ b/src/lib/actions/job-template.ts
@@ -3,7 +3,7 @@
 import { prisma } from '@/lib/prisma';
 import { revalidatePath } from 'next/cache';
 import { logActivity, getErrorMessage, getErrorStack } from '@/lib/logger';
-import { getFacilityAdminSessionData } from '@/lib/admin-session-server';
+import { getFacilityAdminSessionData, validateFacilityAccess } from '@/lib/admin-session-server';
 
 /**
  * 管理者用: 施設に属する全ての求人テンプレートを取得
@@ -430,6 +430,107 @@ export async function updateJobTemplate(
         return {
             success: false,
             error: 'テンプレートの更新に失敗しました',
+        };
+    }
+}
+
+/**
+ * 管理者用: 求人テンプレートを削除
+ * 依存する Job レコードの template_id を NULL に切り離してから削除する。
+ */
+export async function deleteJobTemplate(templateId: number, facilityId: number) {
+    // 入力バリデーション
+    if (!Number.isInteger(templateId) || templateId <= 0) {
+        return { success: false, error: '不正なテンプレートIDです' };
+    }
+    if (!Number.isInteger(facilityId) || facilityId <= 0) {
+        return { success: false, error: '不正な施設IDです' };
+    }
+
+    // 認可: セッションのfacility_idと一致するか検証
+    const access = await validateFacilityAccess(facilityId);
+    if (!access.valid) {
+        return {
+            success: false,
+            error: access.error === 'unauthorized'
+                ? '認証が必要です'
+                : 'この施設にアクセスする権限がありません',
+        };
+    }
+    const session = access.session;
+
+    try {
+        // 権限確認: 同じ施設のテンプレートか
+        const existingTemplate = await prisma.jobTemplate.findFirst({
+            where: {
+                id: templateId,
+                facility_id: facilityId,
+            },
+        });
+
+        if (!existingTemplate) {
+            return {
+                success: false,
+                error: 'テンプレートが見つからないか、アクセス権限がありません',
+            };
+        }
+
+        // 依存する Job の template_id を NULL に切り離してから削除
+        await prisma.$transaction([
+            prisma.job.updateMany({
+                where: { template_id: templateId },
+                data: { template_id: null },
+            }),
+            prisma.jobTemplate.delete({
+                where: { id: templateId },
+            }),
+        ]);
+
+        console.log('[deleteJobTemplate] Template deleted:', templateId);
+
+        revalidatePath('/admin/jobs/templates');
+
+        // ログ記録
+        logActivity({
+            userType: 'FACILITY',
+            userId: session?.adminId,
+            userEmail: session?.email,
+            action: 'JOB_TEMPLATE_DELETE',
+            targetType: 'JobTemplate',
+            targetId: templateId,
+            requestData: {
+                facilityId,
+                name: existingTemplate.name,
+                title: existingTemplate.title,
+            },
+            result: 'SUCCESS',
+        }).catch(() => {});
+
+        return {
+            success: true,
+        };
+    } catch (error) {
+        console.error('[deleteJobTemplate] Error:', error);
+
+        // エラーログ記録
+        logActivity({
+            userType: 'FACILITY',
+            userId: session?.adminId,
+            userEmail: session?.email,
+            action: 'JOB_TEMPLATE_DELETE',
+            targetType: 'JobTemplate',
+            targetId: templateId,
+            requestData: {
+                facilityId,
+            },
+            result: 'ERROR',
+            errorMessage: getErrorMessage(error),
+            errorStack: getErrorStack(error),
+        }).catch(() => {});
+
+        return {
+            success: false,
+            error: 'テンプレートの削除に失敗しました',
         };
     }
 }


### PR DESCRIPTION
## Summary

- 求人テンプレ管理画面の削除ボタンがダミー実装で、`confirm()` 後にトーストを出すだけでDB削除を呼んでいなかった（`deleteJobTemplate` 関数自体が未実装）
- `deleteJobTemplate` Server Action を新規追加し、UI から呼び出すように結線
- 認可・入力検証・参照整合性・監査ログをまとめて整備

## 変更内容

### `src/lib/actions/job-template.ts`
- `deleteJobTemplate(templateId, facilityId)` を新規追加
- **認可**: `validateFacilityAccess()` でセッションの facility_id と突き合わせ（IDOR防止）
- **入力検証**: `Number.isInteger` & `> 0` チェック
- **整合性**: `prisma.\$transaction` で `Job.template_id = NULL` → `JobTemplate.delete` を原子的に実行（既存求人は保持）
- **監査**: `JOB_TEMPLATE_DELETE` を AuditLog に記録（SUCCESS / ERROR 両方）
- `revalidatePath('/admin/jobs/templates')`

### `app/admin/jobs/templates/page.tsx`
- 削除ボタンの onClick を実装（旧: トースト表示のみ）
- `confirm` 文言で「作成済み求人は残るが紐付けは解除」を明示
- `try/catch` で例外時もエラートースト表示
- 成功時に一覧再取得

## レビュー対応

Codex code-reviewer から以下の指摘を反映済み:
- ✅ Critical: facilityId をクライアント信頼せず `validateFacilityAccess` でサーバー検証
- ✅ Recommendation: 引数の整数バリデーション
- ✅ Recommendation: UI の例外パスに try/catch + トースト

## Test plan

- [ ] 自施設のテンプレ削除 → 一覧から消える / トースト表示
- [ ] 削除したテンプレから作成済みの既存 Job が残っていることを確認（template_id が NULL）
- [ ] 他施設の facilityId を渡した場合、Server Action がエラーを返す
- [ ] 削除キャンセル時に何も起きない
- [ ] AuditLog に `JOB_TEMPLATE_DELETE` が記録される

## DB / 環境変数の影響

- DB スキーマ変更: **なし**（デプロイのみで反映可）
- 環境変数追加: なし

🤖 Generated with [Claude Code](https://claude.ai/code)