### PR TITLE
バグ修正: 求人/求人テンプレートの性別指定が保存されない不具合を解消

### DIFF
--- a/app/admin/jobs/templates/[id]/edit/page.tsx
+++ b/app/admin/jobs/templates/[id]/edit/page.tsx
@@ -57,7 +57,7 @@ export default function EditJobTemplatePage() {
           notes: template.notes || '',
           icons: template.icons || [],
           workContent: template.workContent || [],
-          genderRequirement: '',
+          genderRequirement: ((template as any).genderRequirement as string) || '',
           dismissalReasons: '',
         });
       } catch (error) {

--- a/components/admin/JobForm.tsx
+++ b/components/admin/JobForm.tsx
@@ -214,8 +214,8 @@ export default function JobForm({ mode, jobId, initialData, isOfferMode = false,
         recruitmentStartTime: '',
         recruitmentEndDay: 0,
         recruitmentEndTime: '',
-        // 共通
-        genderRequirement: '不問',
+        // 共通: 性別指定（'' = 指定なし, 'MALE_ONLY' = 男性のみ, 'FEMALE_ONLY' = 女性のみ）
+        genderRequirement: '',
         dismissalReasons: '',
         requiresInterview: false,
         // 限定求人用
@@ -519,6 +519,8 @@ export default function JobForm({ mode, jobId, initialData, isOfferMode = false,
                 addressLine: jobData.address_line || facility?.addressLine || '',
                 building: '', // DBにないので空
                 address: jobData.address || facility?.address || '',
+                // 性別指定
+                genderRequirement: ((jobData as any).gender_requirement as string) || '',
             }));
 
         } catch (error) {
@@ -974,6 +976,8 @@ export default function JobForm({ mode, jobId, initialData, isOfferMode = false,
             images: [],
             dresscodeImages: [],
             attachments: [],
+            // テンプレートの性別指定を引き継ぎ（求人作成時に変更可）
+            genderRequirement: ((template as any).genderRequirement as string) || '',
         }));
     };
 
