### PR TITLE
バグ修正: CSV出力の日時表示をJST固定に統一

### DIFF
--- a/app/api/system-admin/worker-csv/route.ts
+++ b/app/api/system-admin/worker-csv/route.ts
@@ -58,16 +58,33 @@ function splitName(name: string): { lastName: string; firstName: string } {
   return { lastName: name, firstName: '' };
 }
 
+// JST(Asia/Tokyo) 固定で年/月/日を取り出すフォーマッタ
+const JST_YMD_FORMATTER = new Intl.DateTimeFormat('en-CA', {
+  timeZone: 'Asia/Tokyo',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+});
+
+function getJstYmd(date: Date): { year: number; month: number; day: number } {
+  const parts = JST_YMD_FORMATTER.formatToParts(date);
+  return {
+    year: Number(parts.find(p => p.type === 'year')?.value ?? '0'),
+    month: Number(parts.find(p => p.type === 'month')?.value ?? '0'),
+    day: Number(parts.find(p => p.type === 'day')?.value ?? '0'),
+  };
+}
+
 /**
- * 生年月日から年齢を計算
+ * 生年月日から年齢を計算（JST基準）
  */
 function calculateAge(birthDate: Date | null): string {
   if (!birthDate) return '';
-  const today = new Date();
-  const birth = new Date(birthDate);
-  let age = today.getFullYear() - birth.getFullYear();
-  const monthDiff = today.getMonth() - birth.getMonth();
-  if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birth.getDate())) {
+  const today = getJstYmd(new Date());
+  const birth = getJstYmd(new Date(birthDate));
+  let age = today.year - birth.year;
+  const monthDiff = today.month - birth.month;
+  if (monthDiff < 0 || (monthDiff === 0 && today.day < birth.day)) {
     age--;
   }
   return String(age);
@@ -110,12 +127,12 @@ function workerToRow(user: any, lpMap: Map<string, string>): (string | number | 
 
   return [
     user.id,
-    user.created_at ? new Date(user.created_at).toLocaleDateString('ja-JP', { year: 'numeric', month: '2-digit', day: '2-digit' }) : '',
+    user.created_at ? new Date(user.created_at).toLocaleDateString('ja-JP', { year: 'numeric', month: '2-digit', day: '2-digit', timeZone: 'Asia/Tokyo' }) : '',
     lastName,
     firstName,
     user.last_name_kana || '',
     user.first_name_kana || '',
-    user.birth_date ? new Date(user.birth_date).toLocaleDateString('ja-JP', { year: 'numeric', month: '2-digit', day: '2-digit' }) : '',
+    user.birth_date ? new Date(user.birth_date).toLocaleDateString('ja-JP', { year: 'numeric', month: '2-digit', day: '2-digit', timeZone: 'Asia/Tokyo' }) : '',
     calculateAge(user.birth_date),
     user.gender || '',
     user.phone_number || '',

--- a/src/lib/csv-export/attendance-info-csv.ts
+++ b/src/lib/csv-export/attendance-info-csv.ts
@@ -50,27 +50,41 @@ const ATTENDANCE_INFO_HEADERS = [
   'ワーカー名',             // 36. User.name（追加項目）
 ];
 
+// JST(Asia/Tokyo) 固定で時/分を取り出すフォーマッタ — Vercel ランタイムが UTC のため
+// getHours/getMinutes ではJSTからずれる
+const JST_TIME_FORMATTER = new Intl.DateTimeFormat('en-GB', {
+  timeZone: 'Asia/Tokyo',
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+});
+
+function getJstHoursMinutes(datetime: Date): { hours: number; minutes: number } {
+  const parts = JST_TIME_FORMATTER.formatToParts(datetime);
+  const hours = Number(parts.find(p => p.type === 'hour')?.value ?? '0');
+  const minutes = Number(parts.find(p => p.type === 'minute')?.value ?? '0');
+  return { hours, minutes };
+}
+
 /**
- * DateTimeからhh:mm形式に変換
+ * DateTimeからhh:mm形式に変換（JST固定）
  */
 function formatDateTimeToTime(datetime: Date | null): string {
   if (!datetime) return '';
   const d = new Date(datetime);
-  const hours = String(d.getHours()).padStart(2, '0');
-  const minutes = String(d.getMinutes()).padStart(2, '0');
-  return `${hours}:${minutes}`;
+  if (isNaN(d.getTime())) return '';
+  const { hours, minutes } = getJstHoursMinutes(d);
+  return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
 }
 
 /**
- * 遅刻時間を計算（分）
+ * 遅刻時間を計算（分） — 実績時刻はJSTで比較
  */
 function calculateLateTime(scheduledStart: string, actualStart: Date | null): string {
   if (!actualStart || !scheduledStart) return '0:00';
 
   const [schedH, schedM] = scheduledStart.split(':').map(Number);
-  const actual = new Date(actualStart);
-  const actualH = actual.getHours();
-  const actualM = actual.getMinutes();
+  const { hours: actualH, minutes: actualM } = getJstHoursMinutes(new Date(actualStart));
 
   const diff = (actualH * 60 + actualM) - (schedH * 60 + schedM);
   if (diff <= 0) return '0:00';
@@ -81,15 +95,13 @@ function calculateLateTime(scheduledStart: string, actualStart: Date | null): st
 }
 
 /**
- * 早退時間を計算（分）
+ * 早退時間を計算（分） — 実績時刻はJSTで比較
  */
 function calculateEarlyLeaveTime(scheduledEnd: string, actualEnd: Date | null): string {
   if (!actualEnd || !scheduledEnd) return '0:00';
 
   const [schedH, schedM] = scheduledEnd.split(':').map(Number);
-  const actual = new Date(actualEnd);
-  const actualH = actual.getHours();
-  const actualM = actual.getMinutes();
+  const { hours: actualH, minutes: actualM } = getJstHoursMinutes(new Date(actualEnd));
 
   const diff = (schedH * 60 + schedM) - (actualH * 60 + actualM);
   if (diff <= 0) return '0:00';

--- a/src/lib/csv-export/utils.ts
+++ b/src/lib/csv-export/utils.ts
@@ -26,8 +26,17 @@ export function generateCsv(headers: string[], rows: string[][]): string {
   return headerRow + '\r\n' + dataRows;
 }
 
+// JST(Asia/Tokyo) 固定の日付フォーマッタ — Vercel ランタイムが UTC のため、
+// getFullYear 等のローカル系メソッドではなく Intl で明示的にJSTに変換する
+const JST_DATE_FORMATTER = new Intl.DateTimeFormat('en-CA', {
+  timeZone: 'Asia/Tokyo',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+});
+
 /**
- * 日付フォーマット（yyyy/mm/dd）
+ * 日付フォーマット（yyyy/mm/dd, JST固定）
  * @param date Date型またはnull/undefined
  * @returns yyyy/mm/dd形式の文字列、または空文字
  */
@@ -35,10 +44,8 @@ export function formatDateForCsv(date: Date | string | null | undefined): string
   if (!date) return '';
   const d = new Date(date);
   if (isNaN(d.getTime())) return '';
-  const year = d.getFullYear();
-  const month = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  return `${year}/${month}/${day}`;
+  // en-CA は yyyy-mm-dd 形式で出力するためセパレータのみ置換
+  return JST_DATE_FORMATTER.format(d).replace(/-/g, '/');
 }
 
 /**


### PR DESCRIPTION
## 背景

クライアントから「システム管理＞CSV出力＞ワーカー情報」の **一覧表示の登録日とCSV出力の登録日が一致しない** との指摘あり。調査の結果、Vercel ランタイム (UTC) で日付フォーマットしていることが原因と判明（CLAUDE.md「日時処理は必ずJST基準にすること」のルール違反）。

JST 00:00〜09:00 に作成されたレコードで CSV 上の日付が前日にずれる挙動になっていた。
詳細な原因切り分けは前回のチャット報告参照。

## 修正範囲

| ファイル | 内容 |
|---|---|
| `src/lib/csv-export/utils.ts` | `formatDateForCsv` を `Intl.DateTimeFormat('en-CA', { timeZone: 'Asia/Tokyo' })` ベースに再実装。staff/shift/attendance CSV の登録日・勤務日・生年月日に波及 |
| `src/lib/csv-export/attendance-info-csv.ts` | `formatDateTimeToTime` / `calculateLateTime` / `calculateEarlyLeaveTime` の `getHours/getMinutes` を JST 固定の Intl 経由に変更 |
| `app/api/system-admin/worker-csv/route.ts` | 登録日・生年月日の `toLocaleDateString('ja-JP', …)` に `timeZone: 'Asia/Tokyo'` を追加。`calculateAge` も JST の年/月/日で判定 |

## 影響範囲

ワーカー情報 / プールスタッフ情報 / 案件シフト情報 / 勤怠情報 の各 CSV 出力。
表示ロジックのみの修正で、DB スキーマ変更・マイグレーションなし。

## 検証

- `npm run build` 成功（既存の `/bookmarks` 等の dynamic server usage 警告は本変更と無関係）
- 一覧表示側はもともとブラウザで JST フォーマットしているため変更不要 → 修正後は CSV と完全一致する想定

## デプロイ前確認

- DB変更: なし
- 環境変数: 追加不要
- マージ後ステージングで `登録日 02:00 JST` 付近に作成されたワーカーがあれば、一覧と CSV の登録日一致を確認推奨

## Test plan

- [ ] ステージングで CSV ダウンロード → 一覧の登録日と完全一致することを確認（特に深夜〜早朝に登録されたユーザー）
- [ ] 勤怠CSVの開始/終了時刻が JST で出力されること
- [ ] 生年月日・年齢が JST 基準で正しいこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)