### PR TITLE
バグ修正: 日給計算のJST/UTC不整合でプレビューと保存値が乖離する問題を解消

### DIFF
--- a/scripts/verify-salary-jst-fix.ts
+++ b/scripts/verify-salary-jst-fix.ts
@@ -1,0 +1,32 @@
+/**
+ * utils/salary.ts の JST/UTC 修正検証スクリプト
+ *
+ * 求人 #464 「夜勤テスト」の実データで:
+ *   - クライアント想定(JST): 25,925円
+ *   - サーバー実体(UTC, 修正前): 25,175円
+ *   - 修正後: 両環境とも 25,925円 になるべき
+ *
+ * 実行方法:
+ *   # JST環境
+ *   npx tsx scripts/verify-salary-jst-fix.ts
+ *   # UTC環境シミュレーション
+ *   TZ=UTC npx tsx scripts/verify-salary-jst-fix.ts
+ */
+
+import { calculateDailyWage } from '../utils/salary';
+
+const expectedWage = 25_925;
+const result = calculateDailyWage('17:00', '09:00', 120, 1500, 800);
+
+const tz = process.env.TZ ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
+console.log(`TZ: ${tz}`);
+console.log(`calculateDailyWage('17:00', '09:00', 120, 1500, 800) = ${result.toLocaleString()}`);
+console.log(`expected: ${expectedWage.toLocaleString()}`);
+
+if (result === expectedWage) {
+  console.log('✓ PASS');
+  process.exit(0);
+} else {
+  console.log(`✗ FAIL (diff: ${result - expectedWage})`);
+  process.exit(1);
+}

--- a/utils/salary.ts
+++ b/utils/salary.ts
@@ -11,6 +11,12 @@
 import { calculateSalary } from '@/src/lib/salary-calculator';
 import { TRANSPORTATION_FEE_MAX, TRANSPORTATION_FEE_RATE_PER_HOUR } from '@/constants/salary';
 