@@ -1225,6 +1229,10 @@ export default function JobForm({ mode, jobId, initialData, isOfferMode = false,
                     city: formData.city,
                     addressLine: formData.addressLine,
                     address: formData.address,
+                    // 性別指定（特定業務時のみ・施設管理者の参照用）
+                    genderRequirement: requiresGenderSpecification && (formData.genderRequirement === 'MALE_ONLY' || formData.genderRequirement === 'FEMALE_ONLY')
+                        ? formData.genderRequirement
+                        : null,
                 });
 
                 if (res.success) {
@@ -1270,6 +1278,10 @@ export default function JobForm({ mode, jobId, initialData, isOfferMode = false,
                     recruitmentStartTime: formData.recruitmentStartTime || undefined,
                     recruitmentEndDay: formData.recruitmentEndDay,
                     recruitmentEndTime: formData.recruitmentEndTime || undefined,
+                    // 性別指定（特定業務時のみ。業務外の場合は null でクリア）
+                    genderRequirement: requiresGenderSpecification && (formData.genderRequirement === 'MALE_ONLY' || formData.genderRequirement === 'FEMALE_ONLY')
+                        ? formData.genderRequirement
+                        : null,
                 });
 
                 if (res.success) {
@@ -2196,17 +2208,21 @@ export default function JobForm({ mode, jobId, initialData, isOfferMode = false,
                             {requiresGenderSpecification && (
                                 <div>
                                     <label className="block text-sm font-medium text-gray-700 mb-2">
-                                        性別指定 <span className="text-red-500">*</span>
+                                        性別指定
                                     </label>
-                                    <p className="text-xs text-gray-500 mb-2">入浴介助または排泄介助を選択した場合のみ指定が必要です</p>
+                                    <p className="text-xs text-gray-500 mb-2">
+                                        入浴介助または排泄介助を選択した場合のみ指定できます。
+                                        <br />
+                                        ※ ワーカーには表示されません。施設運営者の参照用です。
+                                    </p>
                                     <select
                                         value={formData.genderRequirement}
                                         onChange={(e) => handleInputChange('genderRequirement', e.target.value)}
                                         className="w-full px-3 py-2 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-600"
                                     >
                                         <option value="">指定なし</option>
-                                        <option value="male">男性</option>
-                                        <option value="female">女性</option>
+                                        <option value="MALE_ONLY">男性のみ</option>
+                                        <option value="FEMALE_ONLY">女性のみ</option>
                                     </select>
                                 </div>
                             )}

--- a/components/admin/JobTemplateForm.tsx
+++ b/components/admin/JobTemplateForm.tsx
@@ -478,6 +478,10 @@ export default function JobTemplateForm({ mode, templateId, initialData }: JobTe
                 images: finalImages,
                 dresscodeImages: finalDresscodeImages,
                 attachments: finalAttachments,
+                // 性別指定（特定業務時のみ。業務外の場合は null でクリア）
+                genderRequirement: requiresGenderSpecification && (formData.genderRequirement === 'MALE_ONLY' || formData.genderRequirement === 'FEMALE_ONLY')
+                    ? (formData.genderRequirement as 'MALE_ONLY' | 'FEMALE_ONLY')
+                    : null,
             };
 
             let result;
@@ -1051,9 +1055,13 @@ export default function JobTemplateForm({ mode, templateId, initialData }: JobTe
 
                             <div>
                                 <label className="block text-sm font-medium text-gray-700 mb-2">
-                                    性別指定 <span className="text-red-500">*</span>
+                                    性別指定
                                 </label>
-                                <p className="text-xs text-gray-500 mb-2">入浴介助または排泄介助を選択した場合のみ指定が必要です</p>
+                                <p className="text-xs text-gray-500 mb-2">
+                                    入浴介助または排泄介助を選択した場合のみ指定できます。
+                                    <br />
+                                    ※ ワーカーには表示されません。施設運営者の参照用です。
+                                </p>
                                 <select
                                     value={formData.genderRequirement}
                                     onChange={(e) => handleInputChange('genderRequirement', e.target.value)}
@@ -1061,8 +1069,8 @@ export default function JobTemplateForm({ mode, templateId, initialData }: JobTe
                                     disabled={!requiresGenderSpecification}
                                 >
                                     <option value="">指定なし</option>
-                                    <option value="male">男性</option>
-                                    <option value="female">女性</option>
+                                    <option value="MALE_ONLY">男性のみ</option>
+                                    <option value="FEMALE_ONLY">女性のみ</option>
                                 </select>
                             </div>
 

--- a/constants/job.ts
+++ b/constants/job.ts
@@ -117,3 +117,25 @@ export type JobType = typeof JOB_TYPES[number];
 export type WorkContentOption = typeof WORK_CONTENT_OPTIONS[number];
 export type QualificationOption = typeof QUALIFICATION_OPTIONS[number];
 export type IconOption = typeof ICON_OPTIONS[number];
+
+// 性別指定（特定業務でのみ施設管理者が設定。ワーカー側UIには表示しない / 施設運営者の参照用）
+export const GENDER_REQUIREMENT_VALUES = ['MALE_ONLY', 'FEMALE_ONLY'] as const;
+export type GenderRequirement = typeof GENDER_REQUIREMENT_VALUES[number];
+
+export const GENDER_REQUIREMENT_LABELS: Record<GenderRequirement, string> = {
+  MALE_ONLY: '男性のみ',
+  FEMALE_ONLY: '女性のみ',
+};
+
+// 性別指定が必要となる業務（要件: 排泄介助・入浴介助系）
+export const WORK_CONTENTS_REQUIRING_GENDER: ReadonlyArray<string> = [
+  '排泄介助',
+  '入浴介助(全般)',
+  '入浴介助(大浴場)',
+  '入浴介助(個浴)',
+  '入浴介助(機械浴)',
+];
+
+export function requiresGenderSpecification(workContent: string[]): boolean {
+  return workContent.some((c) => WORK_CONTENTS_REQUIRING_GENDER.includes(c));
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -297,6 +297,9 @@ model JobTemplate {
   tags                   String[]
   /// 解雇の事由（労働条件通知書用、nullの場合はデフォルト文言を使用）
   dismissal_reasons      String?  @map("dismissal_reasons")
+  /// 性別指定（"MALE_ONLY" | "FEMALE_ONLY" | null）
+  /// 入浴介助・排泄介助など特定業務でのみ施設管理者が設定。ワーカー側UIには表示しない（参照用）
+  gender_requirement     String?  @map("gender_requirement")
   created_at             DateTime @default(now()) @map("created_at")
   updated_at             DateTime @updatedAt @map("updated_at")
   facility           Facility @relation(fields: [facility_id], references: [id], onDelete: Cascade)
@@ -374,6 +377,9 @@ model Job {
   offer_message                String?              @map("offer_message") @db.Text
   /// 親求人ID（限定求人から切り出された子求人の場合に設定）
   parent_job_id                Int?                 @map("parent_job_id")
+  /// 性別指定（"MALE_ONLY" | "FEMALE_ONLY" | null）
+  /// 入浴介助・排泄介助など特定業務でのみ施設管理者が設定。ワーカー側UIには表示しない（参照用）
+  gender_requirement           String?              @map("gender_requirement")
   created_at                   DateTime             @default(now()) @map("created_at")
   updated_at                   DateTime             @updatedAt @map("updated_at")
   bookmarks                    Bookmark[]

--- a/src/lib/actions/helpers.ts
+++ b/src/lib/actions/helpers.ts
@@ -236,6 +236,8 @@ export interface CreateJobInput {
   city?: string;
   addressLine?: string;
   address?: string;
+  // 性別指定（特定業務時のみ。ワーカー側UIには表示しない・施設管理者の参照用）
+  genderRequirement?: 'MALE_ONLY' | 'FEMALE_ONLY' | null;
 }
 
 export type WorkerListStatus = 'NOT_STARTED' | 'WORKING' | 'COMPLETED' | 'REVIEW_PENDING' | 'CANCELLED';

--- a/src/lib/actions/job-management.ts
+++ b/src/lib/actions/job-management.ts
@@ -511,6 +511,8 @@ export async function createJobs(input: CreateJobInput) {
             // オファー用
             target_worker_id: input.targetWorkerId ?? null,
             offer_message: input.offerMessage ?? null,
+            // 性別指定（特定業務時のみ。施設管理者の参照用）
+            gender_requirement: input.genderRequirement ?? null,
         },
     });
 
@@ -944,6 +946,8 @@ export async function updateJob(
         recruitmentStartTime?: string;
         recruitmentEndDay?: number;
         recruitmentEndTime?: string;
+        // 性別指定（特定業務時のみ。施設管理者の参照用）
+        genderRequirement?: 'MALE_ONLY' | 'FEMALE_ONLY' | null;
     }
 ): Promise<{ success: boolean; error?: string }> {
     // セッションからユーザー情報を取得
@@ -1039,6 +1043,8 @@ export async function updateJob(
                 ...((data.prefecture && data.city && data.addressLine) && {
                     address: `${data.prefecture}${data.city}${data.addressLine}`
                 }),
+                // 性別指定（undefined のときは更新しない、null のときは明示的にクリア）
+                ...(data.genderRequirement !== undefined && { gender_requirement: data.genderRequirement }),
                 updated_at: new Date(),
             },
         });

--- a/src/lib/actions/job-template.ts
+++ b/src/lib/actions/job-template.ts
@@ -40,6 +40,7 @@ export async function getAdminJobTemplates(facilityId: number) {
         attachments: template.attachments || [],
         notes: template.notes,
         tags: template.tags,
+        genderRequirement: (template as any).gender_requirement ?? null,
     }));
 }
 
@@ -88,6 +89,7 @@ export async function getJobTemplate(templateId: number, facilityId: number) {
         tags: template.tags,
         icons: template.tags,
         workContent: template.work_content || [],
+        genderRequirement: (template as any).gender_requirement ?? null,
     };
 }
 
@@ -120,6 +122,8 @@ export async function createJobTemplate(
         images?: string[];
         dresscodeImages?: string[];
         attachments?: string[];
+        // 性別指定（特定業務時のみ。施設管理者の参照用）
+        genderRequirement?: 'MALE_ONLY' | 'FEMALE_ONLY' | null;
     }
 ) {
     const session = await getFacilityAdminSessionData();
@@ -152,6 +156,7 @@ export async function createJobTemplate(
                 images: data.images || [],
                 dresscode_images: data.dresscodeImages || [],
                 attachments: data.attachments || [],
+                gender_requirement: data.genderRequirement ?? null,
             },
         });
 
