### PR TITLE
バグ修正: 応募ステータス自動遷移がUTC判定でJST環境で動作しない不具合（本番影響あり・最優先）

### DIFF
--- a/app/api/cron/update-statuses/route.ts
+++ b/app/api/cron/update-statuses/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
+import { getJSTTimeString } from '@/utils/jst';
 
 export const dynamic = 'force-dynamic';
 
@@ -50,12 +51,9 @@ export async function GET(request: NextRequest) {
 
   try {
     const now = new Date();
-    // JSTで時間を取得するために、UTC時間に9時間を足す
-    // ただし、サーバーのタイムゾーン設定に依存するため、Dateオブジェクトをそのまま使うのが安全
-    // ここでは単純に現在時刻を使用
-
-    const currentTime = now.toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit' });
-    console.log('[CRON] Current time for status update:', currentTime);
+    // JST基準の現在時刻文字列（HH:MM）。求人のstart_time/end_time（JST想定で文字列保存）と比較するため
+    const currentTime = getJSTTimeString(now);
+    console.log('[CRON] Current time for status update (JST):', currentTime);
 
     // 1. SCHEDULED → WORKING（開始時刻を過ぎた）
     // 勤務日が今日以前、かつ開始時刻が現在時刻以前

--- a/src/lib/actions/application-admin.ts
+++ b/src/lib/actions/application-admin.ts
@@ -3,6 +3,7 @@
 import { prisma } from '@/lib/prisma';
 import { revalidatePath } from 'next/cache';
 import { getCurrentTime, getTodayStart } from '@/utils/debugTime';
+import { formatJSTDate } from '@/utils/jst';
 import {
     sendMatchingNotification,
     sendReviewRequestNotification,
@@ -240,7 +241,7 @@ export async function updateApplicationStatus(
                 application.user.name,
                 application.workDate.job.title,
                 application.workDate.job.facility.facility_name,
-                application.workDate.work_date.toLocaleDateString('ja-JP')
+                formatJSTDate(application.workDate.work_date)
             ).catch(err => console.error('[updateApplicationStatus] Admin matching notification error:', err));
 
             // 枠が埋まったかチェック
@@ -565,7 +566,7 @@ export async function getJobsWithApplications(
                 workDates: job.workDates.map(wd => ({
                     id: wd.id,
                     date: wd.work_date.toISOString(),
-                    formattedDate: new Date(wd.work_date).toLocaleDateString('ja-JP', { month: 'numeric', day: 'numeric', weekday: 'short' }),
+                    formattedDate: formatJSTDate(new Date(wd.work_date), { month: 'numeric', day: 'numeric', weekday: 'short' }),
                     recruitmentCount: wd.recruitment_count,
                     appliedCount: wd.applied_count,
                     matchedCount: wd.matched_count,

--- a/src/lib/actions/application-worker.ts
+++ b/src/lib/actions/application-worker.ts
@@ -3,6 +3,7 @@
 import { prisma } from '@/lib/prisma';
 import { revalidatePath } from 'next/cache';
 import { getCurrentTime } from '@/utils/debugTime';
+import { formatJSTDate } from '@/utils/jst';
 import { getAuthenticatedUser } from './helpers';
 import { checkProfileComplete } from './user-profile';
 import { canApplyByGender } from '@/src/lib/jobGenderMatching';
@@ -336,7 +337,7 @@ export async function applyForJob(jobId: string, workDateId?: number) {
             user.name,
             job.title,
             job.facility.facility_name,
-            targetWorkDate.work_date.toLocaleDateString('ja-JP')
+            formatJSTDate(targetWorkDate.work_date)
         ).catch(err => console.error('[applyForJob] Admin notification error:', err));
 
         if (isImmediateMatch) {
@@ -363,7 +364,7 @@ export async function applyForJob(jobId: string, workDateId?: number) {
                 user.name,
                 job.title,
                 job.facility.facility_name,
-                targetWorkDate.work_date.toLocaleDateString('ja-JP')
+                formatJSTDate(targetWorkDate.work_date)
             ).catch(err => console.error('[applyForJob] Admin matching notification error:', err));
 
             // 初回挨拶通知を送信（通知設定に基づく）
@@ -523,7 +524,7 @@ export async function applyForJobMultipleDates(jobId: string, workDateIds: numbe
             for (const workDateId of newWorkDateIds) {
                 const wd = targetWorkDates.find(w => w.id === workDateId);
                 if (wd && wd.matched_count >= wd.recruitment_count) {
-                    return { success: false, error: `勤務日（${new Date(wd.work_date).toLocaleDateString('ja-JP')}）は既に募集人数に達しています` };
+                    return { success: false, error: `勤務日（${formatJSTDate(new Date(wd.work_date))}）は既に募集人数に達しています` };
                 }
             }
         }
@@ -572,7 +573,7 @@ export async function applyForJobMultipleDates(jobId: string, workDateIds: numbe
 
         const appliedWorkDates = targetWorkDates
             .filter(wd => newWorkDateIds.includes(wd.id))
-            .map(wd => new Date(wd.work_date).toLocaleDateString('ja-JP', { month: 'long', day: 'numeric', weekday: 'short' }));
+            .map(wd => formatJSTDate(new Date(wd.work_date), { month: 'long', day: 'numeric', weekday: 'short' }));
 
         sendApplicationNotificationMultiple(
             job.facility_id,
@@ -1127,13 +1128,13 @@ export async function acceptOffer(jobId: string, workDateId: number) {
             user.name,
             job.title,
             job.facility.facility_name,
-            targetWorkDate.work_date.toLocaleDateString('ja-JP')
+            formatJSTDate(targetWorkDate.work_date)
         ).catch(err => console.error('[acceptOffer] Admin application notification error:', err));
         sendAdminMatchingNotification(
             user.name,
             job.title,
             job.facility.facility_name,
-            targetWorkDate.work_date.toLocaleDateString('ja-JP')
+            formatJSTDate(targetWorkDate.work_date)
         ).catch(err => console.error('[acceptOffer] Admin matching notification error:', err));
 
         // マッチングメッセージの送信

--- a/src/lib/actions/attendance-admin.ts
+++ b/src/lib/actions/attendance-admin.ts
@@ -6,6 +6,7 @@
 
 import { prisma } from '@/lib/prisma';
 import { getCurrentTime } from './helpers';
+import { formatJSTDate, formatJSTDateTime } from '@/utils/jst';
 import { calculateSalary } from '@/src/lib/salary-calculator';
 import { sendNotification } from '@/src/lib/notification-service';
 import { sendAdminAttendanceModificationApprovedNotification } from './notification';
@@ -406,7 +407,7 @@ export async function approveModificationRequest(
       applicationId: applicationId,
       variables: {
         work_date: modification.attendance.application?.workDate.work_date
-          ? new Date(modification.attendance.application.workDate.work_date).toLocaleDateString('ja-JP')
+          ? formatJSTDate(new Date(modification.attendance.application.workDate.work_date))
           : '',
         facility_name: modification.attendance.facility.facility_name,
         approved_start_time: modification.requested_start_time.toLocaleTimeString('ja-JP', {
@@ -437,7 +438,7 @@ export async function approveModificationRequest(
       modification.attendance.facility.facility_name,
       modification.attendance.application?.workDate.job.title || '',
       modification.attendance.application?.workDate.work_date
-        ? new Date(modification.attendance.application.workDate.work_date).toLocaleDateString('ja-JP')
+        ? formatJSTDate(new Date(modification.attendance.application.workDate.work_date))
         : ''
     ).catch(err => console.error('[approveModificationRequest] Admin notification error:', err));
 
@@ -565,7 +566,7 @@ export async function rejectModificationRequest(
       applicationId: applicationId,
       variables: {
         work_date: modification.attendance.application?.workDate.work_date
-          ? new Date(modification.attendance.application.workDate.work_date).toLocaleDateString('ja-JP')
+          ? formatJSTDate(new Date(modification.attendance.application.workDate.work_date))
           : '',
         facility_name: modification.attendance.facility.facility_name,
         admin_comment: request.adminComment,
@@ -996,7 +997,7 @@ export async function getUsageDetailsCSV(
     // CSV行を生成
     const rows = items.map((item) => {
       const checkIn = item.actualStartTime
-        ? new Date(item.actualStartTime).toLocaleString('ja-JP', {
+        ? formatJSTDateTime(new Date(item.actualStartTime), {
             year: 'numeric',
             month: '2-digit',
             day: '2-digit',
@@ -1005,7 +1006,7 @@ export async function getUsageDetailsCSV(
           })
         : '';
       const checkOut = item.actualEndTime
-        ? new Date(item.actualEndTime).toLocaleString('ja-JP', {
+        ? formatJSTDateTime(new Date(item.actualEndTime), {
             year: 'numeric',
             month: '2-digit',
             day: '2-digit',

--- a/src/lib/actions/attendance.ts
+++ b/src/lib/actions/attendance.ts
@@ -6,6 +6,7 @@
 
 import { prisma } from '@/lib/prisma';
 import { getAuthenticatedUser, getCurrentTime, getTodayStart } from './helpers';
+import { formatJSTDate } from '@/utils/jst';
 import { calculateSalary } from '@/src/lib/salary-calculator';
 import { sendNotification } from '@/src/lib/notification-service';
 import {
@@ -488,7 +489,7 @@ export async function createModificationRequest(
         variables: {
           workerName: user.name,
           workDate: attendance.application?.workDate.work_date
-            ? new Date(attendance.application.workDate.work_date).toLocaleDateString('ja-JP')
+            ? formatJSTDate(new Date(attendance.application.workDate.work_date))
             : '',
           requestedStartTime: requestedStart.toLocaleTimeString('ja-JP', {
             hour: '2-digit',
@@ -513,7 +514,7 @@ export async function createModificationRequest(
       attendance.facility?.facility_name || '',
       attendance.application?.workDate.job.title || '',
       attendance.application?.workDate.work_date
-        ? new Date(attendance.application.workDate.work_date).toLocaleDateString('ja-JP')
+        ? formatJSTDate(new Date(attendance.application.workDate.work_date))
         : '',
       request.workerComment
     ).catch(err => console.error('[createModificationRequest] Admin notification error:', err));
@@ -657,7 +658,7 @@ export async function resubmitModificationRequest(
         variables: {
           workerName: user.name,
           workDate: modification.attendance.application?.workDate.work_date
-            ? new Date(modification.attendance.application.workDate.work_date).toLocaleDateString('ja-JP')
+            ? formatJSTDate(new Date(modification.attendance.application.workDate.work_date))
             : '',
           requestedStartTime: requestedStart.toLocaleTimeString('ja-JP', {
             hour: '2-digit',

--- a/src/lib/actions/helpers.ts
+++ b/src/lib/actions/helpers.ts
@@ -84,7 +84,7 @@ export function formatMessageTime(date: Date): string {
   } else if (days < 7) {
     return `${days}日前`;
   } else {
-    return date.toLocaleDateString('ja-JP', { month: 'numeric', day: 'numeric' });
+    return date.toLocaleDateString('ja-JP', { month: 'numeric', day: 'numeric', timeZone: 'Asia/Tokyo' });
   }
 }
 

--- a/src/lib/actions/labor-document-shift.ts
+++ b/src/lib/actions/labor-document-shift.ts
@@ -2,6 +2,7 @@
 
 import { prisma } from '@/lib/prisma';
 import { getAuthenticatedUser } from './helpers';
+import { formatJSTDate } from '@/utils/jst';
 import { sendNotification } from '../notification-service';
 import { logActivity, getErrorMessage, getErrorStack } from '@/lib/logger';
 import { getFacilityAdminSessionData } from '@/lib/admin-session-server';
@@ -469,7 +470,7 @@ export async function cancelShift(applicationId: number): Promise<{ success: boo
             variables: {
                 worker_name: application.user.name,
                 facility_name: application.workDate.job.facility.facility_name,
-                work_date: application.workDate.work_date.toLocaleDateString(),
+                work_date: formatJSTDate(application.workDate.work_date),
                 start_time: application.workDate.job.start_time,
                 end_time: application.workDate.job.end_time,
             },

--- a/src/lib/actions/notification.ts
+++ b/src/lib/actions/notification.ts
@@ -3,6 +3,7 @@
 import { prisma } from '@/lib/prisma';
 import { revalidatePath, revalidateTag } from 'next/cache';
 import { getAuthenticatedUser, createNotification } from './helpers';
+import { formatJSTDate } from '@/utils/jst';
 import { sendNotification } from '../notification-service';
 import { getFacilityUnreadMessageCount, getWorkerUnreadMessageCount } from './message';
 import { logActivity, getErrorMessage, getErrorStack } from '@/lib/logger';
@@ -250,7 +251,7 @@ export async function sendMatchingNotification(
 
         // 勤務日時情報をフォーマット
         const formattedWorkDate = workDateInfo?.workDate
-            ? new Date(workDateInfo.workDate).toLocaleDateString('ja-JP', {
+            ? formatJSTDate(new Date(workDateInfo.workDate), {
                 year: 'numeric',
                 month: 'long',
                 day: 'numeric',
@@ -345,7 +346,7 @@ export async function sendApplicationNotification(
         const staffEmails = facility?.staff_emails ?? [];
 
         // 勤務日をフォーマット
-        const workDate = new Date(application.workDate.work_date).toLocaleDateString('ja-JP', {
+        const workDate = formatJSTDate(new Date(application.workDate.work_date), {
             month: 'long',
             day: 'numeric',
             weekday: 'short'

--- a/src/lib/notification-service.ts
+++ b/src/lib/notification-service.ts
@@ -1,4 +1,5 @@
 import { prisma } from '@/lib/prisma';
+import { formatJSTDate } from '@/utils/jst';
 import webPush from 'web-push';
 import { Resend } from 'resend';
 import { getTodayStart } from '@/utils/debugTime';
@@ -697,7 +698,7 @@ export async function sendNearbyJobNotifications(
             facility_name: job.facility.facility_name,
             job_title: job.title,
             work_date: job.workDates[0]?.work_date
-                ? new Date(job.workDates[0].work_date).toLocaleDateString('ja-JP')
+                ? formatJSTDate(new Date(job.workDates[0].work_date))
                 : '未定',
             worker_name: worker.name,
             worker_last_name: worker.last_name_kana || worker.name,

--- a/src/lib/status-updater.ts
+++ b/src/lib/status-updater.ts
@@ -1,4 +1,5 @@
 import { prisma } from '@/lib/prisma';
+import { getJSTTimeString } from '@/utils/jst';
 
 /**
  * アプリケーションのステータスをリアルタイムで更新
@@ -13,7 +14,8 @@ export async function updateApplicationStatuses(options?: {
     facilityId?: number;
 }): Promise<{ scheduledToWorking: number; workingToCompleted: number }> {
     const now = new Date();
-    const currentTime = now.toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit' });
+    // JST基準の現在時刻文字列（HH:MM）。求人のstart_time/end_time（JST想定で文字列保存）と比較するため
+    const currentTime = getJSTTimeString(now);
 
     // ベースのwhere条件
     const baseWhereScheduled: Record<string, unknown> = {

--- a/utils/jst.ts
+++ b/utils/jst.ts
@@ -1,0 +1,88 @@
+/**
+ * JST（日本標準時, UTC+9）基準の日時操作ヘルパー
+ *
+ * Vercel サーバーは UTC で動作するため、new Date() や toLocaleString() を
+ * タイムゾーン指定なしで使うと JST と最大9時間ズレる。本ファイルのヘルパーを
+ * 経由することで、サーバー環境に依存しないJST基準の値が取得できる。
+ *
+ * 使用方針（CLAUDE.md 参照）:
+ *   - 「現在時刻のJST時刻文字列」が必要な箇所 → getJSTTimeString()
+ *   - 「日付の表示文字列」が必要な箇所 → formatJSTDate()
+ *   - 「日時の表示文字列」が必要な箇所 → formatJSTDateTime()
+ *   - 「JSTの日付文字列（YYYY-MM-DD）」が必要な箇所 → toJSTDateString()
+ *   - 「今日のJST 0:00」が必要な箇所 → getTodayJSTStart()
+ *
+ * 禁止パターン:
+ *   - new Date().toLocaleTimeString('en-US', { ... })  ← timeZone 指定なしはUTCになる
+ *   - new Date().getHours() で「現在JST時刻」を取得しようとする  ← UTC値が返る
+ */
+
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+/**
+ * Date を JST の日付文字列（YYYY-MM-DD）に変換
+ */
+export function toJSTDateString(date: Date): string {
+  const jst = new Date(date.getTime() + JST_OFFSET_MS);
+  const y = jst.getUTCFullYear();
+  const m = String(jst.getUTCMonth() + 1).padStart(2, '0');
+  const d = String(jst.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * 今日の JST 00:00:00 を Date で返す
+ */
+export function getTodayJSTStart(): Date {
+  const now = new Date();
+  const jst = new Date(now.getTime() + JST_OFFSET_MS);
+  return new Date(
+    Date.UTC(jst.getUTCFullYear(), jst.getUTCMonth(), jst.getUTCDate()) - JST_OFFSET_MS,
+  );
+}
+
+/**
+ * Date を JST の時刻文字列（HH:MM、24時間表記）に変換
+ * status-updater 等で「JST現在時刻」と「求人の start_time / end_time」を文字列比較する用途
+ */
+export function getJSTTimeString(date: Date): string {
+  return date.toLocaleTimeString('en-US', {
+    hour12: false,
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: 'Asia/Tokyo',
+  });
+}
+
+/**
+ * Date を JST の日付表示文字列に変換（ja-JP ロケール）
+ * options を指定して曜日付き等の表示も可能
+ *
+ * @param date 変換対象の Date
+ * @param options Intl.DateTimeFormatOptions（timeZone は自動で 'Asia/Tokyo' になる）
+ */
+export function formatJSTDate(
+  date: Date,
+  options?: Omit<Intl.DateTimeFormatOptions, 'timeZone'>,
+): string {
+  return date.toLocaleDateString('ja-JP', {
+    ...options,
+    timeZone: 'Asia/Tokyo',
+  });
+}
+
+/**
+ * Date を JST の日時表示文字列に変換（ja-JP ロケール）
+ *
+ * @param date 変換対象の Date
+ * @param options Intl.DateTimeFormatOptions（timeZone は自動で 'Asia/Tokyo' になる）
+ */
+export function formatJSTDateTime(
+  date: Date,
+  options?: Omit<Intl.DateTimeFormatOptions, 'timeZone'>,
+): string {
+  return date.toLocaleString('ja-JP', {
+    ...options,
+    timeZone: 'Asia/Tokyo',
+  });
+}


### PR DESCRIPTION
## 概要

ワーカーの「仕事管理」画面で、勤務開始/終了時刻を過ぎても応募ステータスが `SCHEDULED → WORKING → COMPLETED_RATED` と自動遷移せず、「完了」タブに該当データが表示されない不具合を修正します。

**⚠️ 本番含む全環境で発生中の既存バグです。最優先対応。**

## 原因

\`src/lib/status-updater.ts\` および \`app/api/cron/update-statuses/route.ts\` で、現在時刻文字列を以下のように取得していました：

\`\`\`typescript
const currentTime = now.toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit' });
\`\`\`

タイムゾーン指定がないため、**Vercel サーバー（UTC）では JST より9時間遅れた時刻文字列**が取得されます。例えば JST 17:30 のとき `currentTime = "08:30"` となり、求人の `start_time = "17:00"` との比較で `"17:00" <= "08:30" → false` となり、本来遷移すべき応募が `SCHEDULED` のまま停滞していました。

これは PR #53「ページアクセス時のオンデマンドステータス更新」導入時から存在する既存バグで、長期間気付かれずに本番でも発生していた可能性が高いです。

**PR #597 とは無関係**です。

## 変更内容

### 新規追加
- **\`utils/jst.ts\`** — JST基準ヘルパー集
  - \`getJSTTimeString(date)\` — JSTのHH:MM文字列
  - \`toJSTDateString(date)\` — JSTのYYYY-MM-DD文字列
  - \`getTodayJSTStart()\` — 今日のJST 00:00:00
  - \`formatJSTDate(date, options)\` / \`formatJSTDateTime(date, options)\` — 表示用フォーマット
- **\`prisma/verify-jst-helpers.ts\`** — 動作検証スクリプト

### 確定バグ修正（コアロジック）
- \`src/lib/status-updater.ts\` — メインバグ
- \`app/api/cron/update-statuses/route.ts\` — cron 版の同じバグ

### 関連表示バグ修正（横断調査で発見）
通知メッセージ・エラーメッセージなどで timeZone 指定なしの \`toLocaleDateString/toLocaleString\` を JST 統一：
- \`application-admin.ts\` (2箇所)
- \`application-worker.ts\` (6箇所)
- \`attendance-admin.ts\` (5箇所)
- \`attendance.ts\` (3箇所)
- \`notification.ts\` (2箇所)
- \`notification-service.ts\` (1箇所)
- \`labor-document-shift.ts\` (1箇所)
- \`helpers.ts\` (1箇所)

## 検証

- \`prisma/verify-jst-helpers.ts\` 4ケース全PASS
- \`npx tsc --noEmit\` 型エラーなし

## 通知連鎖リスク

Phase1 調査で **\`updateApplicationStatuses\` 経由の通知発火コードは存在しない**ことを確認済み。修正デプロイ後の一括ステータス遷移で通知が大量配信される懸念はありません。

## デプロイ前確認

- DB変更: なし
- 環境変数追加: なし
- 既存データ移行: 不要（修正デプロイ後の画面アクセスまたはcron実行で自動遷移）

## テスト手順（ステージング反映後）

1. ワーカーアカウントで \`/my-jobs\` を開く
2. これまで「仕事の予定」「勤務中」タブに停滞していた古い応募が、勤務時刻に応じて正しいタブへ自動遷移していることを確認
3. 「完了」タブに過去の完了済み応募が表示されることを確認
4. 新規応募・勤務日が今日の応募について、勤務開始時刻を過ぎたら「勤務中」へ、終了時刻＋双方レビュー完了で「完了」へ遷移することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)