### PR TITLE
docs: ドキュメントギャップ対応 (YUT-151) — 5 件の機能変更を既存仕様へ追記

### DIFF
--- a/docs/features/analytics.md
+++ b/docs/features/analytics.md
@@ -336,3 +336,28 @@ components/system-admin/
 | 登録離脱トラッキング | 未実装 | 登録フローにイベント発火追加必要 |
 | 直前キャンセルの定義 | 要確認 | 24時間以内でOK？ |
 | バッチ処理の実行環境 | 要検討 | cron, Vercel Cron, 外部サービス |
+
+---
+
+## 13. 求人アナリティクス API 認証
+
+`/api/funnel-analytics` と `/api/job-analytics` は system-admin 画面から内部 API として呼び出される。NextAuth のワーカー向け middleware で 401 にならないよう、`middleware.ts` の `ignoredPaths` に以下を追加している。
+
+- `/api/job-analytics`
+- `/api/funnel-analytics`
+
+ただし認証を無くしたわけではない。各 route handler の先頭で `getSystemAdminSessionData()` を呼び、system-admin セッションが無い場合は 401 を返す。
+
+### 13.1 認証責務の分離
+
+| 層 | 責務 |
+|---|---|
+| `middleware.ts` | ワーカー向け NextAuth JWT の強制対象から内部 API を除外する |
+| `app/api/funnel-analytics/route.ts` | system-admin セッションを検証し、登録動線 KPI を返す |
+| `app/api/job-analytics/route.ts` | system-admin セッションを検証し、求人 PV / 応募 KPI を返す |
+
+### 13.2 セキュリティ注意点
+
+- `ignoredPaths` に入れる API は、route handler 側で必ず独自認証を行う。
+- `Cache-Control: no-store` を返し、管理画面の集計値を共有キャッシュに載せない。
+- クライアントからの `startDate`, `endDate`, `breakdown` は集計条件であり、認可条件として扱わない。

