### PR TITLE
バグ修正: 求人テンプレートが使用中なら削除を拒否（仕様変更）

### DIFF
--- a/app/admin/jobs/templates/page.tsx
+++ b/app/admin/jobs/templates/page.tsx
@@ -179,7 +179,7 @@ export default function TemplatesPage() {
                             toast.error('施設情報が取得できませんでした。再ログインしてください');
                             return;
                           }
-                          if (!confirm(`「${template.name}」を削除しますか？\nこのテンプレートから作成済みの求人は残りますが、テンプレートとの紐付けは解除されます。`)) {
+                          if (!confirm(`「${template.name}」を削除しますか？\nこのテンプレートを使用している求人がある場合は削除できません。`)) {
                             return;
                           }
                           try {

--- a/prisma/migrations/20260507_restrict_job_template_delete/migration.sql
+++ b/prisma/migrations/20260507_restrict_job_template_delete/migration.sql
@@ -1,0 +1,9 @@
+-- Change Job.template_id FK from ON DELETE SET NULL to ON DELETE RESTRICT.
+-- Purpose: enforce "cannot delete a JobTemplate that is in use by any Job" at the DB level,
+-- preventing the race window between application-level count check and DELETE.
+
+ALTER TABLE "jobs" DROP CONSTRAINT IF EXISTS "jobs_template_id_fkey";
+
+ALTER TABLE "jobs" ADD CONSTRAINT "jobs_template_id_fkey"
+  FOREIGN KEY ("template_id") REFERENCES "job_templates"("id")
+  ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -379,7 +379,7 @@ model Job {
   bookmarks                    Bookmark[]
   workDates                    JobWorkDate[]
   facility                     Facility             @relation(fields: [facility_id], references: [id], onDelete: Cascade)
-  template                     JobTemplate?         @relation(fields: [template_id], references: [id])
+  template                     JobTemplate?         @relation(fields: [template_id], references: [id], onDelete: Restrict)
   /// オファー対象ワーカー
   targetWorker                 User?                @relation("OfferTargetWorker", fields: [target_worker_id], references: [id])
   /// 親求人（切り出し元）

--- a/src/lib/actions/job-template.ts
+++ b/src/lib/actions/job-template.ts
@@ -1,5 +1,6 @@
 'use server';
 
+import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import { revalidatePath } from 'next/cache';
 import { logActivity, getErrorMessage, getErrorStack } from '@/lib/logger';
@@ -436,7 +437,8 @@ export async function updateJobTemplate(
 
 /**
  * 管理者用: 求人テンプレートを削除
- * 依存する Job レコードの template_id を NULL に切り離してから削除する。
+ * 安全側の挙動として、このテンプレートを使用している求人(Job)が1件でも存在する場合は
+ * 削除を中止する（元データ保護）。
  */
 export async function deleteJobTemplate(templateId: number, facilityId: number) {
     // 入力バリデーション
@@ -475,16 +477,70 @@ export async function deleteJobTemplate(templateId: number, facilityId: number) 
             };
         }
 
-        // 依存する Job の template_id を NULL に切り離してから削除
-        await prisma.$transaction([
-            prisma.job.updateMany({
-                where: { template_id: templateId },
-                data: { template_id: null },
-            }),
-            prisma.jobTemplate.delete({
+        // 使用中チェック: このテンプレートを参照する求人が1件でもあれば削除拒否
+        const referencingJobCount = await prisma.job.count({
+            where: { template_id: templateId },
+        });
+
+        if (referencingJobCount > 0) {
+            // ブロック理由を監査ログに記録（INFO相当）
+            logActivity({
+                userType: 'FACILITY',
+                userId: session?.adminId,
+                userEmail: session?.email,
+                action: 'JOB_TEMPLATE_DELETE',
+                targetType: 'JobTemplate',
+                targetId: templateId,
+                requestData: {
+                    facilityId,
+                    referencingJobCount,
+                    reason: 'IN_USE',
+                },
+                result: 'ERROR',
+                errorMessage: `Template in use by ${referencingJobCount} job(s)`,
+            }).catch(() => {});
+
+            return {
+                success: false,
+                error: 'このテンプレートは使用中の求人があるため削除できません',
+            };
+        }
+
+        try {
+            await prisma.jobTemplate.delete({
                 where: { id: templateId },
-            }),
-        ]);
+            });
+        } catch (deleteError) {
+            // 競合フォールバック:
+            // count チェックと delete の間に Job が新規作成された場合、DBレベルの
+            // FK 制約 (ON DELETE RESTRICT) で P2003 が発生する。
+            // ユーザー向けには同じ「使用中」メッセージを返す。
+            if (
+                deleteError instanceof Prisma.PrismaClientKnownRequestError &&
+                deleteError.code === 'P2003'
+            ) {
+                logActivity({
+                    userType: 'FACILITY',
+                    userId: session?.adminId,
+                    userEmail: session?.email,
+                    action: 'JOB_TEMPLATE_DELETE',
+                    targetType: 'JobTemplate',
+                    targetId: templateId,
+                    requestData: {
+                        facilityId,
+                        reason: 'IN_USE_RACE',
+                    },
+                    result: 'ERROR',
+                    errorMessage: 'FK constraint violated (P2003) — template became in-use during delete',
+                }).catch(() => {});
+
+                return {
+                    success: false,
+                    error: 'このテンプレートは使用中の求人があるため削除できません',
+                };
+            }
+            throw deleteError;
+        }
 
         console.log('[deleteJobTemplate] Template deleted:', templateId);
 


### PR DESCRIPTION
## 仕様変更

PR #580（develop マージ済み）で実装した「依存 Job を切り離してから削除」を、安全側の挙動に変更します。

### Before（PR #580）
- 削除すると依存 Job の `template_id` が NULL に切り離されてからテンプレートが削除される。

### After（本PR）
- 使用中の Job が1件でもあれば削除を**拒否**し、トーストで「このテンプレートは使用中の求人があるため削除できません」を表示。
- 元データを保護する。

## 変更内容

### アプリ層 — `src/lib/actions/job-template.ts`
- `prisma.job.count({ where: { template_id } })` で使用中チェック
- `> 0` なら拒否（AuditLog に `reason: 'IN_USE'` で記録）
- 防御コード: `P2003` (FK違反) を catch して同じメッセージで返す（DBレベルでも保護されているため）

### DB 層 — `prisma/schema.prisma` + マイグレーション
- `Job.template` に `onDelete: Restrict` を追加
- `prisma/migrations/20260507_restrict_job_template_delete/migration.sql` を新規追加
  - 既存 FK を DROP → `ON DELETE RESTRICT` で再作成
- これにより count → delete の間に Job が新規作成されても、DB が FK 制約で削除を防ぐ

### UI — `app/admin/jobs/templates/page.tsx`
- confirm 文言を「使用している求人がある場合は削除できません」に変更

## ⚠️ デプロイ前に必要な作業

**マイグレーションをユーザーが手動実行する必要があります。** Claude Code は実行しません。

\`\`\`bash
# ステージング & 本番 で実行
npx prisma migrate deploy

# あるいは、SQL を直接実行
psql \$DATABASE_URL -f prisma/migrations/20260507_restrict_job_template_delete/migration.sql
\`\`\`

実行内容:
\`\`\`sql
ALTER TABLE \"jobs\" DROP CONSTRAINT IF EXISTS \"jobs_template_id_fkey\";
ALTER TABLE \"jobs\" ADD CONSTRAINT \"jobs_template_id_fkey\"
  FOREIGN KEY (\"template_id\") REFERENCES \"job_templates\"(\"id\")
  ON DELETE RESTRICT ON UPDATE CASCADE;
\`\`\`

## Codex レビュー対応

PR #580 の追加レビューで指摘された **\"count→delete の race window で SET NULL されてしまう\"** 問題を、スキーマレベルの RESTRICT で根本解決しています。

## Test plan

- [ ] 使用中（参照Job 1件以上）のテンプレ削除 → 拒否トースト
- [ ] 未使用のテンプレ削除 → 削除成功
- [ ] AuditLog に `JOB_TEMPLATE_DELETE` + `reason: 'IN_USE'` が記録される
- [ ] マイグレーション後、psql で `\\d jobs` を見て `template_id` の FK が `ON DELETE RESTRICT` になっている

🤖 Generated with [Claude Code](https://claude.ai/code)