### PR TITLE
バグ修正: 施設前日リマインドメールのテンプレート変数未置換を修正

### DIFF
--- a/app/api/cron/notifications/route.ts
+++ b/app/api/cron/notifications/route.ts
@@ -222,28 +222,28 @@ async function sendFacilityDayBeforeReminders() {
         const admins = wd.job.facility.admins;
         if (admins.length === 0) continue;
 
-        const workerNames = wd.applications
-            .map(app => app.user?.name || '不明')
-            .join('、');
-
         const workDateStr = wd.work_date.toISOString().split('T')[0];
         const facilityEmails = admins.map(a => a.email);
         const primaryAdmin = admins[0];
 
-        await sendNotification({
-            notificationKey: 'FACILITY_REMINDER_DAY_BEFORE',
-            targetType: 'FACILITY',
-            recipientId: primaryAdmin.id,
-            recipientName: primaryAdmin.name,
-            facilityEmails,
-            variables: {
-                job_title: wd.job.title,
-                work_date: workDateStr,
-                worker_count: String(wd.applications.length),
-                worker_names: workerNames,
-            },
-        });
-        sentCount++;
+        for (const app of wd.applications) {
+            await sendNotification({
+                notificationKey: 'FACILITY_REMINDER_DAY_BEFORE',
+                targetType: 'FACILITY',
+                recipientId: primaryAdmin.id,
+                recipientName: primaryAdmin.name,
+                facilityEmails,
+                variables: {
+                    facility_name: wd.job.facility.facility_name,
+                    job_title: wd.job.title,
+                    work_date: workDateStr,
+                    worker_name: app.user?.name || '不明',
+                    start_time: wd.job.start_time || '',
+                    end_time: wd.job.end_time || '',
+                },
+            });
+            sentCount++;
+        }
     }
 
     return sentCount;


### PR DESCRIPTION
## Summary
- 施設向け前日リマインドメール（FACILITY_REMINDER_DAY_BEFORE）で `{{facility_name}}` `{{worker_name}}` `{{start_time}}` `{{end_time}}` がそのまま本文に残る不具合を修正
- 同一勤務日に複数ワーカーがいる場合、ワーカーごとに1通ずつ送信するようループ単位を変更

## Root Cause
`app/api/cron/notifications/route.ts` の `sendFacilityDayBeforeReminders` で、テンプレート（`prisma/seed-notifications.ts:389-422`）が要求する変数のうち `facility_name` / `worker_name` / `start_time` / `end_time` を `variables` に渡していなかった。`replaceVariables` は未マップ変数を素通りさせるためメール本文に `{{...}}` が残っていた。

## Changes
`app/api/cron/notifications/route.ts`
- ループ単位を「勤務日」→「予定ワーカー（application）単位」へ変更
- 渡す変数: `facility_name` / `job_title` / `work_date` / `worker_name` / `start_time` / `end_time`
- 不要だった `worker_count` / `worker_names`（テンプレート未使用）を削除

## Test plan
- [ ] ステージングでcron発火 (`/api/cron/notifications`) し、施設管理者宛のメール本文がテンプレート通り展開されること
- [ ] 同一勤務日に複数ワーカー登録時、ワーカー人数分のメールが届くこと
- [ ] 単一ワーカー時に1通のみ送信されること

## DB / Env
- DB変更: なし
- 環境変数追加: なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)