--- a/docs/features/job-matching.md
+++ b/docs/features/job-matching.md
@@ -228,3 +228,27 @@ model Application {
 - [通知機能](./notifications.md) - マッチング通知
 - [レビュー機能](./reviews.md) - 勤務後のレビュー
 - [オファー・限定求人](./offer-limited-job.md) - 特殊求人タイプ
+
+---
+
+## 11. 求人テンプレート削除ルール
+
+施設管理者が求人テンプレートを削除する場合、使用中のテンプレートは削除できない。元データ保護のため、`Job.template_id` が 1 件でも参照していれば拒否する。
+
+### 11.1 実装
+
+`src/lib/actions/job-template.ts#deleteJobTemplate(templateId, facilityId)` で次の順に処理する。
+
+1. `templateId` と `facilityId` が正の整数か検証する。
+2. `validateFacilityAccess(facilityId)` で施設管理者セッションを確認する。
+3. 対象テンプレートが同じ施設に属するか確認する。
+4. `prisma.job.count({ where: { template_id: templateId } })` が 1 以上なら削除を拒否する。
+5. 削除直前に競合で参照が増え、DB の FK 制約 `P2003` が発生した場合も同じ「使用中」エラーとして返す。
+
+### 11.2 ユーザー向けエラー
+
+```text
+このテンプレートは使用中の求人があるため削除できません
+```
+
+削除拒否時は `JOB_TEMPLATE_DELETE` の操作ログに `referencingJobCount` と `reason` を残す。

--- a/docs/features/notifications.md
+++ b/docs/features/notifications.md
@@ -307,3 +307,30 @@ VAPID_SUBJECT=mailto:support@tastas.jp
 └── lib/
     └── push-notification.ts
 ```
+
+---
+
+## 10. 施設向けメール送信先
+
+施設向け通知メールの送信先は `Facility.staff_emails` に統一する。旧来の単一メール項目や管理者メールからの推測送信は使わない。
+
+### 10.1 対象処理
+
+| 処理 | 実装箇所 | 通知キー例 |
+|---|---|---|
+| 勤務前日リマインド | `app/api/cron/notifications/route.ts` | `FACILITY_REMINDER_DAY_BEFORE` |
+| 求人締切警告 | `app/api/cron/notifications/route.ts` | `FACILITY_DEADLINE_WARNING` |
+| 新規応募 | `src/lib/actions/notification.ts` | `FACILITY_NEW_APPLICATION` |
+| レビュー依頼・レビュー受信 | `src/lib/actions/notification.ts` | `FACILITY_REVIEW_REQUEST`, `FACILITY_REVIEW_RECEIVED` |
+| 募集枠充足 | `src/lib/actions/notification.ts` | `FACILITY_SLOTS_FILLED` |
+| 新着メッセージ | `src/lib/actions/notification.ts` | `FACILITY_NEW_MESSAGE` |
+
+### 10.2 送信ルール
+
+- `staff_emails` が空配列または未設定の場合は送信をスキップし、ログに施設 ID を残す。
+- テンプレート変数は送信前にすべて展開する。未置換の `{{variable}}` が残らないよう、通知テンプレート更新時にテスト送信で確認する。
+- 施設管理画面の「通知先メールアドレス」を唯一の運用入力とする。
+
+### 10.3 移行手順
+
+既存施設で `staff_emails` が空の場合は、`prisma/seed-fix-staff-emails-staging.ts` を参考にステージングで補完後、本番用の移行スクリプトを作成する。移行後は dev portal の通知ログで施設向け通知の宛先を確認する。

--- a/docs/features/system-admin.md
+++ b/docs/features/system-admin.md
@@ -782,10 +782,51 @@ enum FacilityStatus {
 
 ---
 
+## 17. LP管理: LP番号バッジ色
+
+`/system-admin/lp` の LP 一覧では、LP 番号バッジの色を 10 色から選択できる。
+
+### 17.1 データ項目
+
+`LandingPage.badge_color` に Tailwind 色名を保存する。
+
+```prisma
+badge_color String @default("rose") @map("badge_color") @db.VarChar(20)
+```
+
+許可値:
+
+| 値 | 表示名 |
+|---|---|
+| `rose` | ローズ |
+| `orange` | オレンジ |
+| `amber` | アンバー |
+| `emerald` | エメラルド |
+| `teal` | ティール |
+| `sky` | スカイ |
+| `blue` | ブルー |
+| `indigo` | インディゴ |
+| `violet` | バイオレット |
+| `pink` | ピンク |
+
+### 17.2 UI / 更新
+
+- UI 定義: `app/system-admin/lp/components/DBLPList.tsx` の `BADGE_COLORS`
+- 更新処理: `lib/lp-actions.ts#updateLandingPageBadgeColor`
+- サーバ側でも `ALLOWED_BADGE_COLORS` で許可値を検証する。
+- 不正値は `無効な色が指定されました` を返し、DB 更新しない。
+
+### 17.3 コピー時の扱い
+
+LP コピーでは `copyLandingPage()` が元 LP の `badge_color` を新 LP に引き継ぐ。コピー後に別色へ変更したい場合は LP 一覧のカラーピッカーから変更する。
+
+---
+
 ## 更新履歴
 
 | 日付 | 内容 |
 |------|------|
+| 2026-05-11 | LP管理のLP番号バッジ色（`badge_color`）仕様を追加 |
 | 2025-12-04 | 初版作成。要件メモとして整理 |
 | 2025-12-05 | マップピン位置調整機能を追加 |
 | 2025-12-09 | 詳細要件定義書として大幅拡充。アナリティクス、AI監視機能、DB設計案を追加 |

--- a/docs/specifications/registration-flow-redesign.md
+++ b/docs/specifications/registration-flow-redesign.md
@@ -501,3 +501,23 @@ if (formData.accountName && !isKatakanaWithSpaceOnly(formData.accountName)) {
 1. **Phase 1**: 登録フォーム2ステップ化 + API変更 + メール認証リダイレクト変更 + プロフィール保存バリデーション緩和
 2. **Phase 2**: PWAインストール促進（モーダル + バナー）
 3. **Phase 3**: プロフィール未入力リマインド（バナー + バッジ + 求人詳細警告）
+
+---
+
+## 11. ログイン済みユーザーの新規登録ページアクセス
+
+LP の「タスタスに登録」バナーなどから `/register/worker` に遷移した際、既にログイン済みのワーカーは新規登録フォームを表示せず求人トップへ転送する。
+
+### 11.1 挙動
+
+| 状態 | 遷移 |
+|---|---|
+| 未ログイン | `/register/worker` の登録フォームを表示 |
+| ログイン済み | `router.replace('/')` で求人トップへ転送 |
+| 認証状態ロード中 | 判定完了までページ内で待機 |
+
+### 11.2 実装メモ
+
+`app/register/worker/page.tsx` で `useAuth()` の `isAuthenticated` と `isLoading` を参照する。`isAuthLoading` が false になり、かつ `isAuthenticated` が true の場合のみ redirect する。
+
+この分岐は会員が LP 経由で再度登録フォームに入ってしまう混乱を避けるためのもので、未会員の登録導線には影響しない。

--- a/docs/specifications/system-design.md
+++ b/docs/specifications/system-design.md
@@ -728,6 +728,17 @@ NEXTAUTH_URL="http://localhost:3000"
 | `cancelRateThreshold` | キャンセル率閾値 | この値を超えるキャンセル率でアラートが発動する | 通知設定で設定可能（デフォルト: 30%） | ダッシュボード アラート |
 | `consecutiveLowRatingCount` | 連続低評価回数 | この回数連続で低評価を受けるとアラートが発動する | 通知設定で設定可能（デフォルト: 3回） | ダッシュボード アラート |
 
+### 9.10 system-admin 内部 API 認証境界
+
+`/api/funnel-analytics` と `/api/job-analytics` は system-admin 画面のタブから呼び出す内部 API である。ワーカー向け NextAuth middleware で 401 にならないよう `middleware.ts` の `ignoredPaths` に追加するが、route handler 側で `getSystemAdminSessionData()` を必ず実行する。
+
+| API | middleware | route handler |
+|---|---|---|
+| `/api/funnel-analytics` | NextAuth JWT 対象外 | system-admin セッション必須 |
+| `/api/job-analytics` | NextAuth JWT 対象外 | system-admin セッション必須 |
+
+この分離により、ワーカー認証と system-admin 認証を混在させずに管理画面の集計 API を使える。`ignoredPaths` へ追加する API は、同じように handler 内で独自認証を持つことを条件にする。
+
 ---
 
 ## 10. 通知システム
@@ -846,6 +857,7 @@ notification_settings (
 
 | 日付 | 内容 |
 |------|------|
+| 2026-05-11 | system-admin 内部アナリティクス API の middleware バイパスと route handler 認証責務を追記 |
 | 2026-02-25 | 登録動線分析（9.8）: 集計方式を「コホート集計」として明記、全指標の計算方法を実装と整合（行動日フィルターなし明記）、applicationTotal指標追加、ソースフィルター転換率制約追記 |
 | 2026-02-25 | 登録動線分析（9.8）: PV指標4種追加（登録ページPV/UU、検索PV、詳細PV）、応募ボタンクリックUU追加、お気に入り定義修正（施設お気に入り除外）、ソースフィルター制約注記 |
 | 2026-02-24 | 指標定義: 求人分析（9.7）・登録動線分析（9.8）セクション追加、退会済みユーザーのログ保持ポリシー明記 |


### PR DESCRIPTION
## Summary
- YUT-151 のドキュメントギャップ分析を受けて `docs/` 配下の 6 ファイルへ追記
- 過去 7 日間（2026-05-04〜2026-05-11）に develop へマージされた機能のうち、System Advisor 以外でドキュメント未追従だったものが対象
- GPT-Codex（run `e05df437`）が起草、Atlas が検証・コミット

## 追記内容
| ファイル | 追記内容 |
|---|---|
| `docs/features/system-admin.md` | LP 番号バッジ カラーピッカー（`LandingPage.badge_color`、10色ホワイトリスト、コピー時引き継ぎ） |
| `docs/features/analytics.md` | `/api/funnel-analytics` `/api/job-analytics` の middleware バイパス + route handler 側で system-admin セッション再確認 |
| `docs/specifications/system-design.md` | 内部 API の認証責務分離（middleware と route handler の役割） |
| `docs/features/notifications.md` | 施設通知の送信先を `staff_emails` に統一、テンプレート変数置換、`prisma/seed-fix-staff-emails-staging.ts` の運用手順 |
| `docs/features/job-matching.md` | 求人テンプレート削除の仕様変更（使用中なら拒否） |
| `docs/specifications/registration-flow-redesign.md` | ワーカー新規登録ページにおけるログイン済みアクセス時の遷移 |

## 対象コミット（参考）
- `5e39a8d` LP 番号バッジ カラーピッカー (#585)
- `1be05c6` 求人アナリティクスタブの 401 解消 (#576)
- `e61f798` 施設通知メールの送信先を staff_emails に統一 (#586)
- `839511a` 施設前日リマインドメールでテンプレート変数が未置換 (#582)
- `722fc89` / `97cbe59` 求人テンプレート削除関連 (#581 / #580)
- `3143dca` ワーカー新規登録ページにログイン済みリダイレクト

## Test plan
- [x] `git diff --check` 通過
- [ ] レビュアー: `LandingPage.badge_color` の許可色リスト（rose/orange/amber/emerald/teal/sky/blue/indigo/violet/pink）が実装と一致しているか確認
- [ ] レビュアー: 内部 API バイパスの ignoredPaths と route handler 側のセッション検証が文書通りか確認

ドキュメントのみの変更のためアプリのテストは未実行です。

## 関連
- Issue: YUT-151
- Drafted-by: GPT-Codex (run `e05df437`)
- Committed-by: Atlas

🤖 Generated with [Claude Code](https://claude.com/claude-code)