### PR TITLE
LP管理: LP番号バッジを10色から選べるカラーピッカー追加

### DIFF
--- a/app/system-admin/lp/components/DBLPList.tsx
+++ b/app/system-admin/lp/components/DBLPList.tsx
@@ -7,7 +7,7 @@ import LPUploadModal from './LPUploadModal';
 import GenreSelectModal from './GenreSelectModal';
 import GenreEditModal from './GenreEditModal';
 import HtmlEditModal from './HtmlEditModal';
-import { getLandingPages, deleteLandingPage, updateLandingPageName, updateLandingPageCtaUrl, toggleLpHidden, updateLpSortOrders, copyLandingPage } from '@/lib/lp-actions';
+import { getLandingPages, deleteLandingPage, updateLandingPageName, updateLandingPageCtaUrl, toggleLpHidden, updateLpSortOrders, copyLandingPage, updateLandingPageBadgeColor } from '@/lib/lp-actions';
 import type { LandingPage } from '@prisma/client';
 
 type Campaign = {
@@ -17,6 +17,23 @@ type Campaign = {
   genreName?: string;
   genrePrefix?: string;
 };
+
+// バッジ色パレット（10色）。Tailwindは静的解析するため完全クラス名で記述する必要あり
+const BADGE_COLORS: Record<string, { label: string; gradient: string; ring: string }> = {
+  rose:    { label: 'ローズ',    gradient: 'from-rose-500 to-rose-600',       ring: 'ring-rose-300' },
+  orange:  { label: 'オレンジ', gradient: 'from-orange-500 to-orange-600',   ring: 'ring-orange-300' },
+  amber:   { label: 'アンバー', gradient: 'from-amber-500 to-amber-600',     ring: 'ring-amber-300' },
+  emerald: { label: 'エメラルド', gradient: 'from-emerald-500 to-emerald-600', ring: 'ring-emerald-300' },
+  teal:    { label: 'ティール', gradient: 'from-teal-500 to-teal-600',       ring: 'ring-teal-300' },
+  sky:     { label: 'スカイ',   gradient: 'from-sky-500 to-sky-600',         ring: 'ring-sky-300' },
+  blue:    { label: 'ブルー',   gradient: 'from-blue-500 to-blue-600',       ring: 'ring-blue-300' },
+  indigo:  { label: 'インディゴ', gradient: 'from-indigo-500 to-indigo-600',   ring: 'ring-indigo-300' },
+  violet:  { label: 'バイオレット', gradient: 'from-violet-500 to-violet-600',   ring: 'ring-violet-300' },
+  pink:    { label: 'ピンク',   gradient: 'from-pink-500 to-pink-600',       ring: 'ring-pink-300' },
+};
+const BADGE_COLOR_KEYS = Object.keys(BADGE_COLORS);
+const getBadgeGradient = (color?: string | null) =>
+  BADGE_COLORS[color || 'rose']?.gradient || BADGE_COLORS.rose.gradient;
 
 type DBLPListProps = {
   initialPages: LandingPage[];
@@ -58,6 +75,36 @@ export default function DBLPList({ initialPages }: DBLPListProps) {
   // CTA URL編集状態
   const [ctaEditingId, setCtaEditingId] = useState<number | null>(null);
   const [ctaEditValue, setCtaEditValue] = useState('');
+
+  // カラーピッカー状態
+  const [colorPickerLpNumber, setColorPickerLpNumber] = useState<number | null>(null);
+  const colorPickerRef = useRef<HTMLDivElement>(null);
+
+  // カラーピッカー外クリックで閉じる
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (colorPickerRef.current && !colorPickerRef.current.contains(event.target as Node)) {
+        setColorPickerLpNumber(null);
+      }
+    };
+    if (colorPickerLpNumber !== null) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [colorPickerLpNumber]);
+
+  const handleColorChange = async (lpNumber: number, color: string) => {
+    setColorPickerLpNumber(null);
+    // 楽観的UI更新
+    setPages(prev =>
+      prev.map(p => (p.lp_number === lpNumber ? { ...p, badge_color: color } : p))
+    );
+    const result = await updateLandingPageBadgeColor(lpNumber, color);
+    if (!result.success) {
+      alert(result.error || '色の変更に失敗しました');
+      await refreshPages();
+    }
+  };
 
   // モーダル状態
   const [genreSelectModalOpen, setGenreSelectModalOpen] = useState(false);
@@ -483,15 +530,46 @@ export default function DBLPList({ initialPages }: DBLPListProps) {
                 <GripVertical className="w-5 h-5" />
               </div>
             )}
