### PR TITLE
LP登録バナー導線: 会員はトップ・非会員は新規登録に振り分け

### DIFF
--- a/app/register/worker/page.tsx
+++ b/app/register/worker/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, Suspense, useMemo } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import toast from 'react-hot-toast';
 import { Eye, EyeOff } from 'lucide-react';
+import { useAuth } from '@/contexts/AuthContext';
 import { useDebugError, extractDebugInfo } from '@/components/debug/DebugErrorBanner';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import { PhoneNumberInput } from '@/components/ui/PhoneNumberInput';
@@ -66,6 +67,15 @@ function WorkerRegisterPageInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { showDebugError } = useDebugError();
+  const { isAuthenticated, isLoading: isAuthLoading } = useAuth();
+
+  // ログイン済みワーカーがこのページに来た場合は求人トップへ転送
+  // (LPバナー「タスタスに登録」からの導線を非会員/会員でハンドリングするため)
+  useEffect(() => {
+    if (!isAuthLoading && isAuthenticated) {
+      router.replace('/');
+    }
+  }, [isAuthLoading, isAuthenticated, router]);
 
   const [currentStep, setCurrentStep] = useState<StepId>('1');
   const [isSubmitting, setIsSubmitting] = useState(false);


### PR DESCRIPTION
## Summary
LP30/LP31 の「タスタスに登録（カンタン1分）」バナーから着地するページの挙動を改善。
非会員は新規登録フォームに、ログイン済みワーカーは自動で求人トップ (/) に転送する。

## 変更内容
- **`app/register/worker/page.tsx`**: `useAuth()` でログイン状態を判定し、認証済みなら `router.replace('/')` で求人トップへ転送

## LP側の対応（別作業・このPRには含めない）
LP30/LP31 の \`<a href=\"#\" data-cats=\"tastasRegisterLink\">\` を
\`<a href=\"https://tastas.work/register/worker\">\` に書き換える必要あり。
ローカルで該当 \`index.html\` を修正済みのため、システム管理者が **「LP管理」画面から再アップロード** してください。
（既存LP管理機能の「再アップロード」を利用）

修正済みファイル: \`~/Desktop/LP修正/\` 配下の LP30, LP31 の index.html

## ⚠️ デプロイ前にユーザー手動作業が必要
1. ステージングDBへの DDL 反映: **不要**（DB変更なし）
2. LP30/LP31 を管理画面からアップロード差し替え（ステージング・本番それぞれ）

## Test plan
- [ ] ステージングにマージ後、修正済みLPをステージング管理画面からアップロード
- [ ] 未ログイン状態で LP30/LP31 の「タスタスに登録」バナーをタップ → 新規登録フォームが表示されること
- [ ] ログイン済み状態で同バナーをタップ → 求人トップ (/) に自動転送されること
- [ ] 直接 \`/register/worker\` にアクセスしてもログイン済みなら / に飛ぶこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)