@@ -253,6 +258,7 @@ export async function duplicateJobTemplate(templateId: number, facilityId: numbe
                 images: original.images || [],
                 dresscode_images: original.dresscode_images || [],
                 attachments: original.attachments || [],
+                gender_requirement: (original as any).gender_requirement ?? null,
             },
         });
 
@@ -335,6 +341,8 @@ export async function updateJobTemplate(
         images?: string[];
         dresscodeImages?: string[];
         attachments?: string[];
+        // 性別指定（特定業務時のみ。施設管理者の参照用）
+        genderRequirement?: 'MALE_ONLY' | 'FEMALE_ONLY' | null;
     }
 ) {
     const session = await getFacilityAdminSessionData();
@@ -382,6 +390,8 @@ export async function updateJobTemplate(
                 images: data.images || [],
                 dresscode_images: data.dresscodeImages || [],
                 attachments: data.attachments || [],
+                // genderRequirement は undefined のとき更新しない、null は明示的にクリア
+                ...(data.genderRequirement !== undefined && { gender_requirement: data.genderRequirement }),
             },
         });
 


### PR DESCRIPTION
## Summary
- クライアント報告: 「特定業務（入浴介助/排泄介助）選択時に性別指定の保存が反映されず、指定なしで公開される」不具合を修正
- 性別指定機能が UI のみ実装で、サーバ・DB まで配線されていなかった（フォーム値が `createJobs`/`updateJob`/`createJobTemplate`/`updateJobTemplate` で送信されておらず、Prismaモデルにもカラムが存在しなかった）
- パターンC仕様で実装: **ワーカー側UI・応募制限は変更なし**。施設管理者の参照用フィールドとして保存のみ
- テンプレート → 求人作成時の値引き継ぎを実装（求人作成画面で変更可能）

