### PR TITLE
求人管理一覧から1クリックでおすすめ求人(LP)に登録/解除できる星ボタン

### DIFF
--- a/app/api/system-admin/recommended-jobs/route.ts
+++ b/app/api/system-admin/recommended-jobs/route.ts
@@ -108,6 +108,81 @@ export async function GET(request: NextRequest) {
   });
 }
 
+export async function POST(request: NextRequest) {
+  const session = await getSystemAdminSessionData();
+  if (!session) {
+    return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+  }
+
+  try {
+    const body = await request.json();
+    const { jobId } = body as { jobId: number };
+
+    if (typeof jobId !== 'number' || !Number.isFinite(jobId)) {
+      return NextResponse.json({ error: '無効な求人IDです' }, { status: 400 });
+    }
+
+    const job = await prisma.job.findUnique({
+      where: { id: jobId },
+      select: { id: true },
+    });
+    if (!job) {
+      return NextResponse.json({ error: '求人が見つかりません' }, { status: 404 });
+    }
+
+    const existing = await prisma.recommendedJob.findFirst({
+      where: { job_id: jobId },
+    });
+    if (existing) {
+      return NextResponse.json({ error: '既に登録済みです' }, { status: 400 });
+    }
+
+    const count = await prisma.recommendedJob.count();
+    if (count >= MAX_RECOMMENDED_JOBS) {
+      return NextResponse.json({ error: `最大${MAX_RECOMMENDED_JOBS}件までです` }, { status: 400 });
+    }
+
+    await prisma.recommendedJob.create({
+      data: { job_id: jobId, sort_order: count },
+    });
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Recommended job create error:', error);
+    return NextResponse.json({ error: '登録に失敗しました' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request: NextRequest) {
+  const session = await getSystemAdminSessionData();
+  if (!session) {
+    return NextResponse.json({ error: '認証が必要です' }, { status: 401 });
+  }
+
+  try {
+    const { searchParams } = new URL(request.url);
+    const jobIdParam = searchParams.get('jobId');
+    const jobId = jobIdParam ? parseInt(jobIdParam, 10) : NaN;
+
+    if (!Number.isFinite(jobId)) {
+      return NextResponse.json({ error: '無効な求人IDです' }, { status: 400 });
+    }
+
+    const result = await prisma.recommendedJob.deleteMany({
+      where: { job_id: jobId },
+    });
+
+    if (result.count === 0) {
+      return NextResponse.json({ error: '登録されていません' }, { status: 404 });
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Recommended job delete error:', error);
+    return NextResponse.json({ error: '削除に失敗しました' }, { status: 500 });
+  }
+}
+
 export async function PUT(request: NextRequest) {
   const session = await getSystemAdminSessionData();
   if (!session) {

--- a/app/register/worker/page.tsx
+++ b/app/register/worker/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, Suspense, useMemo } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import toast from 'react-hot-toast';
 import { Eye, EyeOff } from 'lucide-react';
+import { useAuth } from '@/contexts/AuthContext';
 import { useDebugError, extractDebugInfo } from '@/components/debug/DebugErrorBanner';
 import { LoadingSpinner } from '@/components/ui/LoadingSpinner';
 import { PhoneNumberInput } from '@/components/ui/PhoneNumberInput';
@@ -66,6 +67,15 @@ function WorkerRegisterPageInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { showDebugError } = useDebugError();
+  const { isAuthenticated, isLoading: isAuthLoading } = useAuth();
+
+  // ログイン済みワーカーがこのページに来た場合は求人トップへ転送
+  // (LPバナー「タスタスに登録」からの導線を非会員/会員でハンドリングするため)
+  useEffect(() => {
+    if (!isAuthLoading && isAuthenticated) {
+      router.replace('/');
+    }
+  }, [isAuthLoading, isAuthenticated, router]);
 
   const [currentStep, setCurrentStep] = useState<StepId>('1');
   const [isSubmitting, setIsSubmitting] = useState(false);

--- a/app/system-admin/jobs/page.tsx
+++ b/app/system-admin/jobs/page.tsx
@@ -19,6 +19,7 @@ import {
     Building2,
     CalendarDays,
     X,
+    Star,
 } from 'lucide-react';
 import { PREFECTURES } from '@/constants/job';
 import { getCitiesByPrefecture, Prefecture } from '@/constants/prefectureCities';
@@ -202,6 +203,60 @@ export default function SystemAdminJobsPage() {
     // 勤務日管理モーダル
     const [workDateModalJob, setWorkDateModalJob] = useState<Job | null>(null);
     const [workDateUpdating, setWorkDateUpdating] = useState<number | null>(null);
+
+    // おすすめ求人（LP）
+    const [recommendedJobIds, setRecommendedJobIds] = useState<Set<number>>(new Set());
+    const [recommendUpdating, setRecommendUpdating] = useState<number | null>(null);
+
+    const fetchRecommendedJobIds = async () => {
+        try {
+            const res = await fetch('/api/system-admin/recommended-jobs');
+            if (!res.ok) return;
+            const data = await res.json();
+            const ids = new Set<number>((data.jobs ?? []).map((r: any) => r.job.id as number));
+            setRecommendedJobIds(ids);
+        } catch (e) {
+            console.error('Failed to fetch recommended jobs', e);
+        }
+    };
+
+    useEffect(() => {
+        fetchRecommendedJobIds();
+    }, []);
+
+    const handleToggleRecommend = async (job: Job) => {
+        if (recommendUpdating === job.id) return;
+        const isRegistered = recommendedJobIds.has(job.id);
+        setRecommendUpdating(job.id);
+        try {
+            const res = isRegistered
+                ? await fetch(`/api/system-admin/recommended-jobs?jobId=${job.id}`, { method: 'DELETE' })
+                : await fetch('/api/system-admin/recommended-jobs', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ jobId: job.id }),
+                });
+
+            if (!res.ok) {
+                const err = await res.json().catch(() => ({}));
+                toast.error(err.error || (isRegistered ? '解除に失敗しました' : '登録に失敗しました'));
+                return;
+            }
+
+            setRecommendedJobIds(prev => {
+                const next = new Set(prev);
+                if (isRegistered) next.delete(job.id);
+                else next.add(job.id);
+                return next;
+            });
+            toast.success(isRegistered ? 'おすすめ求人から外しました' : 'おすすめ求人に登録しました');
+        } catch (e) {
+            console.error(e);
+            toast.error('通信エラーが発生しました');
+        } finally {
+            setRecommendUpdating(null);
+        }
+    };
 
     const handleToggleWorkDate = async (workDateId: number, isClosed: boolean) => {
         setWorkDateUpdating(workDateId);
@@ -567,6 +622,19 @@ export default function SystemAdminJobsPage() {
                                     </td>
                                     <td className="px-4 py-4 text-right">
                                         <div className="flex items-center justify-end gap-1">
+                                            {/* おすすめ求人 */}
+                                            <button
+                                                onClick={() => handleToggleRecommend(job)}
+                                                disabled={recommendUpdating === job.id}
+                                                className={`p-1.5 rounded-lg transition-colors disabled:opacity-50 ${
+                                                    recommendedJobIds.has(job.id)
+                                                        ? 'text-amber-500 hover:text-amber-600 hover:bg-amber-50'
+                                                        : 'text-slate-400 hover:text-amber-500 hover:bg-amber-50'
+                                                }`}
+                                                title={recommendedJobIds.has(job.id) ? 'おすすめ求人から外す' : 'おすすめ求人に登録'}
+                                            >
+                                                <Star className={`w-4 h-4 ${recommendedJobIds.has(job.id) ? 'fill-current' : ''}`} />
+                                            </button>
                                             {/* 勤務日管理 */}
                                             <button
                                                 onClick={() => setWorkDateModalJob(job)}


### PR DESCRIPTION
## Summary
- `/system-admin/jobs` の各行アクションに★ボタンを追加し、押すだけで `/system-admin/lp/recommended-jobs` への登録／解除が即時保存・反映されるように
- 既存仕様（おすすめ求人ページでの並び替え・保存）はそのまま温存し、API に単件追加・解除用エンドポイントを追加

## 変更内容
### UI: `app/system-admin/jobs/page.tsx`
- アクション欄の先頭に `Star` ボタンを追加
  - 未登録: グレー枠
  - 登録済: amber 塗りつぶし
- 初回ロードで `GET /api/system-admin/recommended-jobs` から登録済み job_id を取得し `Set` で保持
- クリックで POST/DELETE → 成功時にローカル状態を即時更新（楽観的トグル + トースト表示）
- 連打防止のため `recommendUpdating` で対象行をロック

### API: `app/api/system-admin/recommended-jobs/route.ts`
- `POST { jobId }`: 単件追加
  - 求人存在チェック / 重複登録チェック / 上限20件チェック
  - `sort_order` は末尾に自動付与
- `DELETE ?jobId=N`: 単件解除
- 既存の `PUT`（全件置換、ドラッグ＆ドロップ並び替え用）は変更なし

## Test plan
- [ ] `/system-admin/jobs` の任意の行で★を押下 → トースト「おすすめ求人に登録しました」、★が塗りつぶしに変化
- [ ] `/system-admin/lp/recommended-jobs` を開き、末尾に追加されていることを確認
- [ ] 同じ★を再度押下 → トースト「おすすめ求人から外しました」、★がグレーに戻り、おすすめ求人一覧から消える
- [ ] 既に20件登録済みの状態で★押下 → 「最大20件までです」エラーになる
- [ ] おすすめ求人ページ側でのドラッグ並び替え・保存が引き続き動作する（PUT 影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)