### PR TITLE
バグ修正: 求人検索の都道府県/市区町村フィルタが0件になる問題を修正

### DIFF
--- a/src/lib/actions/job-worker.ts
+++ b/src/lib/actions/job-worker.ts
@@ -123,28 +123,26 @@ export async function getJobs(
     }
 
     // 都道府県フィルター
+    // Job.prefecture（厳密一致）を優先、未設定の旧データは Job.address のあいまい一致で救済
     if (searchParams?.prefecture) {
-        facilityConditions.address = {
-            contains: searchParams.prefecture,
-            mode: 'insensitive',
-        };
+        whereConditions.AND = whereConditions.AND || [];
+        whereConditions.AND.push({
+            OR: [
+                { prefecture: searchParams.prefecture },
+                { address: { contains: searchParams.prefecture, mode: 'insensitive' } },
+            ],
+        });
     }
 
-    // 市区町村フィルター（都道府県と組み合わせる）
+    // 市区町村フィルター
     if (searchParams?.city) {
-        if (facilityConditions.address) {
-            // 都道府県と市区町村の両方を含む
-            facilityConditions.AND = [
-                { address: { contains: searchParams.prefecture, mode: 'insensitive' } },
+        whereConditions.AND = whereConditions.AND || [];
+        whereConditions.AND.push({
+            OR: [
+                { city: searchParams.city },
                 { address: { contains: searchParams.city, mode: 'insensitive' } },
-            ];
-            delete facilityConditions.address;
-        } else {
-            facilityConditions.address = {
-                contains: searchParams.city,
-                mode: 'insensitive',
-            };
-        }
+            ],
+        });
     }
 
     // サービス種別フィルター（複数選択対応）
@@ -693,28 +691,26 @@ export async function getJobsListWithPagination(
     }
 
     // 都道府県フィルター
+    // Job.prefecture（厳密一致）を優先、未設定の旧データは Job.address のあいまい一致で救済
     if (searchParams?.prefecture) {
-        facilityConditions.address = {
-            contains: searchParams.prefecture,
-            mode: 'insensitive',
-        };
+        whereConditions.AND = whereConditions.AND || [];
+        whereConditions.AND.push({
+            OR: [
+                { prefecture: searchParams.prefecture },
+                { address: { contains: searchParams.prefecture, mode: 'insensitive' } },
+            ],
+        });
     }
 
-    // 市区町村フィルター（都道府県と組み合わせる）
+    // 市区町村フィルター
     if (searchParams?.city) {
-        if (facilityConditions.address) {
-            // 都道府県と市区町村の両方を含む
-            facilityConditions.AND = [
-                { address: { contains: searchParams.prefecture, mode: 'insensitive' } },
+        whereConditions.AND = whereConditions.AND || [];
+        whereConditions.AND.push({
+            OR: [
+                { city: searchParams.city },
                 { address: { contains: searchParams.city, mode: 'insensitive' } },
-            ];
-            delete facilityConditions.address;
-        } else {
-            facilityConditions.address = {
-                contains: searchParams.city,
-                mode: 'insensitive',
-            };
-        }
+            ],
+        });
     }
 
     // サービス種別フィルター（複数選択対応）


### PR DESCRIPTION
## 背景

クライアントより、ワーカー画面で **勤務地（都道府県・市区町村）** で絞り込むと検索結果が必ず0件になるとの報告。

## 現象（本番で再現確認済み）

| フィルタ | 結果 |
|----------|------|
| フィルタなし | 65件 ✅ |
| 最低時給 / サービス種別 / こだわり条件 / 勤務時間 / 時給順など | 正常 ✅ |
| **都道府県（東京都・埼玉県など）** | **0件** ❌ |
| **市区町村** | **0件** ❌ |

## 原因

`src/lib/actions/job-worker.ts` の都道府県/市区町村フィルタが `facility.address` を `contains` で検索していたが、本番DBでは `facility.address` がほぼ全件空文字。実住所は `Job` 側のカラム（`prefecture`/`city`/`address`）に保存されているため、フィルタが絶対にヒットしない状態になっていた。

```
job 619 : address='東京都北区赤羽北2-28-1...' （住所あり）
facility 135 : address=''                    （空）
```

## 修正内容

都道府県・市区町村フィルタを **`Job` 側のカラム** を参照するよう変更。

- **第一マッチ**: `Job.prefecture` / `Job.city` の厳密一致
- **フォールバック**: `Job.address.contains`（OR で併用、Job.prefecture/cityが未設定の旧データを救済）

`getJobs` と `getJobsListWithPagination` の双方に適用。

## 影響範囲

- ✅ ワーカー画面トップ（求人一覧）の都道府県・市区町村フィルタ
- ✅ 公開（未ログイン）求人一覧の同フィルタ（同関数を共有）
- ❌ 他のフィルタ（時給・サービス種別・こだわり条件・勤務時間・距離検索）への影響なし
- ❌ 外部連携（TasLink ワーカー住所同期）はワーカー側 `User` テーブルを参照しており影響なし
- ❌ DB変更なし（デプロイのみで反映）

## Test plan

- [ ] ステージングデプロイ後、`https://stg-share-worker.vercel.app/` にアクセス
- [ ] 絞り込みモーダルから「東京都」を選択 → 件数が出ることを確認
- [ ] 「東京都」+「北区」を選択 → 件数が絞り込まれることを確認
- [ ] 「埼玉県」など他の都道府県でも件数が出ることを確認
- [ ] 都道府県を外すと全件に戻ることを確認
- [ ] 都道府県+時給フィルタなど他フィルタとの併用で挙動が壊れていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)