## 変更内容
- `prisma/schema.prisma`: Job / JobTemplate に `gender_requirement String?` を追加
- `src/lib/actions/job-management.ts`: `createJobs` / `updateJob` に `genderRequirement` を配線
- `src/lib/actions/job-template.ts`: `createJobTemplate` / `updateJobTemplate` / `getJobTemplate` / `getAdminJobTemplates` / `duplicateJobTemplate` に配線
- `components/admin/JobForm.tsx`: 送信ペイロード追加、編集モード初期値、テンプレート選択時の引き継ぎ
- `components/admin/JobTemplateForm.tsx`: 送信ペイロード追加、UIラベル更新
- `app/admin/jobs/templates/[id]/edit/page.tsx`: ハードコード `''` → `template.genderRequirement` に修正
- `constants/job.ts`: `GENDER_REQUIREMENT_VALUES` / `GENDER_REQUIREMENT_LABELS` / `WORK_CONTENTS_REQUIRING_GENDER` を集約
- UI選択肢を「男性のみ / 女性のみ」に統一（DB保存値: `MALE_ONLY` / `FEMALE_ONLY`）

## 仕様（クライアント確認済み）
- 性別指定が必要な業務: 排泄介助 / 入浴介助(全般) / 入浴介助(大浴場) / 入浴介助(個浴) / 入浴介助(機械浴)
- 選択肢: 指定なし / 男性のみ / 女性のみ
- 公開挙動: パターンC（DB保存のみ。ワーカー側UI・応募制限なし、施設管理者の参照用）
- 既存データ: 全て NULL（指定なし）扱い
- テンプレート連動: 完全連動（ただし求人作成時に変更可能）

## ⚠️ DB Migration（重要・デプロイ順序注意）
**コードのデプロイ前に、ステージング/本番DBそれぞれで `npx prisma db push` をユーザー手動実行が必要。**
- 既存データは NULL 扱いで安全。マイグレーション不要
- 推奨デプロイ順序:
  1. ステージングDBで `npx prisma db push`（merge前）
  2. develop へマージ → Vercel自動デプロイ
  3. ステージング動作確認
  4. 本番DBで `npx prisma db push`（main merge前）
  5. develop → main へマージ
- 順序が逆だと SSR で `PrismaClientKnownRequestError: gender_requirement does not exist` が発生

## Test plan
- [ ] 入浴介助系・排泄介助を選択 → 性別指定セレクトが表示される
- [ ] 「男性のみ」「女性のみ」選択して保存 → 編集画面で値が復元される
- [ ] テンプレートに性別指定保存 → 求人作成時に初期値として引き継がれる
- [ ] 業務内容（入浴介助等）を解除 → 保存値が NULL になる
- [ ] ワーカー側の求人詳細画面に性別指定が**表示されない**ことを確認
- [ ] ワーカー側の応募フローが性別指定の影響を受けないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)