### PR TITLE
バグ修正: 性別指定求人のワーカー側フィルタ・応募制限を実装

### DIFF
--- a/app/jobs/[id]/page.tsx
+++ b/app/jobs/[id]/page.tsx
@@ -4,6 +4,10 @@ import JobDetailTracker from '@/components/tracking/JobDetailTracker';
 import { notFound } from 'next/navigation';
 import { cookies } from 'next/headers';
 import { DEBUG_TIME_COOKIE_NAME, parseDebugTimeCookie, getCurrentTimeFromSettings } from '@/utils/debugTime.server';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+import { canApplyByGender } from '@/src/lib/jobGenderMatching';
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -121,7 +125,23 @@ export default async function JobDetail({ params, searchParams }: PageProps) {
     targetWorkerId: jobData.target_worker_id,
     // 募集完了フラグ
     isRecruitmentClosed: jobData.isRecruitmentClosed || false,
+    // 性別指定
+    genderRequirement: jobData.gender_requirement || null,
   };
+
+  // 性別指定による応募可否判定（サーバー側）
+  const session = await getServerSession(authOptions);
+  let genderApplyResult: { allowed: boolean; reason?: string } = { allowed: true };
+  if (session?.user?.id) {
+    const currentUser = await prisma.user.findUnique({
+      where: { id: parseInt(session.user.id, 10) },
+      select: { gender: true },
+    });
+    genderApplyResult = canApplyByGender(jobData.gender_requirement, currentUser?.gender);
+  } else if (jobData.gender_requirement) {
+    // 未ログインかつ性別指定ありの求人
+    genderApplyResult = canApplyByGender(jobData.gender_requirement, null);
+  }
 
   const facility = {
     id: jobData.facility.id,
@@ -193,6 +213,7 @@ export default async function JobDetail({ params, searchParams }: PageProps) {
         isPreviewMode={isPreviewMode}
         scheduledJobs={scheduledJobs}
         interviewPassRate={interviewPassRate}
+        genderApplyResult={genderApplyResult}
       />
     </>
   );

--- a/components/job/JobDetailClient.tsx
+++ b/components/job/JobDetailClient.tsx
@@ -48,6 +48,8 @@ interface JobDetailClientProps {
   scheduledJobs?: ScheduledJob[]; // ユーザーのスケジュール済み仕事（時間重複判定用）
   isPublic?: boolean; // 公開版（未ログイン）表示モード
   interviewPassRate?: InterviewPassRateData | null; // 面接通過率データ（審査あり求人用）
+  /** 性別指定による応募可否（サーバー側判定結果）。allowed=false の場合は応募ボタンを無効化 */
+  genderApplyResult?: { allowed: boolean; reason?: string };
 }
 
 /**
@@ -67,7 +69,7 @@ function isTimeOverlapping(start1: string, end1: string, start2: string, end2: s
   return e1 > s2 && e2 > s1;
 }
 
-export function JobDetailClient({ job, facility, relatedJobs: _relatedJobs, facilityReviews, initialHasApplied: _initialHasApplied, initialAppliedWorkDateIds = [], selectedDate, isPreviewMode = false, scheduledJobs = [], isPublic = false, interviewPassRate = null }: JobDetailClientProps) {
+export function JobDetailClient({ job, facility, relatedJobs: _relatedJobs, facilityReviews, initialHasApplied: _initialHasApplied, initialAppliedWorkDateIds = [], selectedDate, isPreviewMode = false, scheduledJobs = [], isPublic = false, interviewPassRate = null, genderApplyResult }: JobDetailClientProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { refreshBadges } = useBadge();
@@ -1533,21 +1535,28 @@ export function JobDetailClient({ job, facility, relatedJobs: _relatedJobs, faci
       {!isPreviewMode && !isPublic && (
         <div className="fixed bottom-16 left-0 right-0 bg-white border-t border-gray-200 z-10" style={{ bottom: 'calc(4rem + env(safe-area-inset-bottom))' }}>
           <div className="p-4">
+            {genderApplyResult && !genderApplyResult.allowed && (
+              <p className="text-xs text-red-600 mb-2 text-center">
+                {genderApplyResult.reason || 'この求人は応募条件を満たしていないため応募不可です'}
+              </p>
+            )}
             <Button
               onClick={handleApplyButtonClick}
               size="lg"
               className="w-full"
-              disabled={isApplying || selectedWorkDateIds.length === 0 || !hasAvailableDates}
+              disabled={isApplying || selectedWorkDateIds.length === 0 || !hasAvailableDates || (genderApplyResult ? !genderApplyResult.allowed : false)}
             >
-              {!hasAvailableDates
-                ? '応募できる日程がありません'
-                : isApplying
-                  ? (job.jobType === 'OFFER' ? '受諾中...' : '応募中...')
-                  : selectedWorkDateIds.length > 0
-                    ? (job.jobType === 'OFFER' ? 'オファーを受ける' : `${selectedWorkDateIds.length}件の日程に応募する`)
-                    : !hasAvailableDates
-                      ? '応募できる日程がありません'
-                      : '日程を選択してください'}
+              {genderApplyResult && !genderApplyResult.allowed
+                ? '応募条件を満たしていません'
+                : !hasAvailableDates
+                  ? '応募できる日程がありません'
+                  : isApplying
+                    ? (job.jobType === 'OFFER' ? '受諾中...' : '応募中...')
+                    : selectedWorkDateIds.length > 0
+                      ? (job.jobType === 'OFFER' ? 'オファーを受ける' : `${selectedWorkDateIds.length}件の日程に応募する`)
+                      : !hasAvailableDates
+                        ? '応募できる日程がありません'
+                        : '日程を選択してください'}
             </Button>
           </div>
         </div>

--- a/src/lib/actions/application-worker.ts
+++ b/src/lib/actions/application-worker.ts
@@ -5,6 +5,7 @@ import { revalidatePath } from 'next/cache';
 import { getCurrentTime } from '@/utils/debugTime';
 import { getAuthenticatedUser } from './helpers';
 import { checkProfileComplete } from './user-profile';
+import { canApplyByGender } from '@/src/lib/jobGenderMatching';
 import {
     sendApplicationNotification,
     sendApplicationNotificationMultiple,
@@ -249,6 +250,13 @@ export async function applyForJob(jobId: string, workDateId?: number) {
             };
         }
 
+        // 性別指定バリデーション（求人の gender_requirement とユーザー性別をチェック）
+        const genderCheck = canApplyByGender(job.gender_requirement, user.gender);
+        if (!genderCheck.allowed) {
+            console.log('[applyForJob] Gender mismatch:', { jobReq: job.gender_requirement, userGender: user.gender });
+            return { success: false, error: genderCheck.reason || '応募条件を満たしていません' };
+        }
+
         const targetWorkDateId = workDateId || job.workDates[0].id;
         const targetWorkDate = job.workDates.find(wd => wd.id === targetWorkDateId);
 
@@ -472,6 +480,13 @@ export async function applyForJobMultipleDates(jobId: string, workDateIds: numbe
                 error: `プロフィールを完成させてください。未入力項目: ${profileCheck.missingFields.join('、')}`,
                 missingFields: profileCheck.missingFields,
             };
+        }
+
+        // 性別指定バリデーション
+        const genderCheck = canApplyByGender(job.gender_requirement, user.gender);
+        if (!genderCheck.allowed) {
+            console.log('[applyForJobMultipleDates] Gender mismatch:', { jobReq: job.gender_requirement, userGender: user.gender });
+            return { success: false, error: genderCheck.reason || '応募条件を満たしていません' };
         }
 
         const targetWorkDates = job.workDates.filter(wd => workDateIds.includes(wd.id));
@@ -1037,6 +1052,13 @@ export async function acceptOffer(jobId: string, workDateId: number) {
                 error: `プロフィールを完成させてください。未入力項目: ${profileCheck.missingFields.join('、')}`,
                 missingFields: profileCheck.missingFields,
             };
+        }
+
+        // 性別指定バリデーション（オファーの場合も誤承諾を防ぐ）
+        const genderCheck = canApplyByGender(job.gender_requirement, user.gender);
+        if (!genderCheck.allowed) {
+            console.log('[acceptOffer] Gender mismatch:', { jobReq: job.gender_requirement, userGender: user.gender });
+            return { success: false, error: genderCheck.reason || '応募条件を満たしていません' };
         }
 
         const targetWorkDate = job.workDates.find(wd => wd.id === workDateId);

--- a/src/lib/actions/job-worker.ts
+++ b/src/lib/actions/job-worker.ts
@@ -15,6 +15,26 @@ import {
     JobListType
 } from './helpers';
 import { logActivity, getErrorMessage, getErrorStack } from '@/lib/logger';
+import { buildGenderFilterWhere } from '@/src/lib/jobGenderMatching';
+
+/**
+ * 現在ログイン中ユーザーの性別を取得（未ログイン時はnull）
+ * 求人一覧の性別フィルタで使用
+ */
+async function getCurrentUserGender(): Promise<string | null> {
+    try {
+        const session = await getServerSession(authOptions);
+        if (!session?.user?.id) return null;
+        const userId = parseInt(session.user.id, 10);
+        const user = await prisma.user.findUnique({
+            where: { id: userId },
+            select: { gender: true },
+        });
+        return user?.gender ?? null;
+    } catch {
+        return null;
+    }
+}
 
 /**
  * キャッシュされた求人詳細を取得
@@ -325,6 +345,11 @@ export async function getJobs(
             });
         }
     }
+
+    // 性別指定フィルタ（求人の gender_requirement と ユーザー性別をマッチング）
+    const userGender = await getCurrentUserGender();
+    whereConditions.AND = whereConditions.AND || [];
+    whereConditions.AND.push(buildGenderFilterWhere(userGender));
 
     const jobs = await prisma.job.findMany({
         where: whereConditions,
@@ -953,6 +978,11 @@ export async function getJobsListWithPagination(
     if (sort === 'wage') {
         orderByCondition = { hourly_wage: 'desc' };
     }
+
+    // 性別指定フィルタ（求人の gender_requirement と ユーザー性別をマッチング）
+    const userGender = await getCurrentUserGender();
+    whereConditions.AND = whereConditions.AND || [];
+    whereConditions.AND.push(buildGenderFilterWhere(userGender));
 
     // workDatesの取得条件（先に定義して並列実行可能に）
     const workDatesWhereCondition: any = {
@@ -1698,6 +1728,9 @@ export async function getBookmarkedJobs(type: 'FAVORITE' | 'WATCH_LATER', option
         const limit = options?.limit ?? 50; // デフォルト50件
         const offset = options?.offset ?? 0;
 
+        // 性別指定フィルタ: ターゲット求人の gender_requirement とユーザー性別が一致するブックマークのみ
+        const genderFilter = buildGenderFilterWhere(user.gender);
+
         const bookmarks = await prisma.bookmark.findMany({
             where: {
                 user_id: user.id,
@@ -1705,6 +1738,7 @@ export async function getBookmarkedJobs(type: 'FAVORITE' | 'WATCH_LATER', option
                 target_job_id: {
                     not: null,
                 },
+                targetJob: { is: genderFilter },
             },
             include: {
                 targetJob: {
@@ -1760,6 +1794,10 @@ export async function getJobListTypeCounts(): Promise<{
     // 日本時間（JST）での今日の開始時刻を使用
     const todayStart = getJSTTodayStart(now);
 
+    // 性別指定フィルタ
+    const userGender = await getCurrentUserGender();
+    const genderFilter = buildGenderFilterWhere(userGender);
+
     // 基本条件（表示可能な求人）
     const baseConditions: any = {
         status: { in: ['PUBLISHED', 'WORKING', 'COMPLETED'] },
@@ -1784,7 +1822,8 @@ export async function getJobListTypeCounts(): Promise<{
         },
         facility: {
             deleted_at: null,
-        }
+        },
+        AND: [genderFilter],
     };
 
     // 「すべて」の件数（通常求人・説明会）

--- a/src/lib/actions/notification.ts
+++ b/src/lib/actions/notification.ts
@@ -6,6 +6,7 @@ import { getAuthenticatedUser, createNotification } from './helpers';
 import { sendNotification } from '../notification-service';
 import { getFacilityUnreadMessageCount, getWorkerUnreadMessageCount } from './message';
 import { logActivity, getErrorMessage, getErrorStack } from '@/lib/logger';
+import { canApplyByGender } from '@/src/lib/jobGenderMatching';
 
 /**
  * ユーザーの通知一覧を取得
@@ -749,7 +750,13 @@ export async function sendFavoriteNewJobNotification(
     jobId: number
 ) {
     try {
-        // この施設をお気に入りしているワーカーを取得
+        // 求人の性別指定を取得（通知対象を絞り込むため）
+        const job = await prisma.job.findUnique({
+            where: { id: jobId },
+            select: { gender_requirement: true },
+        });
+
+        // この施設をお気に入りしているワーカーを取得（性別マッチ判定用に gender も取得）
         const bookmarks = await prisma.bookmark.findMany({
             where: {
                 target_facility_id: facilityId,
@@ -757,7 +764,7 @@ export async function sendFavoriteNewJobNotification(
             },
             include: {
                 user: {
-                    select: { id: true, name: true, email: true },
+                    select: { id: true, name: true, email: true, gender: true },
                 },
             },
         });
@@ -768,8 +775,16 @@ export async function sendFavoriteNewJobNotification(
         }
 
         let sentCount = 0;
+        let skippedByGender = 0;
         for (const bookmark of bookmarks) {
             if (!bookmark.user) continue;
+
+            // 性別指定フィルタ: 応募できないワーカーには通知しない
+            const genderCheck = canApplyByGender(job?.gender_requirement, bookmark.user.gender);
+            if (!genderCheck.allowed) {
+                skippedByGender++;
+                continue;
+            }
 
             await sendNotification({
                 notificationKey: 'WORKER_FAVORITE_NEW_JOB',
@@ -785,7 +800,7 @@ export async function sendFavoriteNewJobNotification(
             sentCount++;
         }
 
-        console.log('[sendFavoriteNewJobNotification] Sent to', sentCount, 'workers');
+        console.log('[sendFavoriteNewJobNotification] Sent to', sentCount, 'workers, skipped by gender:', skippedByGender);
         return { success: true, count: sentCount };
     } catch (error) {
         console.error('[sendFavoriteNewJobNotification] Error:', error);

--- a/src/lib/jobGenderMatching.ts
+++ b/src/lib/jobGenderMatching.ts
@@ -1,0 +1,44 @@
+/**
+ * 求人の性別指定とワーカーの性別をマッチング判定するヘルパー
+ *
+ * 仕様:
+ * - 求人の gender_requirement が NULL: 全ワーカー対象
+ * - gender_requirement = 'MALE_ONLY': User.gender = '男性' のみ
+ * - gender_requirement = 'FEMALE_ONLY': User.gender = '女性' のみ
+ * - 性別未登録(NULL)/その他: 性別指定のある求人は表示・応募不可
+ */
+
+import type { Prisma } from '@prisma/client';
+
+/**
+ * Prismaの where 句に AND で結合する性別フィルタを生成
+ * 一覧クエリで使用
+ */
+export function buildGenderFilterWhere(
+  userGender: string | null | undefined
+): Prisma.JobWhereInput {
+  if (userGender === '男性') {
+    return { OR: [{ gender_requirement: null }, { gender_requirement: 'MALE_ONLY' }] };
+  }
+  if (userGender === '女性') {
+    return { OR: [{ gender_requirement: null }, { gender_requirement: 'FEMALE_ONLY' }] };
+  }
+  return { gender_requirement: null };
+}
+
+/**
+ * 個別求人 vs ユーザー性別の応募可否判定
+ * 詳細ページ・応募サーバーアクションで使用
+ */
+export function canApplyByGender(
+  jobGenderRequirement: string | null | undefined,
+  userGender: string | null | undefined
+): { allowed: boolean; reason?: string } {
+  if (!jobGenderRequirement) return { allowed: true };
+  if (jobGenderRequirement === 'MALE_ONLY' && userGender === '男性') return { allowed: true };
+  if (jobGenderRequirement === 'FEMALE_ONLY' && userGender === '女性') return { allowed: true };
+  return {
+    allowed: false,
+    reason: 'この求人は応募条件を満たしていないため応募不可です',
+  };
+}

--- a/src/lib/notification-service.ts
+++ b/src/lib/notification-service.ts
@@ -4,6 +4,7 @@ import { Resend } from 'resend';
 import { getTodayStart } from '@/utils/debugTime';
 import { getVersionForLog } from '@/lib/version';
 import { cacheResendQuotaHeader } from '@/src/lib/resend-quota';
+import { canApplyByGender } from '@/src/lib/jobGenderMatching';
 
 // Resend設定（遅延初期化 - APIキーがない場合はnull）
 let resend: Resend | null = null;
@@ -679,13 +680,17 @@ export async function sendNearbyJobNotifications(
         const canSend = await canSendNearbyNotification(workerId, notificationKey, maxPerDay);
         if (!canSend) continue;
 
-        // ワーカー情報を取得（名前に置換するため）
+        // ワーカー情報を取得（名前に置換するため・性別フィルタ用）
         const worker = await prisma.user.findUnique({
             where: { id: workerId },
-            select: { name: true, email: true, last_name_kana: true }
+            select: { name: true, email: true, last_name_kana: true, gender: true }
         });
 
         if (!worker) continue;
+
+        // 性別指定フィルタ: 応募できないワーカーには通知しない
+        const genderCheck = canApplyByGender(job.gender_requirement, worker.gender);
+        if (!genderCheck.allowed) continue;
 
         // 通知データ準備
         const variables = {


### PR DESCRIPTION
## 概要

PR #588 で施設管理者が求人/テンプレに性別指定（男性のみ／女性のみ）を保存できるようにしたが、ワーカー側に反映されておらず、性別不一致でも閲覧・応募できる状態だった。本PRでワーカー側の表示・応募制限を実装する。

## 仕様

| 求人の gender_requirement | 表示・応募対象 |
|---|---|
| NULL | 全ワーカー |
| MALE_ONLY | User.gender = '男性' のみ |
| FEMALE_ONLY | User.gender = '女性' のみ |
| 未登録(NULL)/その他 | 性別指定のある求人は非表示・応募不可 |

## 変更内容

### 共通ヘルパー（新規）
- `src/lib/jobGenderMatching.ts`: `buildGenderFilterWhere` / `canApplyByGender`

### 一覧フィルタ
- `src/lib/actions/job-worker.ts`: `getJobs` / `getJobsListWithPagination` / `getBookmarkedJobs` / `getJobListTypeCounts`
- 限定求人（LIMITED_WORKED/LIMITED_FAVORITE）・説明会・お気に入り・ホーム新着も同じ関数経由のため一括対応

### 詳細ページ
- `app/jobs/[id]/page.tsx`: サーバー側で `canApplyByGender` 判定
- `components/job/JobDetailClient.tsx`: 応募ボタンをグレーアウト＋「応募条件を満たしていません」表示

### サーバー側応募バリデーション
- `src/lib/actions/application-worker.ts`: `applyForJob` / `applyForJobMultipleDates` / `acceptOffer`
- URL直接アクセスや API 直叩きでも応募不可

### 通知系
- `src/lib/actions/notification.ts`: `sendFavoriteNewJobNotification`（お気に入り施設新着）
- `src/lib/notification-service.ts`: `sendNearbyJobNotifications`（近隣新着）
- 性別マッチワーカーのみに通知送信

## DB変更
- **なし**（カラムは PR #588 で本番反映済み）

## Test plan

ステージング (https://stg-share-worker.vercel.app/) で確認:

- [ ] 男性ワーカーが「女性のみ」求人を検索 → 一覧に非表示
- [ ] 男性ワーカーが「女性のみ」求人詳細URLを直接アクセス → 応募ボタングレーアウト＋メッセージ表示
- [ ] 女性ワーカーが「女性のみ」求人に応募 → 正常に応募完了
- [ ] 性別未登録ワーカーが「女性のみ」求人を検索 → 一覧に非表示
- [ ] 性別指定なし（NULL）の求人 → 全ワーカーに表示
- [ ] お気に入り済み一覧で性別違いの求人 → 非表示
- [ ] お気に入り施設の新着求人通知 → 性別マッチワーカーのみに送信
- [ ] 既存応募データ（性別不一致あり） → 影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)