### PR TITLE
バグ修正: 登録サンクスページのLINE登録ボタンをLステップ専用URLに固定

### DIFF
--- a/app/register/worker/thanks/page.tsx
+++ b/app/register/worker/thanks/page.tsx
@@ -1,48 +1,13 @@
 import { redirect } from 'next/navigation';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
-import prisma from '@/lib/prisma';
 import ThanksClient from './ThanksClient';
 
 export const dynamic = 'force-dynamic';
 
-/**
- * LINE 友だち追加 URL を取得。優先順位:
- * 1. 登録時の LP (user.registration_lp_id) の LandingPage.cta_url
- * 2. LpLineTag の is_default=true のエントリの URL
- * 3. 空文字（LINE ボタン非表示）
- * 環境変数に依存しない。DB 側は LP 管理画面 / LINE タグ管理画面から設定可能
- */
-async function resolveLineUrlForUser(userId: number): Promise<string> {
-  try {
-    // 1. 登録 LP の cta_url
-    const user = await prisma.user.findUnique({
-      where: { id: userId },
-      select: { registration_lp_id: true },
-    });
-    if (user?.registration_lp_id) {
-      const lpNum = parseInt(user.registration_lp_id, 10);
-      if (!isNaN(lpNum)) {
-        const lp = await prisma.landingPage.findUnique({
-          where: { lp_number: lpNum },
-          select: { cta_url: true },
-        });
-        if (lp?.cta_url) return lp.cta_url;
-      }
-    }
-
-    // 2. フォールバック: デフォルト LINE タグ（複数 is_default=true があっても安定選択）
-    const defaultTag = await prisma.lpLineTag.findFirst({
-      where: { is_default: true },
-      orderBy: [{ sort_order: 'asc' }, { id: 'asc' }],
-      select: { url: true },
-    });
-    return defaultTag?.url ?? '';
-  } catch (e) {
-    console.error('[thanks] Failed to resolve LINE URL:', e);
-    return '';
-  }
-}
+// Lステップのサンクスページ経由を識別するための専用URL（lp=jOaQo9 が「サンクスページ流入」のシナリオ分岐キー）
+const THANKS_LINE_URL =
+  'https://liff.line.me/2009053059-UzfNXDJd/landing?follow=%40894ipobi&lp=jOaQo9&liff_id=2009053059-UzfNXDJd';
 
 export default async function RegisterThanksPage() {
   const session = await getServerSession(authOptions);
@@ -51,8 +16,5 @@ export default async function RegisterThanksPage() {
     redirect('/login');
   }
 
-  const userId = parseInt(session.user.id, 10);
-  const lineUrl = await resolveLineUrlForUser(userId);
-
-  return <ThanksClient userName={session.user.name ?? ''} lineUrl={lineUrl} />;
+  return <ThanksClient userName={session.user.name ?? ''} lineUrl={THANKS_LINE_URL} />;
 }


### PR DESCRIPTION
## Summary
- 登録サンクスページ (`/register/worker/thanks`) のLINE登録ボタンの遷移先を、LP由来のCTA URLから **Lステップ専用のサンクスページ識別URL (`lp=jOaQo9`)** に固定
- これにより既登録ユーザーへワーカー登録促進シナリオが再発動するバグ（デバック一覧No68）を解消

## 背景
クライアント仕様（PDF「Lステップ 流入経路分析URLの正しい流れ」）に基づく:
- LP本体のLINEボタン → LP別の `lp` コード（広告ソース識別用）
- サンクスページのLINEボタン → 単一の専用URL `lp=jOaQo9`（サンクスページ流入の識別用）

現状コードはサンクスページでもLPの `cta_url` を返していたため、Lステップが「LP流入」と誤認し、登録済みユーザーにも再度ワーカー登録を促していた。

## 変更内容
- `app/register/worker/thanks/page.tsx`
  - `resolveLineUrlForUser()` 関数と `prisma` インポートを削除
  - モジュール定数 `THANKS_LINE_URL` でハードコード化
  - WHYコメント1行を追加

## 影響範囲
- 影響を受ける: `/register/worker/thanks` のLINEボタンのみ
- 影響を受けない: LP本体のLINEボタン（`LandingPage.cta_url` 経由）、おすすめ求人ウィジェット

## Test plan
- [ ] ステージング (`https://stg-share-worker.vercel.app`) でテストユーザー新規登録 → サンクスページ到達
- [ ] 「公式LINEに登録」ボタンの遷移先URLが `…&lp=jOaQo9&…` であることを確認
- [ ] LP1/LP2 等の異なるLP経由でも同URLに固定されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)