-            {/* LP番号バッジ */}
-            <div className={`
-              flex-shrink-0 w-10 h-10 rounded-lg flex items-center justify-center text-sm font-bold
-              ${lp.is_published === false
-                ? 'bg-gray-200 text-gray-500'
-                : 'bg-gradient-to-br from-rose-500 to-rose-600 text-white'
-              }
-            `}>
-              {lp.lp_number}
+            {/* LP番号バッジ（クリックで色変更） */}
+            <div className="relative flex-shrink-0" ref={colorPickerLpNumber === lp.lp_number ? colorPickerRef : null}>
+              <button
+                type="button"
+                onClick={() => setColorPickerLpNumber(colorPickerLpNumber === lp.lp_number ? null : lp.lp_number)}
+                title="クリックして色を変更"
+                className={`
+                  w-10 h-10 rounded-lg flex items-center justify-center text-sm font-bold transition-all
+                  hover:scale-105 hover:shadow-md
+                  ${lp.is_published === false
+                    ? 'bg-gray-200 text-gray-500'
+                    : `bg-gradient-to-br ${getBadgeGradient(lp.badge_color)} text-white`
+                  }
+                `}
+              >
+                {lp.lp_number}
+              </button>
+              {colorPickerLpNumber === lp.lp_number && (
+                <div className="absolute left-0 top-full mt-2 z-20 bg-white rounded-lg shadow-lg border border-gray-200 p-3 w-[200px]">
+                  <p className="text-[10px] font-semibold text-gray-500 mb-2 whitespace-nowrap">バッジの色を選択</p>
+                  <div className="grid grid-cols-5 gap-2">
+                    {BADGE_COLOR_KEYS.map((colorKey) => {
+                      const isSelected = (lp.badge_color || 'rose') === colorKey;
+                      return (
+                        <button
+                          key={colorKey}
+                          type="button"
+                          onClick={() => handleColorChange(lp.lp_number, colorKey)}
+                          title={BADGE_COLORS[colorKey].label}
+                          className={`
+                            w-6 h-6 rounded-md bg-gradient-to-br ${BADGE_COLORS[colorKey].gradient}
+                            transition-transform hover:scale-110
+                            ${isSelected ? `ring-2 ring-offset-1 ${BADGE_COLORS[colorKey].ring}` : ''}
+                          `}
+                        />
+                      );
+                    })}
+                  </div>
+                </div>
+              )}
             </div>
 
             {/* タイトル & ステータス */}

--- a/lib/lp-actions.ts
+++ b/lib/lp-actions.ts
@@ -492,6 +492,33 @@ export async function updateLandingPageCtaUrl(
 }
 
 /**
+ * LPバッジ色を更新
+ * 許可される値: rose, orange, amber, emerald, teal, sky, blue, indigo, violet, pink
+ */
+const ALLOWED_BADGE_COLORS = [
+  'rose', 'orange', 'amber', 'emerald', 'teal', 'sky', 'blue', 'indigo', 'violet', 'pink',
+];
+
+export async function updateLandingPageBadgeColor(
+  lpNumber: number,
+  badgeColor: string
+): Promise<{ success: boolean; error?: string }> {
+  if (!ALLOWED_BADGE_COLORS.includes(badgeColor)) {
+    return { success: false, error: '無効な色が指定されました' };
+  }
+  try {
+    await prisma.landingPage.update({
+      where: { lp_number: lpNumber },
+      data: { badge_color: badgeColor },
+    });
+    return { success: true };
+  } catch (error: any) {
+    console.error('[LP Badge Color Update] Error:', error);
+    return { success: false, error: error.message || '更新に失敗しました' };
+  }
+}
+
+/**
  * LP非表示/再表示を切り替え
  */
 export async function toggleLpHidden(
@@ -605,6 +632,7 @@ export async function copyLandingPage(
         delivery_utm_source: null,
         cta_url: sourceLp.cta_url,
         sort_order: newSortOrder,
+        badge_color: sourceLp.badge_color,
       },
     });
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1808,6 +1808,8 @@ model LandingPage {
   is_hidden           Boolean  @default(false) @map("is_hidden")
   /// 表示順序（D&D並び替え用、小さい順に表示）
   sort_order          Int      @default(0) @map("sort_order")
+  /// LP番号バッジの色（Tailwindカラー名: rose, orange, amber, emerald, teal, sky, blue, indigo, violet, pink）
+  badge_color         String   @default("rose") @map("badge_color") @db.VarChar(20)
   created_at          DateTime @default(now()) @map("created_at")
   updated_at          DateTime @updatedAt @map("updated_at")
 


### PR DESCRIPTION
## Summary
- LP管理画面で、各LPカードの番号バッジ(これまで全部赤)をクリックすると10色のパレットが開き、好きな色に変更できるようにした
- 色は DB の `LandingPage.badge_color` に保存され、LPコピー時にも引き継がれる

## 変更内容
- **DB**: `landing_pages.badge_color VARCHAR(20) DEFAULT 'rose' NOT NULL` を追加
- **server action**: `updateLandingPageBadgeColor()` を追加(許可色のホワイトリスト検証付き)
- **UI**: バッジ自体をボタン化、クリックで5×2の10色パレット(rose / orange / amber / emerald / teal / sky / blue / indigo / violet / pink)をポップオーバー表示
- 楽観的UI更新で即時反映、外側クリックで閉じる

## ⚠️ デプロイ前にユーザー手動作業が必要
**ステージングDBへの schema push が必要です**:
\`\`\`
npx prisma db push
\`\`\`
(Claude Codeは本番/ステージングDBを直接操作しない方針のため、ユーザーが実行してください)

## Test plan
- [ ] ステージングDBへ `prisma db push` を実行
- [ ] https://stg-share-worker.vercel.app/system-admin/lp でLP番号バッジをクリック
- [ ] パレットが正しく表示され、色が綺麗に並んで重ならないこと
- [ ] 色を選択したら即座にバッジ色が変わること
- [ ] リロード後も色が保持されていること
- [ ] LPをコピーした際、コピー先にも色が引き継がれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)