### PR TITLE
develop → main: JST/UTC不整合修正・日給計算修正・CSV出力JST統一

### DIFF
--- a/app/api/cron/update-statuses/route.ts
+++ b/app/api/cron/update-statuses/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { prisma } from '@/lib/prisma';
+import { getJSTTimeString } from '@/utils/jst';
 
 export const dynamic = 'force-dynamic';
 
@@ -50,12 +51,9 @@ export async function GET(request: NextRequest) {
 
   try {
     const now = new Date();
-    // JSTで時間を取得するために、UTC時間に9時間を足す
-    // ただし、サーバーのタイムゾーン設定に依存するため、Dateオブジェクトをそのまま使うのが安全
-    // ここでは単純に現在時刻を使用
-
-    const currentTime = now.toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit' });
-    console.log('[CRON] Current time for status update:', currentTime);
+    // JST基準の現在時刻文字列（HH:MM）。求人のstart_time/end_time（JST想定で文字列保存）と比較するため
+    const currentTime = getJSTTimeString(now);
+    console.log('[CRON] Current time for status update (JST):', currentTime);
 
     // 1. SCHEDULED → WORKING（開始時刻を過ぎた）
     // 勤務日が今日以前、かつ開始時刻が現在時刻以前

--- a/app/api/system-admin/worker-csv/route.ts
+++ b/app/api/system-admin/worker-csv/route.ts
@@ -58,16 +58,33 @@ function splitName(name: string): { lastName: string; firstName: string } {
   return { lastName: name, firstName: '' };
 }
 
+// JST(Asia/Tokyo) 固定で年/月/日を取り出すフォーマッタ
+const JST_YMD_FORMATTER = new Intl.DateTimeFormat('en-CA', {
+  timeZone: 'Asia/Tokyo',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+});
+
+function getJstYmd(date: Date): { year: number; month: number; day: number } {
+  const parts = JST_YMD_FORMATTER.formatToParts(date);
+  return {
+    year: Number(parts.find(p => p.type === 'year')?.value ?? '0'),
+    month: Number(parts.find(p => p.type === 'month')?.value ?? '0'),
+    day: Number(parts.find(p => p.type === 'day')?.value ?? '0'),
+  };
+}
+
 /**
- * 生年月日から年齢を計算
+ * 生年月日から年齢を計算（JST基準）
  */
 function calculateAge(birthDate: Date | null): string {
   if (!birthDate) return '';
-  const today = new Date();
-  const birth = new Date(birthDate);
-  let age = today.getFullYear() - birth.getFullYear();
-  const monthDiff = today.getMonth() - birth.getMonth();
-  if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birth.getDate())) {
+  const today = getJstYmd(new Date());
+  const birth = getJstYmd(new Date(birthDate));
+  let age = today.year - birth.year;
+  const monthDiff = today.month - birth.month;
+  if (monthDiff < 0 || (monthDiff === 0 && today.day < birth.day)) {
     age--;
   }
   return String(age);
@@ -110,12 +127,12 @@ function workerToRow(user: any, lpMap: Map<string, string>): (string | number | 
 
   return [
     user.id,
-    user.created_at ? new Date(user.created_at).toLocaleDateString('ja-JP', { year: 'numeric', month: '2-digit', day: '2-digit' }) : '',
+    user.created_at ? new Date(user.created_at).toLocaleDateString('ja-JP', { year: 'numeric', month: '2-digit', day: '2-digit', timeZone: 'Asia/Tokyo' }) : '',
     lastName,
     firstName,
     user.last_name_kana || '',
     user.first_name_kana || '',
-    user.birth_date ? new Date(user.birth_date).toLocaleDateString('ja-JP', { year: 'numeric', month: '2-digit', day: '2-digit' }) : '',
+    user.birth_date ? new Date(user.birth_date).toLocaleDateString('ja-JP', { year: 'numeric', month: '2-digit', day: '2-digit', timeZone: 'Asia/Tokyo' }) : '',
     calculateAge(user.birth_date),
     user.gender || '',
     user.phone_number || '',

--- a/prisma/recalc-job-wage-with-overtime.ts
+++ b/prisma/recalc-job-wage-with-overtime.ts
@@ -16,7 +16,12 @@
  *   ドライラン（読み取りのみ・差額一覧と集計を表示）:
  *     npx tsx prisma/recalc-job-wage-with-overtime.ts --dry-run
  *
- *   実行（実際にDBを更新）:
+ *   SQL生成（DBを更新せず、UPDATE文をファイル出力）:
+ *     npx tsx prisma/recalc-job-wage-with-overtime.ts --generate-sql
+ *     → prisma/output/recalc-job-wage-YYYYMMDD-HHmm.sql に保存
+ *     生成されたSQLをレビュー後、Supabase SQL Editor 等で実行する
+ *
+ *   実行（このスクリプトから直接DBを更新）:
  *     npx tsx prisma/recalc-job-wage-with-overtime.ts --execute
  *
  * 注意:
@@ -28,6 +33,8 @@
 
 import { PrismaClient } from '@prisma/client';
 import { calculateDailyWage } from '../utils/salary';
+import { mkdirSync, writeFileSync } from 'fs';
+import { join, dirname } from 'path';
 
 const prisma = new PrismaClient();
 
@@ -53,13 +60,19 @@ async function main() {
   const args = process.argv.slice(2);
   const isDryRun = args.includes('--dry-run');
   const isExecute = args.includes('--execute');
+  const isGenerateSql = args.includes('--generate-sql');
 
-  if (!isDryRun && !isExecute) {
-    console.error('使用方法: --dry-run または --execute を指定してください');
+  const modeCount = [isDryRun, isExecute, isGenerateSql].filter(Boolean).length;
+  if (modeCount !== 1) {
+    console.error('使用方法: --dry-run / --generate-sql / --execute のいずれか1つを指定してください');
     process.exit(1);
   }
 
-  const mode = isDryRun ? 'DRY RUN（読み取りのみ）' : 'EXECUTE（DB更新あり）';
+  const mode = isDryRun
+    ? 'DRY RUN（読み取りのみ）'
+    : isGenerateSql
+      ? 'GENERATE SQL（UPDATE文をファイル出力）'
+      : 'EXECUTE（DB更新あり）';
   console.log('='.repeat(70));
   console.log(`求人日給 再計算スクリプト - ${mode}`);
   console.log('='.repeat(70));
@@ -193,8 +206,75 @@ async function main() {
   if (isDryRun) {
     console.log('\n' + '='.repeat(70));
     console.log('DRY RUN モードのため DB は更新していません');
-    console.log('実際に更新するには --execute を付けて実行してください');
+    console.log('実際に更新するには --execute、SQLファイルを生成するには --generate-sql を指定してください');
     console.log('='.repeat(70));
+    await prisma.$disconnect();
+    return;
+  }
+
+  if (isGenerateSql) {
+    if (candidates.length === 0) {
+      console.log('\n更新対象がないためSQLは生成しません');
+      await prisma.$disconnect();
+      return;
+    }
+
+    const now = new Date();
+    const pad = (n: number) => n.toString().padStart(2, '0');
+    const timestamp = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-${pad(now.getHours())}${pad(now.getMinutes())}`;
+    const outputPath = join(process.cwd(), 'prisma', 'output', `recalc-job-wage-${timestamp}.sql`);
+
+    const lines: string[] = [];
+    lines.push('-- 求人日給 再計算スクリプト 生成SQL');
+    lines.push(`-- 生成日時: ${now.toISOString()}`);
+    lines.push(`-- 対象求人数: ${candidates.length} 件`);
+    lines.push(`-- 旧wage合計: ${totalOldWage}`);
+    lines.push(`-- 新wage合計: ${totalNewWage}`);
+    lines.push(`-- 差額合計:   ${totalDiff}`);
+    lines.push('');
+    lines.push('-- 対象条件: status=PUBLISHED かつ 有効な応募0件');
+    lines.push('-- 実行方法: トランザクション内で実行することを推奨');
+    lines.push('-- 例:');
+    lines.push('--   BEGIN;');
+    lines.push('--   （以下のUPDATE群）');
+    lines.push('--   -- 結果を確認');
+    lines.push('--   COMMIT;  （または問題があれば ROLLBACK;）');
+    lines.push('');
+    lines.push('BEGIN;');
+    lines.push('');
+
+    for (const c of candidates) {
+      lines.push(
+        `-- Job #${c.jobId} ${c.startTime}-${c.endTime} 休${c.breakTime}分 時給¥${c.hourlyWage}: 旧¥${c.oldWage} → 新¥${c.newWage} (差額 ¥${c.diff})`,
+      );
+      lines.push(`UPDATE jobs SET wage = ${c.newWage} WHERE id = ${c.jobId} AND wage = ${c.oldWage};`);
+      lines.push('');
+    }
+
+    lines.push('-- 件数チェック用クエリ（実行前後で件数を比較できる）');
+    lines.push(
+      `-- SELECT COUNT(*) FROM jobs WHERE id IN (${candidates.map((c) => c.jobId).join(', ')});`,
+    );
+    lines.push('');
+    lines.push('COMMIT;');
+    lines.push('');
+
+    mkdirSync(dirname(outputPath), { recursive: true });
+    writeFileSync(outputPath, lines.join('\n'), 'utf-8');
+
+    console.log('\n' + '='.repeat(70));
+    console.log('SQLファイルを生成しました');
+    console.log('='.repeat(70));
+    console.log(`  出力先: ${outputPath}`);
+    console.log(`  対象求人数: ${candidates.length} 件`);
+    console.log('');
+    console.log('次の手順:');
+    console.log('  1. 生成されたSQLファイルの内容をレビューしてください');
+    console.log('  2. Supabase SQL Editor 等で本番/ステージングDBに対して実行してください');
+    console.log('  3. UPDATE文は WHERE wage = 旧wage 条件付きなので、');
+    console.log('     生成時から値が変わっている求人は更新されません（安全策）');
+    console.log('='.repeat(70));
+
     await prisma.$disconnect();
     return;
   }

--- a/prisma/recalc-job-wage-with-overtime.ts
+++ b/prisma/recalc-job-wage-with-overtime.ts
@@ -1,0 +1,258 @@
+/**
+ * 公開中・未応募求人の日給再計算スクリプト
+ *
+ * 目的:
+ *   求人保存時の calculateWage が割増（深夜・残業）を反映していなかった旧バグの影響で、
+ *   Job.wage に「時給×稼働時間+交通費」のみの値が保存されている既存求人がある。
+ *   本スクリプトは、現在公開中（status = PUBLISHED）かつ未応募の求人について、
+ *   utils/salary.ts の calculateDailyWage（割増対応版）で再計算し、Job.wage を更新する。
+ *
+ * 対象条件:
+ *   - Job.status = 'PUBLISHED'
+ *   - そのJob配下の全WorkDateに、有効な Application（cancelled_at IS NULL）が0件
+ *   - 再計算結果が現行 wage と異なる場合のみ更新対象
+ *
+ * 使い方:
+ *   ドライラン（読み取りのみ・差額一覧と集計を表示）:
+ *     npx tsx prisma/recalc-job-wage-with-overtime.ts --dry-run
+ *
+ *   実行（実際にDBを更新）:
+ *     npx tsx prisma/recalc-job-wage-with-overtime.ts --execute
+ *
+ * 注意:
+ *   - 本番DBに対する書き込みは Claude Code が行ってはならない（CLAUDE.md 参照）
+ *   - 本スクリプトの本番実行はユーザーが手動で行うこと
+ *   - ステージングDBで先行実行して妥当性を確認すること
+ *   - 実行前にDBバックアップを取得することを推奨
+ */
+
+import { PrismaClient } from '@prisma/client';
+import { calculateDailyWage } from '../utils/salary';
+
+const prisma = new PrismaClient();
+
+interface JobUpdateCandidate {
+  jobId: number;
+  title: string;
+  startTime: string;
+  endTime: string;
+  breakTime: number;
+  hourlyWage: number;
+  transportationFee: number;
+  oldWage: number;
+  newWage: number;
+  diff: number;
+}
+
+function parseBreakMinutes(breakTime: string): number {
+  const match = breakTime.match(/^(\d+)/);
+  return match ? parseInt(match[1], 10) : 0;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const isDryRun = args.includes('--dry-run');
+  const isExecute = args.includes('--execute');
+
+  if (!isDryRun && !isExecute) {
+    console.error('使用方法: --dry-run または --execute を指定してください');
+    process.exit(1);
+  }
+
+  const mode = isDryRun ? 'DRY RUN（読み取りのみ）' : 'EXECUTE（DB更新あり）';
+  console.log('='.repeat(70));
+  console.log(`求人日給 再計算スクリプト - ${mode}`);
+  console.log('='.repeat(70));
+
+  // 対象: PUBLISHED かつ 有効な応募0件 の求人
+  const jobs = await prisma.job.findMany({
+    where: {
+      status: 'PUBLISHED',
+      workDates: {
+        every: {
+          applications: {
+            none: {
+              cancelled_at: null,
+            },
+          },
+        },
+      },
+    },
+    select: {
+      id: true,
+      title: true,
+      start_time: true,
+      end_time: true,
+      break_time: true,
+      hourly_wage: true,
+      transportation_fee: true,
+      wage: true,
+    },
+    orderBy: { id: 'asc' },
+  });
+
+  console.log(`\n対象求人数（公開中・有効な応募0件）: ${jobs.length} 件\n`);
+
+  const candidates: JobUpdateCandidate[] = [];
+  let skippedInvalid = 0;
+  let unchangedCount = 0;
+  let totalOldWage = 0;
+  let totalNewWage = 0;
+  let totalDiff = 0;
+
+  for (const job of jobs) {
+    const breakMinutes = parseBreakMinutes(job.break_time);
+
+    let newWage: number;
+    try {
+      newWage = calculateDailyWage(
+        job.start_time,
+        job.end_time,
+        breakMinutes,
+        job.hourly_wage,
+        job.transportation_fee,
+      );
+    } catch (e) {
+      skippedInvalid++;
+      console.warn(
+        `  ⚠ Job #${job.id} 再計算失敗（スキップ）: ${e instanceof Error ? e.message : String(e)}`,
+      );
+      continue;
+    }
+
+    if (newWage === job.wage) {
+      unchangedCount++;
+      continue;
+    }
+
+    const diff = newWage - job.wage;
+    totalOldWage += job.wage;
+    totalNewWage += newWage;
+    totalDiff += diff;
+
+    candidates.push({
+      jobId: job.id,
+      title: job.title,
+      startTime: job.start_time,
+      endTime: job.end_time,
+      breakTime: breakMinutes,
+      hourlyWage: job.hourly_wage,
+      transportationFee: job.transportation_fee,
+      oldWage: job.wage,
+      newWage,
+      diff,
+    });
+  }
+
+  console.log('-'.repeat(70));
+  console.log('集計結果');
+  console.log('-'.repeat(70));
+  console.log(`処理対象:              ${jobs.length} 件`);
+  console.log(`更新対象（差額あり）:  ${candidates.length} 件`);
+  console.log(`変更なし:              ${unchangedCount} 件`);
+  console.log(`スキップ（計算不可）:  ${skippedInvalid} 件`);
+  console.log('');
+  console.log(`旧 wage 合計:          ¥${totalOldWage.toLocaleString()}`);
+  console.log(`新 wage 合計:          ¥${totalNewWage.toLocaleString()}`);
+  console.log(`差額合計（新-旧）:     ¥${totalDiff.toLocaleString()}`);
+  if (candidates.length > 0) {
+    console.log(
+      `平均差額（差額発生時）:¥${Math.round(totalDiff / candidates.length).toLocaleString()}`,
+    );
+  }
+
+  // 差額発生レコードの詳細（上位30件）
+  if (candidates.length > 0) {
+    console.log('\n更新対象の詳細（差額の大きい順、最大30件）:');
+    console.log('-'.repeat(70));
+    const sorted = [...candidates].sort((a, b) => b.diff - a.diff);
+    sorted.slice(0, 30).forEach((c) => {
+      console.log(
+        `  Job #${c.jobId} ${c.startTime}-${c.endTime} 休${c.breakTime}分 時給¥${c.hourlyWage.toLocaleString()}: ` +
+          `旧¥${c.oldWage.toLocaleString()} → 新¥${c.newWage.toLocaleString()} (差額 ¥${c.diff.toLocaleString()})`,
+      );
+    });
+    if (candidates.length > 30) {
+      console.log(`  ... 他 ${candidates.length - 30} 件`);
+    }
+  }
+
+  // 新値が旧値より小さくなったケースは要確認
+  const decreased = candidates.filter((c) => c.diff < 0);
+  if (decreased.length > 0) {
+    console.log(
+      `\n⚠ 新wage < 旧wage となったレコードが ${decreased.length} 件あります（要確認）:`,
+    );
+    decreased.slice(0, 10).forEach((c) => {
+      console.log(
+        `  Job #${c.jobId}: 旧¥${c.oldWage.toLocaleString()} → 新¥${c.newWage.toLocaleString()} (差額 ¥${c.diff.toLocaleString()})`,
+      );
+    });
+  }
+
+  if (isDryRun) {
+    console.log('\n' + '='.repeat(70));
+    console.log('DRY RUN モードのため DB は更新していません');
+    console.log('実際に更新するには --execute を付けて実行してください');
+    console.log('='.repeat(70));
+    await prisma.$disconnect();
+    return;
+  }
+
+  if (candidates.length === 0) {
+    console.log('\n更新対象がないため終了します');
+    await prisma.$disconnect();
+    return;
+  }
+
+  console.log('\n' + '='.repeat(70));
+  console.log('DB更新を開始します...');
+  console.log('='.repeat(70));
+
+  let updatedCount = 0;
+  let errorCount = 0;
+  const errors: Array<{ jobId: number; error: string }> = [];
+
+  for (const c of candidates) {
+    try {
+      await prisma.job.update({
+        where: { id: c.jobId },
+        data: { wage: c.newWage },
+      });
+      updatedCount++;
+      if (updatedCount % 50 === 0) {
+        console.log(`  進捗: ${updatedCount} / ${candidates.length} 件 完了`);
+      }
+    } catch (e) {
+      errorCount++;
+      errors.push({
+        jobId: c.jobId,
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+  }
+
+  console.log('\n' + '-'.repeat(70));
+  console.log('更新完了');
+  console.log('-'.repeat(70));
+  console.log(`成功: ${updatedCount} 件`);
+  console.log(`失敗: ${errorCount} 件`);
+
+  if (errors.length > 0) {
+    console.log('\n失敗したレコード:');
+    errors.slice(0, 10).forEach((e) => {
+      console.log(`  Job #${e.jobId}: ${e.error}`);
+    });
+    if (errors.length > 10) {
+      console.log(`  ... 他 ${errors.length - 10} 件`);
+    }
+  }
+
+  await prisma.$disconnect();
+}
+
+main().catch(async (e) => {
+  console.error('スクリプト実行エラー:', e);
+  await prisma.$disconnect();
+  process.exit(1);
+});

--- a/scripts/verify-salary-jst-fix.ts
+++ b/scripts/verify-salary-jst-fix.ts
@@ -1,0 +1,32 @@
+/**
+ * utils/salary.ts の JST/UTC 修正検証スクリプト
+ *
+ * 求人 #464 「夜勤テスト」の実データで:
+ *   - クライアント想定(JST): 25,925円
+ *   - サーバー実体(UTC, 修正前): 25,175円
+ *   - 修正後: 両環境とも 25,925円 になるべき
+ *
+ * 実行方法:
+ *   # JST環境
+ *   npx tsx scripts/verify-salary-jst-fix.ts
+ *   # UTC環境シミュレーション
+ *   TZ=UTC npx tsx scripts/verify-salary-jst-fix.ts
+ */
+
+import { calculateDailyWage } from '../utils/salary';
+
+const expectedWage = 25_925;
+const result = calculateDailyWage('17:00', '09:00', 120, 1500, 800);
+
+const tz = process.env.TZ ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
+console.log(`TZ: ${tz}`);
+console.log(`calculateDailyWage('17:00', '09:00', 120, 1500, 800) = ${result.toLocaleString()}`);
+console.log(`expected: ${expectedWage.toLocaleString()}`);
+
+if (result === expectedWage) {
+  console.log('✓ PASS');
+  process.exit(0);
+} else {
+  console.log(`✗ FAIL (diff: ${result - expectedWage})`);
+  process.exit(1);
+}

--- a/src/lib/actions/application-admin.ts
+++ b/src/lib/actions/application-admin.ts
@@ -3,6 +3,7 @@
 import { prisma } from '@/lib/prisma';
 import { revalidatePath } from 'next/cache';
 import { getCurrentTime, getTodayStart } from '@/utils/debugTime';
+import { formatJSTDate } from '@/utils/jst';
 import {
     sendMatchingNotification,
     sendReviewRequestNotification,
@@ -240,7 +241,7 @@ export async function updateApplicationStatus(
                 application.user.name,
                 application.workDate.job.title,
                 application.workDate.job.facility.facility_name,
-                application.workDate.work_date.toLocaleDateString('ja-JP')
+                formatJSTDate(application.workDate.work_date)
             ).catch(err => console.error('[updateApplicationStatus] Admin matching notification error:', err));
 
             // 枠が埋まったかチェック
@@ -565,7 +566,7 @@ export async function getJobsWithApplications(
                 workDates: job.workDates.map(wd => ({
                     id: wd.id,
                     date: wd.work_date.toISOString(),
-                    formattedDate: new Date(wd.work_date).toLocaleDateString('ja-JP', { month: 'numeric', day: 'numeric', weekday: 'short' }),
+                    formattedDate: formatJSTDate(new Date(wd.work_date), { month: 'numeric', day: 'numeric', weekday: 'short' }),
                     recruitmentCount: wd.recruitment_count,
                     appliedCount: wd.applied_count,
                     matchedCount: wd.matched_count,

--- a/src/lib/actions/application-worker.ts
+++ b/src/lib/actions/application-worker.ts
@@ -3,6 +3,7 @@
 import { prisma } from '@/lib/prisma';
 import { revalidatePath } from 'next/cache';
 import { getCurrentTime } from '@/utils/debugTime';
+import { formatJSTDate } from '@/utils/jst';
 import { getAuthenticatedUser } from './helpers';
 import { checkProfileComplete } from './user-profile';
 import { canApplyByGender } from '@/src/lib/jobGenderMatching';
@@ -336,7 +337,7 @@ export async function applyForJob(jobId: string, workDateId?: number) {
             user.name,
             job.title,
             job.facility.facility_name,
-            targetWorkDate.work_date.toLocaleDateString('ja-JP')
+            formatJSTDate(targetWorkDate.work_date)
         ).catch(err => console.error('[applyForJob] Admin notification error:', err));
 
         if (isImmediateMatch) {
@@ -363,7 +364,7 @@ export async function applyForJob(jobId: string, workDateId?: number) {
                 user.name,
                 job.title,
                 job.facility.facility_name,
-                targetWorkDate.work_date.toLocaleDateString('ja-JP')
+                formatJSTDate(targetWorkDate.work_date)
             ).catch(err => console.error('[applyForJob] Admin matching notification error:', err));
 
             // 初回挨拶通知を送信（通知設定に基づく）
@@ -523,7 +524,7 @@ export async function applyForJobMultipleDates(jobId: string, workDateIds: numbe
             for (const workDateId of newWorkDateIds) {
                 const wd = targetWorkDates.find(w => w.id === workDateId);
                 if (wd && wd.matched_count >= wd.recruitment_count) {
-                    return { success: false, error: `勤務日（${new Date(wd.work_date).toLocaleDateString('ja-JP')}）は既に募集人数に達しています` };
+                    return { success: false, error: `勤務日（${formatJSTDate(new Date(wd.work_date))}）は既に募集人数に達しています` };
                 }
             }
         }
@@ -572,7 +573,7 @@ export async function applyForJobMultipleDates(jobId: string, workDateIds: numbe
 
         const appliedWorkDates = targetWorkDates
             .filter(wd => newWorkDateIds.includes(wd.id))
-            .map(wd => new Date(wd.work_date).toLocaleDateString('ja-JP', { month: 'long', day: 'numeric', weekday: 'short' }));
+            .map(wd => formatJSTDate(new Date(wd.work_date), { month: 'long', day: 'numeric', weekday: 'short' }));
 
         sendApplicationNotificationMultiple(
             job.facility_id,
@@ -1127,13 +1128,13 @@ export async function acceptOffer(jobId: string, workDateId: number) {
             user.name,
             job.title,
             job.facility.facility_name,
-            targetWorkDate.work_date.toLocaleDateString('ja-JP')
+            formatJSTDate(targetWorkDate.work_date)
         ).catch(err => console.error('[acceptOffer] Admin application notification error:', err));
         sendAdminMatchingNotification(
             user.name,
             job.title,
             job.facility.facility_name,
-            targetWorkDate.work_date.toLocaleDateString('ja-JP')
+            formatJSTDate(targetWorkDate.work_date)
         ).catch(err => console.error('[acceptOffer] Admin matching notification error:', err));
 
         // マッチングメッセージの送信

--- a/src/lib/actions/attendance-admin.ts
+++ b/src/lib/actions/attendance-admin.ts
@@ -6,6 +6,7 @@
 
 import { prisma } from '@/lib/prisma';
 import { getCurrentTime } from './helpers';
+import { formatJSTDate, formatJSTDateTime } from '@/utils/jst';
 import { calculateSalary } from '@/src/lib/salary-calculator';
 import { sendNotification } from '@/src/lib/notification-service';
 import { sendAdminAttendanceModificationApprovedNotification } from './notification';
@@ -406,7 +407,7 @@ export async function approveModificationRequest(
       applicationId: applicationId,
       variables: {
         work_date: modification.attendance.application?.workDate.work_date
-          ? new Date(modification.attendance.application.workDate.work_date).toLocaleDateString('ja-JP')
+          ? formatJSTDate(new Date(modification.attendance.application.workDate.work_date))
           : '',
         facility_name: modification.attendance.facility.facility_name,
         approved_start_time: modification.requested_start_time.toLocaleTimeString('ja-JP', {
@@ -437,7 +438,7 @@ export async function approveModificationRequest(
       modification.attendance.facility.facility_name,
       modification.attendance.application?.workDate.job.title || '',
       modification.attendance.application?.workDate.work_date
-        ? new Date(modification.attendance.application.workDate.work_date).toLocaleDateString('ja-JP')
+        ? formatJSTDate(new Date(modification.attendance.application.workDate.work_date))
         : ''
     ).catch(err => console.error('[approveModificationRequest] Admin notification error:', err));
 
@@ -565,7 +566,7 @@ export async function rejectModificationRequest(
       applicationId: applicationId,
       variables: {
         work_date: modification.attendance.application?.workDate.work_date
-          ? new Date(modification.attendance.application.workDate.work_date).toLocaleDateString('ja-JP')
+          ? formatJSTDate(new Date(modification.attendance.application.workDate.work_date))
           : '',
         facility_name: modification.attendance.facility.facility_name,
         admin_comment: request.adminComment,
@@ -996,7 +997,7 @@ export async function getUsageDetailsCSV(
     // CSV行を生成
     const rows = items.map((item) => {
       const checkIn = item.actualStartTime
-        ? new Date(item.actualStartTime).toLocaleString('ja-JP', {
+        ? formatJSTDateTime(new Date(item.actualStartTime), {
             year: 'numeric',
             month: '2-digit',
             day: '2-digit',
@@ -1005,7 +1006,7 @@ export async function getUsageDetailsCSV(
           })
         : '';
       const checkOut = item.actualEndTime
-        ? new Date(item.actualEndTime).toLocaleString('ja-JP', {
+        ? formatJSTDateTime(new Date(item.actualEndTime), {
             year: 'numeric',
             month: '2-digit',
             day: '2-digit',

--- a/src/lib/actions/attendance.ts
+++ b/src/lib/actions/attendance.ts
@@ -6,6 +6,7 @@
 
 import { prisma } from '@/lib/prisma';
 import { getAuthenticatedUser, getCurrentTime, getTodayStart } from './helpers';
+import { formatJSTDate } from '@/utils/jst';
 import { calculateSalary } from '@/src/lib/salary-calculator';
 import { sendNotification } from '@/src/lib/notification-service';
 import {
@@ -488,7 +489,7 @@ export async function createModificationRequest(
         variables: {
           workerName: user.name,
           workDate: attendance.application?.workDate.work_date
-            ? new Date(attendance.application.workDate.work_date).toLocaleDateString('ja-JP')
+            ? formatJSTDate(new Date(attendance.application.workDate.work_date))
             : '',
           requestedStartTime: requestedStart.toLocaleTimeString('ja-JP', {
             hour: '2-digit',
@@ -513,7 +514,7 @@ export async function createModificationRequest(
       attendance.facility?.facility_name || '',
       attendance.application?.workDate.job.title || '',
       attendance.application?.workDate.work_date
-        ? new Date(attendance.application.workDate.work_date).toLocaleDateString('ja-JP')
+        ? formatJSTDate(new Date(attendance.application.workDate.work_date))
         : '',
       request.workerComment
     ).catch(err => console.error('[createModificationRequest] Admin notification error:', err));
@@ -657,7 +658,7 @@ export async function resubmitModificationRequest(
         variables: {
           workerName: user.name,
           workDate: modification.attendance.application?.workDate.work_date
-            ? new Date(modification.attendance.application.workDate.work_date).toLocaleDateString('ja-JP')
+            ? formatJSTDate(new Date(modification.attendance.application.workDate.work_date))
             : '',
           requestedStartTime: requestedStart.toLocaleTimeString('ja-JP', {
             hour: '2-digit',

--- a/src/lib/actions/helpers.ts
+++ b/src/lib/actions/helpers.ts
@@ -84,7 +84,7 @@ export function formatMessageTime(date: Date): string {
   } else if (days < 7) {
     return `${days}日前`;
   } else {
-    return date.toLocaleDateString('ja-JP', { month: 'numeric', day: 'numeric' });
+    return date.toLocaleDateString('ja-JP', { month: 'numeric', day: 'numeric', timeZone: 'Asia/Tokyo' });
   }
 }
 

--- a/src/lib/actions/job-management.ts
+++ b/src/lib/actions/job-management.ts
@@ -11,7 +11,7 @@ import { logActivity, getErrorMessage, getErrorStack } from '@/lib/logger';
 import { getFacilityAdminSessionData } from '@/lib/admin-session-server';
 import { getMinimumWageForPrefecture } from '@/src/lib/actions/minimumWage';
 import { notifyJobUpdated, notifyJobsUpdated, notifyJobsDeleted } from '@/src/lib/google-indexing';
-import { calculateTransportationFee } from '@/utils/salary';
+import { calculateTransportationFee, calculateDailyWage } from '@/utils/salary';
 
 /**
  * 開始時刻・終了時刻・休憩時間から実働時間（分）を計算
@@ -359,29 +359,7 @@ export async function createJobs(input: CreateJobInput) {
     }
     const transportationFee = calculateTransportationFee(workingMinutes);
 
-    const calculateWage = (startTime: string, endTime: string, breakMinutes: number, hourlyWage: number, transportFee: number) => {
-        const [startHour, startMin] = startTime.split(':').map(Number);
-        const isNextDay = endTime.startsWith('翌');
-        const endTimePart = isNextDay ? endTime.slice(1) : endTime;
-        const [endHour, endMin] = endTimePart.split(':').map(Number);
-
-        const startMinutes = startHour * 60 + startMin;
-        let endMinutes = endHour * 60 + endMin;
-
-        if (isNextDay) {
-            endMinutes += 24 * 60;
-        }
-
-        let totalMinutes = endMinutes - startMinutes;
-        if (totalMinutes < 0) totalMinutes += 24 * 60;
-
-        const workMinutes = totalMinutes - breakMinutes;
-        const workHours = workMinutes / 60;
-
-        return Math.floor(hourlyWage * workHours) + transportFee;
-    };
-
-    const wage = calculateWage(
+    const wage = calculateDailyWage(
         input.startTime,
         input.endTime,
         input.breakTime,
@@ -987,22 +965,7 @@ export async function updateJob(
         }
         const transportationFee = calculateTransportationFee(workingMinutes);
 
-        const calculateWage = (startTime: string, endTime: string, breakMinutes: number, hourlyWage: number, transportFee: number) => {
-            const [startHour, startMin] = startTime.split(':').map(Number);
-            const isNextDay = endTime.startsWith('翌');
-            const endTimePart = isNextDay ? endTime.slice(1) : endTime;
-            const [endHour, endMin] = endTimePart.split(':').map(Number);
-
-            let totalMinutes = (endHour * 60 + endMin) - (startHour * 60 + startMin);
-            if (isNextDay || totalMinutes < 0) totalMinutes += 24 * 60;
-
-            const workMinutes = totalMinutes - breakMinutes;
-            const workHours = workMinutes / 60;
-
-            return Math.floor(hourlyWage * workHours) + transportFee;
-        };
-
-        const wage = calculateWage(
+        const wage = calculateDailyWage(
             data.startTime,
             data.endTime,
             breakTimeMinutes,

--- a/src/lib/actions/labor-document-shift.ts
+++ b/src/lib/actions/labor-document-shift.ts
@@ -2,6 +2,7 @@
 
 import { prisma } from '@/lib/prisma';
 import { getAuthenticatedUser } from './helpers';
+import { formatJSTDate } from '@/utils/jst';
 import { sendNotification } from '../notification-service';
 import { logActivity, getErrorMessage, getErrorStack } from '@/lib/logger';
 import { getFacilityAdminSessionData } from '@/lib/admin-session-server';
@@ -469,7 +470,7 @@ export async function cancelShift(applicationId: number): Promise<{ success: boo
             variables: {
                 worker_name: application.user.name,
                 facility_name: application.workDate.job.facility.facility_name,
-                work_date: application.workDate.work_date.toLocaleDateString(),
+                work_date: formatJSTDate(application.workDate.work_date),
                 start_time: application.workDate.job.start_time,
                 end_time: application.workDate.job.end_time,
             },

--- a/src/lib/actions/notification.ts
+++ b/src/lib/actions/notification.ts
@@ -3,6 +3,7 @@
 import { prisma } from '@/lib/prisma';
 import { revalidatePath, revalidateTag } from 'next/cache';
 import { getAuthenticatedUser, createNotification } from './helpers';
+import { formatJSTDate } from '@/utils/jst';
 import { sendNotification } from '../notification-service';
 import { getFacilityUnreadMessageCount, getWorkerUnreadMessageCount } from './message';
 import { logActivity, getErrorMessage, getErrorStack } from '@/lib/logger';
@@ -250,7 +251,7 @@ export async function sendMatchingNotification(
 
         // 勤務日時情報をフォーマット
         const formattedWorkDate = workDateInfo?.workDate
-            ? new Date(workDateInfo.workDate).toLocaleDateString('ja-JP', {
+            ? formatJSTDate(new Date(workDateInfo.workDate), {
                 year: 'numeric',
                 month: 'long',
                 day: 'numeric',
@@ -345,7 +346,7 @@ export async function sendApplicationNotification(
         const staffEmails = facility?.staff_emails ?? [];
 
         // 勤務日をフォーマット
-        const workDate = new Date(application.workDate.work_date).toLocaleDateString('ja-JP', {
+        const workDate = formatJSTDate(new Date(application.workDate.work_date), {
             month: 'long',
             day: 'numeric',
             weekday: 'short'

--- a/src/lib/csv-export/attendance-info-csv.ts
+++ b/src/lib/csv-export/attendance-info-csv.ts
@@ -50,27 +50,41 @@ const ATTENDANCE_INFO_HEADERS = [
   'ワーカー名',             // 36. User.name（追加項目）
 ];
 
+// JST(Asia/Tokyo) 固定で時/分を取り出すフォーマッタ — Vercel ランタイムが UTC のため
+// getHours/getMinutes ではJSTからずれる
+const JST_TIME_FORMATTER = new Intl.DateTimeFormat('en-GB', {
+  timeZone: 'Asia/Tokyo',
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+});
+
+function getJstHoursMinutes(datetime: Date): { hours: number; minutes: number } {
+  const parts = JST_TIME_FORMATTER.formatToParts(datetime);
+  const hours = Number(parts.find(p => p.type === 'hour')?.value ?? '0');
+  const minutes = Number(parts.find(p => p.type === 'minute')?.value ?? '0');
+  return { hours, minutes };
+}
+
 /**
- * DateTimeからhh:mm形式に変換
+ * DateTimeからhh:mm形式に変換（JST固定）
  */
 function formatDateTimeToTime(datetime: Date | null): string {
   if (!datetime) return '';
   const d = new Date(datetime);
-  const hours = String(d.getHours()).padStart(2, '0');
-  const minutes = String(d.getMinutes()).padStart(2, '0');
-  return `${hours}:${minutes}`;
+  if (isNaN(d.getTime())) return '';
+  const { hours, minutes } = getJstHoursMinutes(d);
+  return `${String(hours).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
 }
 
 /**
- * 遅刻時間を計算（分）
+ * 遅刻時間を計算（分） — 実績時刻はJSTで比較
  */
 function calculateLateTime(scheduledStart: string, actualStart: Date | null): string {
   if (!actualStart || !scheduledStart) return '0:00';
 
   const [schedH, schedM] = scheduledStart.split(':').map(Number);
-  const actual = new Date(actualStart);
-  const actualH = actual.getHours();
-  const actualM = actual.getMinutes();
+  const { hours: actualH, minutes: actualM } = getJstHoursMinutes(new Date(actualStart));
 
   const diff = (actualH * 60 + actualM) - (schedH * 60 + schedM);
   if (diff <= 0) return '0:00';
@@ -81,15 +95,13 @@ function calculateLateTime(scheduledStart: string, actualStart: Date | null): st
 }
 
 /**
- * 早退時間を計算（分）
+ * 早退時間を計算（分） — 実績時刻はJSTで比較
  */
 function calculateEarlyLeaveTime(scheduledEnd: string, actualEnd: Date | null): string {
   if (!actualEnd || !scheduledEnd) return '0:00';
 
   const [schedH, schedM] = scheduledEnd.split(':').map(Number);
-  const actual = new Date(actualEnd);
-  const actualH = actual.getHours();
-  const actualM = actual.getMinutes();
+  const { hours: actualH, minutes: actualM } = getJstHoursMinutes(new Date(actualEnd));
 
   const diff = (schedH * 60 + schedM) - (actualH * 60 + actualM);
   if (diff <= 0) return '0:00';

--- a/src/lib/csv-export/utils.ts
+++ b/src/lib/csv-export/utils.ts
@@ -26,8 +26,17 @@ export function generateCsv(headers: string[], rows: string[][]): string {
   return headerRow + '\r\n' + dataRows;
 }
 
+// JST(Asia/Tokyo) 固定の日付フォーマッタ — Vercel ランタイムが UTC のため、
+// getFullYear 等のローカル系メソッドではなく Intl で明示的にJSTに変換する
+const JST_DATE_FORMATTER = new Intl.DateTimeFormat('en-CA', {
+  timeZone: 'Asia/Tokyo',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+});
+
 /**
- * 日付フォーマット（yyyy/mm/dd）
+ * 日付フォーマット（yyyy/mm/dd, JST固定）
  * @param date Date型またはnull/undefined
  * @returns yyyy/mm/dd形式の文字列、または空文字
  */
@@ -35,10 +44,8 @@ export function formatDateForCsv(date: Date | string | null | undefined): string
   if (!date) return '';
   const d = new Date(date);
   if (isNaN(d.getTime())) return '';
-  const year = d.getFullYear();
-  const month = String(d.getMonth() + 1).padStart(2, '0');
-  const day = String(d.getDate()).padStart(2, '0');
-  return `${year}/${month}/${day}`;
+  // en-CA は yyyy-mm-dd 形式で出力するためセパレータのみ置換
+  return JST_DATE_FORMATTER.format(d).replace(/-/g, '/');
 }
 
 /**

--- a/src/lib/notification-service.ts
+++ b/src/lib/notification-service.ts
@@ -1,4 +1,5 @@
 import { prisma } from '@/lib/prisma';
+import { formatJSTDate } from '@/utils/jst';
 import webPush from 'web-push';
 import { Resend } from 'resend';
 import { getTodayStart } from '@/utils/debugTime';
@@ -697,7 +698,7 @@ export async function sendNearbyJobNotifications(
             facility_name: job.facility.facility_name,
             job_title: job.title,
             work_date: job.workDates[0]?.work_date
-                ? new Date(job.workDates[0].work_date).toLocaleDateString('ja-JP')
+                ? formatJSTDate(new Date(job.workDates[0].work_date))
                 : '未定',
             worker_name: worker.name,
             worker_last_name: worker.last_name_kana || worker.name,

--- a/src/lib/status-updater.ts
+++ b/src/lib/status-updater.ts
@@ -1,4 +1,5 @@
 import { prisma } from '@/lib/prisma';
+import { getJSTTimeString } from '@/utils/jst';
 
 /**
  * アプリケーションのステータスをリアルタイムで更新
@@ -13,7 +14,8 @@ export async function updateApplicationStatuses(options?: {
     facilityId?: number;
 }): Promise<{ scheduledToWorking: number; workingToCompleted: number }> {
     const now = new Date();
-    const currentTime = now.toLocaleTimeString('en-US', { hour12: false, hour: '2-digit', minute: '2-digit' });
+    // JST基準の現在時刻文字列（HH:MM）。求人のstart_time/end_time（JST想定で文字列保存）と比較するため
+    const currentTime = getJSTTimeString(now);
 
     // ベースのwhere条件
     const baseWhereScheduled: Record<string, unknown> = {

--- a/utils/jst.ts
+++ b/utils/jst.ts
@@ -1,0 +1,88 @@
+/**
+ * JST（日本標準時, UTC+9）基準の日時操作ヘルパー
+ *
+ * Vercel サーバーは UTC で動作するため、new Date() や toLocaleString() を
+ * タイムゾーン指定なしで使うと JST と最大9時間ズレる。本ファイルのヘルパーを
+ * 経由することで、サーバー環境に依存しないJST基準の値が取得できる。
+ *
+ * 使用方針（CLAUDE.md 参照）:
+ *   - 「現在時刻のJST時刻文字列」が必要な箇所 → getJSTTimeString()
+ *   - 「日付の表示文字列」が必要な箇所 → formatJSTDate()
+ *   - 「日時の表示文字列」が必要な箇所 → formatJSTDateTime()
+ *   - 「JSTの日付文字列（YYYY-MM-DD）」が必要な箇所 → toJSTDateString()
+ *   - 「今日のJST 0:00」が必要な箇所 → getTodayJSTStart()
+ *
+ * 禁止パターン:
+ *   - new Date().toLocaleTimeString('en-US', { ... })  ← timeZone 指定なしはUTCになる
+ *   - new Date().getHours() で「現在JST時刻」を取得しようとする  ← UTC値が返る
+ */
+
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+/**
+ * Date を JST の日付文字列（YYYY-MM-DD）に変換
+ */
+export function toJSTDateString(date: Date): string {
+  const jst = new Date(date.getTime() + JST_OFFSET_MS);
+  const y = jst.getUTCFullYear();
+  const m = String(jst.getUTCMonth() + 1).padStart(2, '0');
+  const d = String(jst.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * 今日の JST 00:00:00 を Date で返す
+ */
+export function getTodayJSTStart(): Date {
+  const now = new Date();
+  const jst = new Date(now.getTime() + JST_OFFSET_MS);
+  return new Date(
+    Date.UTC(jst.getUTCFullYear(), jst.getUTCMonth(), jst.getUTCDate()) - JST_OFFSET_MS,
+  );
+}
+
+/**
+ * Date を JST の時刻文字列（HH:MM、24時間表記）に変換
+ * status-updater 等で「JST現在時刻」と「求人の start_time / end_time」を文字列比較する用途
+ */
+export function getJSTTimeString(date: Date): string {
+  return date.toLocaleTimeString('en-US', {
+    hour12: false,
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: 'Asia/Tokyo',
+  });
+}
+
+/**
+ * Date を JST の日付表示文字列に変換（ja-JP ロケール）
+ * options を指定して曜日付き等の表示も可能
+ *
+ * @param date 変換対象の Date
+ * @param options Intl.DateTimeFormatOptions（timeZone は自動で 'Asia/Tokyo' になる）
+ */
+export function formatJSTDate(
+  date: Date,
+  options?: Omit<Intl.DateTimeFormatOptions, 'timeZone'>,
+): string {
+  return date.toLocaleDateString('ja-JP', {
+    ...options,
+    timeZone: 'Asia/Tokyo',
+  });
+}
+
+/**
+ * Date を JST の日時表示文字列に変換（ja-JP ロケール）
+ *
+ * @param date 変換対象の Date
+ * @param options Intl.DateTimeFormatOptions（timeZone は自動で 'Asia/Tokyo' になる）
+ */
+export function formatJSTDateTime(
+  date: Date,
+  options?: Omit<Intl.DateTimeFormatOptions, 'timeZone'>,
+): string {
+  return date.toLocaleString('ja-JP', {
+    ...options,
+    timeZone: 'Asia/Tokyo',
+  });
+}

--- a/utils/salary.ts
+++ b/utils/salary.ts
@@ -11,6 +11,12 @@
 import { calculateSalary } from '@/src/lib/salary-calculator';
 import { TRANSPORTATION_FEE_MAX, TRANSPORTATION_FEE_RATE_PER_HOUR } from '@/constants/salary';
 
+// JSTオフセット（+9時間 = 32400000ミリ秒）
+// Vercel等のUTCサーバーで Date#setHours / setDate を使うと
+// サーバーのローカルタイムゾーン(UTC)で解釈されてJSTと9時間ズレるため、
+// 全てUTCプリミティブ+このオフセットでJST時刻を構築する
+const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
 /**
  * 時刻をパースする（翌日プレフィックス対応）
  * @param time - 時刻文字列 (HH:mm または 翌HH:mm 形式)
@@ -25,23 +31,30 @@ const parseTime = (time: string): { hour: number; min: number; isNextDay: boolea
 
 /**
  * 時刻文字列からDateオブジェクトを生成（JST基準）
- * @param timeStr - 時刻文字列 (HH:mm 形式)
+ *
+ * baseDate の JST 日付に対して timeStr の時刻(JST)を設定する。
+ * サーバー(UTC)・クライアント(JST)どちらで実行しても同じ結果になる。
+ *
+ * @param timeStr - 時刻文字列 (HH:mm 形式、または 翌HH:mm)
  * @param isNextDay - 翌日かどうか
- * @param baseDate - 基準日（省略時は今日）
- * @returns Date オブジェクト
+ * @param baseDate - 基準日（このDateのJST日付を使用）
+ * @returns Date オブジェクト（指定したJST時刻に対応するUTC Date）
  */
 const timeStringToDate = (
   timeStr: string,
   isNextDay: boolean,
-  baseDate: Date = new Date()
+  baseDate: Date
 ): Date => {
   const parsed = parseTime(timeStr);
-  const date = new Date(baseDate);
-  date.setHours(parsed.hour, parsed.min, 0, 0);
-  if (isNextDay || parsed.isNextDay) {
-    date.setDate(date.getDate() + 1);
-  }
-  return date;
+  // baseDateのJST日付を取得（タイムゾーン非依存）
+  const baseJst = new Date(baseDate.getTime() + JST_OFFSET_MS);
+  const year = baseJst.getUTCFullYear();
+  const month = baseJst.getUTCMonth();
+  const dayOfMonth = baseJst.getUTCDate() + ((isNextDay || parsed.isNextDay) ? 1 : 0);
+  // 「JST year-month-dayOfMonth parsed.hour:parsed.min」を表すUTCタイムスタンプ
+  return new Date(
+    Date.UTC(year, month, dayOfMonth, parsed.hour, parsed.min, 0, 0) - JST_OFFSET_MS
+  );
 };
 
 /**
@@ -73,17 +86,22 @@ export const calculateDailyWage = (
     const start = parseTime(startTime);
     const end = parseTime(endTime);
 
-    // 基準日を設定（JST）
-    const baseDate = new Date();
-    baseDate.setHours(0, 0, 0, 0);
+    // 基準日（JSTでの「今日」の 00:00 を表すUTC Date）
+    // サーバー(UTC)で new Date().setHours(0,0,0,0) を使うと UTC 00:00 = JST 09:00 になり
+    // 後段の calculateSalary が時間帯判定をミスるため、UTCプリミティブで構築する
+    const now = new Date();
+    const jstNow = new Date(now.getTime() + JST_OFFSET_MS);
+    const baseDate = new Date(
+      Date.UTC(jstNow.getUTCFullYear(), jstNow.getUTCMonth(), jstNow.getUTCDate(), 0, 0, 0, 0) - JST_OFFSET_MS
+    );
 
     // 開始・終了時刻をDateオブジェクトに変換
     const startDate = timeStringToDate(startTime, false, baseDate);
     let endDate = timeStringToDate(endTime, end.isNextDay, baseDate);
 
-    // 終了時刻が開始時刻より前の場合は翌日とみなす
+    // 終了時刻が開始時刻より前の場合は翌日とみなす（ms加算でTZ非依存）
     if (endDate <= startDate) {
-      endDate.setDate(endDate.getDate() + 1);
+      endDate = new Date(endDate.getTime() + 24 * 60 * 60 * 1000);
     }
 
     // salary-calculatorを使用して割増計算


### PR DESCRIPTION
## Summary
- バグ修正: 日給計算のJST/UTC不整合でプレビューと保存値が乖離する問題を解消 (#602)
- バグ修正: 応募ステータス自動遷移がUTC判定でJST環境で動作しない不具合（本番影響あり） (#600)
- バグ修正: CSV出力の日時表示をJST(Asia/Tokyo)固定に統一 (#599)
- バグ修正: 夜勤求人の日給計算に深夜・残業の割増が反映されない不具合を解消 (#597)

## Test plan
- [ ] ステージング (https://stg-share-worker.vercel.app) で動作確認済み
- [ ] 日給計算プレビューと保存値が一致することを確認
- [ ] 応募ステータス自動遷移がJSTで正しく動作することを確認
- [ ] CSV出力の日時がJST表示になることを確認
- [ ] 夜勤求人の日給に深夜・残業割増が反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)