### PR TITLE
バグ修正: SMS認証済みの電話番号が再度変更できない不具合を修正

### DIFF
--- a/components/ui/SmsVerification.tsx
+++ b/components/ui/SmsVerification.tsx
@@ -287,18 +287,16 @@ export function SmsVerification({
             <path strokeLinecap="round" strokeLinejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
           <span className="font-medium">電話番号認証済み</span>
-          {!initialVerified && (
-            <button
-              type="button"
-              onClick={() => {
-                setState('input');
-                verifiedPhoneRef.current = '';
-              }}
-              className="text-xs text-gray-400 hover:text-gray-600 ml-auto"
-            >
-              変更する
-            </button>
-          )}
+          <button
+            type="button"
+            onClick={() => {
+              setState('input');
+              verifiedPhoneRef.current = '';
+            }}
+            className="text-xs text-gray-400 hover:text-gray-600 ml-auto"
+          >
+            変更する
+          </button>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- マイページのプロフィール編集画面で、既に SMS 認証済み (`phone_verified=true`) のユーザーが画面を再度開くと、電話番号フィールドがロックされ変更できない不具合を修正
- `SmsVerification` の verified 状態で表示される「変更する」ボタンが `!initialVerified` でガードされており、初期ロード時に既に認証済みだった場合に表示されなかったのが原因

## Root Cause
`components/ui/SmsVerification.tsx:290` の `{!initialVerified && (...)}` により、「その場で認証完了したセッションのみ」にしかボタンが出ない仕様になっていた。

呼び出し元 `app/mypage/profile/ProfileEditClient.tsx:1208` は `initialVerified={!phoneChanged && userProfile.phone_verified}` で初期化するため、DB に保存済みのユーザーが再訪問すると `initialVerified=true` で初期化 → ボタン非表示 → `PhoneNumberInput` も `disabled/readOnly` → 完全にロック、という状態に陥っていた。

## Fix
verified 状態では常に「変更する」ボタンを表示するよう、`!initialVerified` のガード条件を削除。

押下後の挙動：
1. `state='input'` に戻り、`PhoneNumberInput` の `disabled/readOnly` が解除
2. 新番号を入力 → SMS 再認証 → 親フォームへ新トークン通知
3. 保存時に既存ガード `phoneChanged && !phoneVerificationToken` を通過して保存完了

親フォーム側に再認証強制チェック (`ProfileEditClient.tsx:605-607`) が既に存在するため、ボタン常時表示にしても保存時の整合性は担保される。

## Scope / Impact
- `SmsVerification` を使用するのは `app/mypage/profile/ProfileEditClient.tsx` の 1 箇所のみ（grep 確認済み）
- 新規登録画面 (`app/register/worker`) は別の SMS 認証フローを使用するため影響なし
- DB スキーマ変更・API 変更なし、クライアントコンポーネント 1 ファイル・実質 1 行の修正

## Test plan
- [x] `npx tsc --noEmit` — TypeScript 型チェック通過
- [x] `npm run build` — Next.js フルビルド成功
- [ ] ステージング (https://stg-share-worker.vercel.app/mypage/profile) で手動確認:
  - [ ] 既に `phone_verified=true` のワーカーでログイン → プロフィール編集画面を開き「変更する」ボタンが表示されることを確認
  - [ ] 「変更する」クリック → 電話番号フィールドが編集可能になることを確認
  - [ ] 新番号入力 → SMS 認証完了 → 保存ボタンで正常に保存されることを確認
  - [ ] 番号未変更で「変更する」を押さずに他項目だけ変更しても保存できることを確認（回帰確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)