+// JSTオフセット（+9時間 = 32400000ミリ秒）
+// Vercel等のUTCサーバーで Date#setHours / setDate を使うと
+// サーバーのローカルタイムゾーン(UTC)で解釈されてJSTと9時間ズレるため、
+// 全てUTCプリミティブ+このオフセットでJST時刻を構築する
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
 /**
  * 時刻をパースする（翌日プレフィックス対応）
  * @param time - 時刻文字列 (HH:mm または 翌HH:mm 形式)
@@ -25,23 +31,30 @@ const parseTime = (time: string): { hour: number; min: number; isNextDay: boolea
 
 /**
  * 時刻文字列からDateオブジェクトを生成（JST基準）
- * @param timeStr - 時刻文字列 (HH:mm 形式)
+ *
+ * baseDate の JST 日付に対して timeStr の時刻(JST)を設定する。
+ * サーバー(UTC)・クライアント(JST)どちらで実行しても同じ結果になる。
+ *
+ * @param timeStr - 時刻文字列 (HH:mm 形式、または 翌HH:mm)
  * @param isNextDay - 翌日かどうか
- * @param baseDate - 基準日（省略時は今日）
- * @returns Date オブジェクト
+ * @param baseDate - 基準日（このDateのJST日付を使用）
+ * @returns Date オブジェクト（指定したJST時刻に対応するUTC Date）
  */
 const timeStringToDate = (
   timeStr: string,
   isNextDay: boolean,
-  baseDate: Date = new Date()
+  baseDate: Date
 ): Date => {
   const parsed = parseTime(timeStr);
-  const date = new Date(baseDate);
-  date.setHours(parsed.hour, parsed.min, 0, 0);
-  if (isNextDay || parsed.isNextDay) {
-    date.setDate(date.getDate() + 1);
-  }
-  return date;
+  // baseDateのJST日付を取得（タイムゾーン非依存）
+  const baseJst = new Date(baseDate.getTime() + JST_OFFSET_MS);
+  const year = baseJst.getUTCFullYear();
+  const month = baseJst.getUTCMonth();
+  const dayOfMonth = baseJst.getUTCDate() + ((isNextDay || parsed.isNextDay) ? 1 : 0);
+  // 「JST year-month-dayOfMonth parsed.hour:parsed.min」を表すUTCタイムスタンプ
+  return new Date(
+    Date.UTC(year, month, dayOfMonth, parsed.hour, parsed.min, 0, 0) - JST_OFFSET_MS
+  );
 };
 
 /**
@@ -73,17 +86,22 @@ export const calculateDailyWage = (
     const start = parseTime(startTime);
     const end = parseTime(endTime);
 
-    // 基準日を設定（JST）
-    const baseDate = new Date();
-    baseDate.setHours(0, 0, 0, 0);
+    // 基準日（JSTでの「今日」の 00:00 を表すUTC Date）
+    // サーバー(UTC)で new Date().setHours(0,0,0,0) を使うと UTC 00:00 = JST 09:00 になり
+    // 後段の calculateSalary が時間帯判定をミスるため、UTCプリミティブで構築する
+    const now = new Date();
+    const jstNow = new Date(now.getTime() + JST_OFFSET_MS);
+    const baseDate = new Date(
+      Date.UTC(jstNow.getUTCFullYear(), jstNow.getUTCMonth(), jstNow.getUTCDate(), 0, 0, 0, 0) - JST_OFFSET_MS
+    );
 
     // 開始・終了時刻をDateオブジェクトに変換
     const startDate = timeStringToDate(startTime, false, baseDate);
     let endDate = timeStringToDate(endTime, end.isNextDay, baseDate);
 
-    // 終了時刻が開始時刻より前の場合は翌日とみなす
+    // 終了時刻が開始時刻より前の場合は翌日とみなす（ms加算でTZ非依存）
     if (endDate <= startDate) {
-      endDate.setDate(endDate.getDate() + 1);
+      endDate = new Date(endDate.getTime() + 24 * 60 * 60 * 1000);
     }
 
     // salary-calculatorを使用して割増計算


### PR DESCRIPTION
## Summary

夜勤求人(17:00-09:00 等)で **求人プレビュー表示と保存後の求人詳細の日給が乖離** する不具合を修正しました。
クライアントで先行調査した求人 #464 「夜勤テスト」で **プレビュー 25,925円 / DB保存値 25,175円(差額 750円)** の事象を再現・修正・回帰検証済みです。

## 原因

`utils/salary.ts` の `calculateDailyWage` 内の `timeStringToDate` が `new Date() + setHours/setDate` を使っており、サーバーのローカルタイムゾーン(Vercel=UTC)で時刻を構築していました。

- ブラウザ(JST): `\"17:00\"` → 17:00 JST と解釈 ✓
- Vercel(UTC):  `\"17:00\"` → 17:00 UTC = 翌02:00 JST と誤解釈 ✗

後段の `calculateSalary` は `getJSTHour` で時間帯判定するため、サーバー側では夜勤の深夜帯(22:00-05:00)が消失し、**深夜残業(1.5倍)が通常残業(1.25倍)に振り替わって計算**され、PR #597 (b6f93c5) で統一されたはずのプレビュー/保存ロジックが**タイムゾーン依存で再び乖離**していました。

CLAUDE.md の「日時処理は必ずJST基準にすること(必須ルール)」違反です。

## 修正内容

### `utils/salary.ts`
- `timeStringToDate` を UTCプリミティブ + JST_OFFSET_MS で構築するよう変更(ローカルTZ非依存)
- `calculateDailyWage` 内の `baseDate` 構築も同様に修正
- `endDate += 1日` のロジックも ms 加算に変更(`setDate` 回避)

### `scripts/verify-salary-jst-fix.ts` (新規)
回帰検証用スクリプト。`TZ=Asia/Tokyo` と `TZ=UTC` の両環境で同じ結果を返すことを確認できます。

## 検証

\`\`\`
$ npx tsx scripts/verify-salary-jst-fix.ts
TZ: Asia/Tokyo
calculateDailyWage('17:00', '09:00', 120, 1500, 800) = 25,925
expected: 25,925
✓ PASS

$ TZ=UTC npx tsx scripts/verify-salary-jst-fix.ts
TZ: UTC
calculateDailyWage('17:00', '09:00', 120, 1500, 800) = 25,925
expected: 25,925
✓ PASS
\`\`\`

`npm run build` 型エラーなし。

## 既存データへの影響(要フォローアップ)

本修正は **新規作成/更新時の wage 計算** を正します。修正前にUTCサーバーで保存された既存求人の `Job.wage` カラムは古い値(間違った計算結果)のまま残ります。

ステージングへのマージ・デプロイ後、以下を **ユーザーが手動で実行** してください(CLAUDE.md DB操作ルール):

\`\`\`bash
# ステージングDB接続で影響範囲確認
npx tsx prisma/recalc-job-wage-with-overtime.ts --dry-run

# UPDATE SQL生成 → Supabase SQL Editor で実行
npx tsx prisma/recalc-job-wage-with-overtime.ts --generate-sql
\`\`\`

本番にも同様の対応が必要です(本番影響あり)。

## Test plan

- [ ] develop マージ後、ステージングで求人 #464 「夜勤テスト」を更新 → DB の wage が 25,925 になることを確認
- [ ] 新規夜勤求人を作成 → プレビューと保存後の表示が一致することを確認
- [ ] 日勤求人(09:00-17:00 等)も従来どおり正しく計算されることを確認
- [ ] `recalc-job-wage-with-overtime.ts --dry-run` を実行し、修正前に作成された既存求人の差分を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)