### PR TITLE
バグ修正: ワーカーアカウント停止が機能しない不具合を修正＋退会機能の取り急ぎ対応

### DIFF
--- a/app/api/auth/auto-login/route.ts
+++ b/app/api/auth/auto-login/route.ts
@@ -45,6 +45,41 @@ export async function GET(request: NextRequest) {
       );
     }
 
+    // 退会・停止チェック（退会優先）
+    // この経路は NextAuth の authorize() を通らないため、ここで明示的にガードする
+    if (user.deleted_at) {
+      console.warn('[AutoLogin] Blocked: account withdrawn, userId:', user.id);
+      logActivity({
+        userType: 'WORKER',
+        userId: user.id,
+        userEmail: user.email,
+        action: 'LOGIN_FAILED',
+        targetType: 'User',
+        targetId: user.id,
+        result: 'ERROR',
+        errorMessage: 'アカウント退会済み（auto-login経由）',
+      }).catch(() => {});
+      const errorUrl = new URL('/login', request.nextUrl.origin);
+      errorUrl.searchParams.set('error', 'AccountWithdrawn');
+      return secureRedirect(errorUrl);
+    }
+    if (user.is_suspended) {
+      console.warn('[AutoLogin] Blocked: account suspended, userId:', user.id);
+      logActivity({
+        userType: 'WORKER',
+        userId: user.id,
+        userEmail: user.email,
+        action: 'LOGIN_FAILED',
+        targetType: 'User',
+        targetId: user.id,
+        result: 'ERROR',
+        errorMessage: 'アカウント停止中（auto-login経由）',
+      }).catch(() => {});
+      const errorUrl = new URL('/login', request.nextUrl.origin);
+      errorUrl.searchParams.set('error', 'AccountSuspended');
+      return secureRedirect(errorUrl);
+    }
+
     // auto_login_token の検証
     if (
       user.auto_login_token !== token ||

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -178,10 +178,18 @@ export async function POST(request: NextRequest) {
     }
 
     // メールアドレスの重複チェック（case-insensitive、既存レガシーデータ対応）
+    // 退会済みアカウントの場合は専用メッセージを返す（取り急ぎ対応・再登録は本実装後）
     const existingEmailUser = await prisma.user.findFirst({
       where: { email: { equals: normalizedEmail, mode: 'insensitive' } },
+      select: { id: true, deleted_at: true },
     });
     if (existingEmailUser) {
+      if (existingEmailUser.deleted_at) {
+        return NextResponse.json(
+          { error: '以前ご利用いただいたアカウントです。再登録をご希望の場合はお問い合わせください。' },
+          { status: 409 }
+        );
+      }
       return NextResponse.json(
         { error: 'このメールアドレスは既に登録されています' },
         { status: 409 }
@@ -218,14 +226,17 @@ export async function POST(request: NextRequest) {
         // ロック取得後の再チェック（race safe）
         // 既存データにハイフンや全角数字が残っている可能性に備え、SQL 側で正規化比較
         // translate で全角数字 → 半角数字、regexp_replace で非数字除去
-        const phoneExists = await tx.$queryRaw<{ id: number }[]>(
-          Prisma.sql`SELECT id FROM users
+        // 退会済みもヒットさせ、後段で deleted_at を確認して専用エラーを返す
+        const phoneExists = await tx.$queryRaw<{ id: number; deleted_at: Date | null }[]>(
+          Prisma.sql`SELECT id, deleted_at FROM users
             WHERE regexp_replace(translate(phone_number, '０１２３４５６７８９', '0123456789'), '[^0-9]', '', 'g') = ${normalizedPhone}
             AND phone_verified = true
-            AND deleted_at IS NULL
             LIMIT 1`
         );
         if (phoneExists.length > 0) {
+          if (phoneExists[0].deleted_at) {
+            throw new Error('PHONE_WITHDRAWN_USER');
+          }
           throw new Error('PHONE_ALREADY_REGISTERED');
         }
 
@@ -269,6 +280,12 @@ export async function POST(request: NextRequest) {
         });
       });
     } catch (e) {
+      if (e instanceof Error && e.message === 'PHONE_WITHDRAWN_USER') {
+        return NextResponse.json(
+          { error: '以前ご利用いただいたアカウントです。再登録をご希望の場合はお問い合わせください。' },
+          { status: 409 }
+        );
+      }
       if (e instanceof Error && e.message === 'PHONE_ALREADY_REGISTERED') {
         return NextResponse.json(
           { error: 'この電話番号は既に登録されています' },
@@ -278,6 +295,17 @@ export async function POST(request: NextRequest) {
       if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002') {
         const target = (e.meta?.target as string[] | undefined)?.join(',') || '';
         if (target.includes('email')) {
+          // P2002 で email がぶつかった場合、退会済みかどうかを確認して適切なメッセージを返す
+          const conflicting = await prisma.user.findFirst({
+            where: { email: { equals: normalizedEmail, mode: 'insensitive' } },
+            select: { deleted_at: true },
+          });
+          if (conflicting?.deleted_at) {
+            return NextResponse.json(
+              { error: '以前ご利用いただいたアカウントです。再登録をご希望の場合はお問い合わせください。' },
+              { status: 409 }
+            );
+          }
           return NextResponse.json(
             { error: 'このメールアドレスは既に登録されています' },
             { status: 409 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -39,6 +39,17 @@ function WorkerLoginInner() {
     });
   }, []);
 
+  // /api/auth/auto-login 等から ?error= で遷移してきた場合の表示
+  useEffect(() => {
+    const errorCode = searchParams?.get('error');
+    if (!errorCode) return;
+    if (errorCode === 'AccountWithdrawn') {
+      setError('このアカウントは退会済みです。');
+    } else if (errorCode === 'AccountSuspended') {
+      setError('このアカウントは停止されています。お問い合わせください。');
+    }
+  }, [searchParams]);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');

--- a/app/system-admin/workers/[id]/page.tsx
+++ b/app/system-admin/workers/[id]/page.tsx
@@ -3,11 +3,11 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { getSystemWorkerDetail, toggleWorkerSuspension, generateWorkerMasqueradeToken, getWorkerEditLogs } from '@/src/lib/system-actions';
+import { getSystemWorkerDetail, toggleWorkerSuspension, generateWorkerMasqueradeToken, getWorkerEditLogs, withdrawWorker } from '@/src/lib/system-actions';
 import {
     ChevronLeft, Ban, CheckCircle, Mail, Phone, MapPin, Calendar, Briefcase,
     FileText, Star, User, Clock, AlertTriangle, LogIn, Shield, CreditCard,
-    Building, Users, History, Link2
+    Building, Users, History, Link2, UserX, X
 } from 'lucide-react';
 import { format } from 'date-fns';
 import toast from 'react-hot-toast';
@@ -74,9 +74,14 @@ export default function SystemAdminWorkerDetailPage({ params }: { params: { id: 
     const [worker, setWorker] = useState<any>(null);
     const [loading, setLoading] = useState(true);
     const [isSuspended, setIsSuspended] = useState(false);
+    const [isWithdrawn, setIsWithdrawn] = useState(false);
+    const [withdrawnAt, setWithdrawnAt] = useState<Date | string | null>(null);
+    const [deleteReason, setDeleteReason] = useState<string | null>(null);
     const [processing, setProcessing] = useState(false);
     const [editLogs, setEditLogs] = useState<any[]>([]);
     const [showEditLogs, setShowEditLogs] = useState(false);
+    const [showWithdrawModal, setShowWithdrawModal] = useState(false);
+    const [withdrawReasonInput, setWithdrawReasonInput] = useState('');
 
     useEffect(() => {
         const loadWorker = async () => {
@@ -89,6 +94,9 @@ export default function SystemAdminWorkerDetailPage({ params }: { params: { id: 
                 if (data) {
                     setWorker(data);
                     setIsSuspended(data.isSuspended);
+                    setIsWithdrawn(!!data.isWithdrawn);
+                    setWithdrawnAt(data.withdrawnAt ?? null);
+                    setDeleteReason(data.deleteReason ?? null);
                 }
                 setEditLogs(logs);
             } catch (error) {
@@ -132,6 +140,43 @@ export default function SystemAdminWorkerDetailPage({ params }: { params: { id: 
                 details: debugInfo.details,
                 stack: debugInfo.stack,
                 context: { workerId, targetSuspension: !isSuspended }
+            });
+            toast.error('エラーが発生しました');
+        } finally {
+            setProcessing(false);
+        }
+    };
+
+    const handleOpenWithdrawModal = () => {
+        setWithdrawReasonInput('');
+        setShowWithdrawModal(true);
+    };
+
+    const handleConfirmWithdraw = async () => {
+        if (!confirm('このワーカーを「退会済み」にします。\nワーカーは即座にログインできなくなり、この操作はサポート問い合わせ無しには元に戻せません。\n本当に実行してよろしいですか？')) {
+            return;
+        }
+        setProcessing(true);
+        try {
+            const result = await withdrawWorker(workerId, withdrawReasonInput.trim() || undefined);
+            if (result.success) {
+                setIsWithdrawn(true);
+                setWithdrawnAt(new Date());
+                setDeleteReason(withdrawReasonInput.trim() || null);
+                setShowWithdrawModal(false);
+                toast.success('退会扱いにしました');
+            } else {
+                toast.error(result.error || '更新に失敗しました');
+            }
+        } catch (error) {
+            const debugInfo = extractDebugInfo(error);
+            showDebugError({
+                type: 'update',
+                operation: 'ワーカー退会処理',
+                message: debugInfo.message,
+                details: debugInfo.details,
+                stack: debugInfo.stack,
+                context: { workerId }
             });
             toast.error('エラーが発生しました');
         } finally {
@@ -207,7 +252,11 @@ export default function SystemAdminWorkerDetailPage({ params }: { params: { id: 
                         <div>
                             <h1 className="text-xl font-bold text-gray-900 flex items-center gap-3">
                                 {worker.name}
-                                {isSuspended ? (
+                                {isWithdrawn ? (
+                                    <span className="px-3 py-1 bg-gray-200 text-gray-700 text-sm rounded-full flex items-center gap-1 font-medium">
+                                        <UserX className="w-4 h-4" /> 退会済み
+                                    </span>
+                                ) : isSuspended ? (
                                     <span className="px-3 py-1 bg-red-100 text-red-700 text-sm rounded-full flex items-center gap-1 font-medium">
                                         <Ban className="w-4 h-4" /> 停止中
                                     </span>
@@ -222,36 +271,70 @@ export default function SystemAdminWorkerDetailPage({ params }: { params: { id: 
                     </div>
 
                     <div className="flex gap-3">
-                        <button
-                            onClick={handleMasquerade}
-                            className="flex items-center gap-2 px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg font-medium transition-colors"
-                        >
-                            <LogIn className="w-4 h-4" />
-                            ワーカーとしてログイン
-                        </button>
-                        <button
-                            onClick={handleToggleSuspension}
-                            disabled={processing}
-                            className={`flex items-center gap-2 px-4 py-2 rounded-lg font-medium text-white transition-colors ${isSuspended
-                                ? 'bg-green-600 hover:bg-green-700'
-                                : 'bg-red-600 hover:bg-red-700'
-                                } disabled:opacity-50`}
-                        >
-                            {isSuspended ? (
-                                <>
-                                    <CheckCircle className="w-4 h-4" />
-                                    停止解除
-                                </>
-                            ) : (
-                                <>
-                                    <Ban className="w-4 h-4" />
-                                    アカウント停止
-                                </>
-                            )}
-                        </button>
+                        {!isWithdrawn && (
+                            <button
+                                onClick={handleMasquerade}
+                                className="flex items-center gap-2 px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white rounded-lg font-medium transition-colors"
+                            >
+                                <LogIn className="w-4 h-4" />
+                                ワーカーとしてログイン
+                            </button>
+                        )}
+                        {!isWithdrawn && (
+                            <button
+                                onClick={handleToggleSuspension}
+                                disabled={processing}
+                                className={`flex items-center gap-2 px-4 py-2 rounded-lg font-medium text-white transition-colors ${isSuspended
+                                    ? 'bg-green-600 hover:bg-green-700'
+                                    : 'bg-red-600 hover:bg-red-700'
+                                    } disabled:opacity-50`}
+                            >
+                                {isSuspended ? (
+                                    <>
+                                        <CheckCircle className="w-4 h-4" />
+                                        停止解除
+                                    </>
+                                ) : (
+                                    <>
+                                        <Ban className="w-4 h-4" />
+                                        アカウント停止
+                                    </>
+                                )}
+                            </button>
+                        )}
+                        {!isWithdrawn && (
+                            <button
+                                onClick={handleOpenWithdrawModal}
+                                disabled={processing}
+                                className="flex items-center gap-2 px-4 py-2 rounded-lg font-medium text-white bg-gray-700 hover:bg-gray-800 transition-colors disabled:opacity-50"
+                            >
+                                <UserX className="w-4 h-4" />
+                                退会済みにする
+                            </button>
+                        )}
                     </div>
                 </div>
             </header>
+
+            {/* 退会済みバナー（退会時のみ表示） */}
+            {isWithdrawn && (
+                <div className="bg-gray-100 border-b border-gray-300 px-6 py-4">
+                    <div className="max-w-7xl mx-auto flex items-start gap-3">
+                        <UserX className="w-5 h-5 text-gray-600 mt-0.5 flex-shrink-0" />
+                        <div className="flex-1">
+                            <p className="font-medium text-gray-900">このワーカーは退会済みです</p>
+                            <p className="text-sm text-gray-600 mt-1">
+                                退会日時: {withdrawnAt ? format(new Date(withdrawnAt), 'yyyy/MM/dd HH:mm') : '不明'}
+                            </p>
+                            {deleteReason && (
+                                <p className="text-sm text-gray-600 mt-1">
+                                    退会理由（運営メモ）: {deleteReason}
+                                </p>
+                            )}
+                        </div>
+                    </div>
+                </div>
+            )}
 
             {/* Main Content - Bento Grid */}
             <main className="p-6 max-w-7xl mx-auto">
@@ -730,6 +813,67 @@ export default function SystemAdminWorkerDetailPage({ params }: { params: { id: 
                     </div>
                 </div>
             </main>
+
+            {/* 退会確認モーダル */}
+            {showWithdrawModal && (
+                <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
+                    <div className="bg-white rounded-lg shadow-xl max-w-md w-full p-6">
+                        <div className="flex items-start justify-between mb-4">
+                            <h3 className="text-lg font-bold text-gray-900 flex items-center gap-2">
+                                <UserX className="w-5 h-5 text-gray-700" />
+                                退会扱いにする
+                            </h3>
+                            <button
+                                onClick={() => setShowWithdrawModal(false)}
+                                disabled={processing}
+                                className="p-1 hover:bg-gray-100 rounded disabled:opacity-50"
+                            >
+                                <X className="w-5 h-5 text-gray-500" />
+                            </button>
+                        </div>
+                        <div className="space-y-4">
+                            <div className="bg-amber-50 border border-amber-200 rounded p-3 text-sm text-amber-900">
+                                <p className="font-medium mb-1">⚠️ この操作は元に戻せません</p>
+                                <p>
+                                    退会扱いにすると、ワーカーは即座にログインできなくなります。
+                                    同じメールアドレス・電話番号での再登録もブロックされます（再登録機能は本実装後に対応予定）。
+                                </p>
+                            </div>
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-1">
+                                    退会理由（任意・運営メモ用）
+                                </label>
+                                <textarea
+                                    value={withdrawReasonInput}
+                                    onChange={(e) => setWithdrawReasonInput(e.target.value)}
+                                    placeholder="例: 本人からの退会希望（電話）"
+                                    rows={3}
+                                    maxLength={500}
+                                    disabled={processing}
+                                    className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm disabled:bg-gray-50"
+                                />
+                                <p className="text-xs text-gray-500 mt-1">運営側（System Admin）のみ閲覧可能です</p>
+                            </div>
+                        </div>
+                        <div className="flex justify-end gap-3 mt-6">
+                            <button
+                                onClick={() => setShowWithdrawModal(false)}
+                                disabled={processing}
+                                className="px-4 py-2 text-gray-700 hover:bg-gray-100 rounded font-medium disabled:opacity-50"
+                            >
+                                キャンセル
+                            </button>
+                            <button
+                                onClick={handleConfirmWithdraw}
+                                disabled={processing}
+                                className="px-4 py-2 bg-gray-800 hover:bg-gray-900 text-white rounded font-medium disabled:opacity-50"
+                            >
+                                {processing ? '処理中...' : '退会扱いにする'}
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
         </div>
     );
 }

--- a/app/system-admin/workers/page.tsx
+++ b/app/system-admin/workers/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { getSystemWorkers, geocodeAddress } from '@/src/lib/system-actions';
-import { Search, Filter, Eye, Ban, ChevronDown, X, ArrowUpDown, Users, MapPin, Star, Briefcase, CheckCircle2 } from 'lucide-react';
+import { Search, Filter, Eye, Ban, ChevronDown, X, ArrowUpDown, Users, MapPin, Star, Briefcase, CheckCircle2, UserX } from 'lucide-react';
 import { PREFECTURES, QUALIFICATION_OPTIONS } from '@/constants/job';
 import { getCitiesByPrefecture, Prefecture } from '@/constants/prefectureCities';
 
@@ -20,6 +20,7 @@ interface Worker {
     gender: string | null;
     birth_date: Date | null;
     isSuspended: boolean;
+    isWithdrawn: boolean;
     phoneVerified: boolean;
     age: number | null;
     avgRating: number | null;
@@ -41,7 +42,7 @@ export default function SystemAdminWorkersPage() {
 
     // フィルター状態
     const [showFilters, setShowFilters] = useState(false);
-    const [statusFilter, setStatusFilter] = useState<'all' | 'active' | 'suspended'>('all');
+    const [statusFilter, setStatusFilter] = useState<'all' | 'active' | 'suspended' | 'withdrawn'>('all');
     const [prefectureFilter, setPrefectureFilter] = useState('');
     const [cityFilter, setCityFilter] = useState('');
     const [qualificationFilter, setQualificationFilter] = useState('');
@@ -268,6 +269,7 @@ export default function SystemAdminWorkersPage() {
                                     <option value="all">すべて</option>
                                     <option value="active">有効</option>
                                     <option value="suspended">停止中</option>
+                                    <option value="withdrawn">退会済み</option>
                                 </select>
                             </div>
 
@@ -422,7 +424,7 @@ export default function SystemAdminWorkersPage() {
                     <span className="text-xs text-slate-500">フィルター:</span>
                     {statusFilter !== 'all' && (
                         <span className="inline-flex items-center gap-1 px-2 py-1 bg-indigo-100 text-indigo-700 text-xs rounded-full">
-                            {statusFilter === 'active' ? '有効' : '停止中'}
+                            {statusFilter === 'active' ? '有効' : statusFilter === 'suspended' ? '停止中' : '退会済み'}
                             <button onClick={() => { setStatusFilter('all'); fetchWorkers(); }}>
                                 <X className="w-3 h-3" />
                             </button>
@@ -530,7 +532,12 @@ export default function SystemAdminWorkersPage() {
                                             <div>
                                                 <div className="font-bold text-slate-800">{worker.name || '名前未設定'}</div>
                                                 <div className="text-xs text-slate-500">ID: {worker.id}</div>
-                                                {worker.isSuspended && (
+                                                {worker.isWithdrawn ? (
+                                                    <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded bg-gray-200 text-gray-700 text-[10px] font-medium mt-0.5">
+                                                        <UserX className="w-2.5 h-2.5" />
+                                                        退会済み
+                                                    </span>
+                                                ) : worker.isSuspended && (
                                                     <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded bg-red-100 text-red-700 text-[10px] font-medium mt-0.5">
                                                         <Ban className="w-2.5 h-2.5" />
                                                         停止中

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -27,6 +27,34 @@ export const authOptions: NextAuthOptions = {
             throw new Error('ユーザーが見つかりません');
           }
 
+          // 退会・停止チェック（退会優先）
+          if (user.deleted_at) {
+            logActivity({
+              userType: 'WORKER',
+              userId: user.id,
+              userEmail: user.email,
+              action: 'LOGIN_FAILED',
+              targetType: 'User',
+              targetId: user.id,
+              result: 'ERROR',
+              errorMessage: 'アカウント退会済み（自動ログイン）',
+            }).catch(() => {});
+            throw new Error('このアカウントは退会済みです。');
+          }
+          if (user.is_suspended) {
+            logActivity({
+              userType: 'WORKER',
+              userId: user.id,
+              userEmail: user.email,
+              action: 'LOGIN_FAILED',
+              targetType: 'User',
+              targetId: user.id,
+              result: 'ERROR',
+              errorMessage: 'アカウント停止中（自動ログイン）',
+            }).catch(() => {});
+            throw new Error('このアカウントは停止されています。お問い合わせください。');
+          }
+
           // 自動ログイントークンの検証
           if (
             user.auto_login_token !== credentials.autoLoginToken ||
@@ -108,11 +136,11 @@ export const authOptions: NextAuthOptions = {
           user = emailMatches[0];
         } else {
           // 電話番号ログイン: DB 側も正規化して比較（レガシーデータのハイフン・全角数字対応）
+          // 退会済みもヒットさせ、認証後段で deleted_at/is_suspended をチェックして専用エラーを返す
           const rows = await prisma.$queryRaw<{ id: number }[]>(
             Prisma.sql`SELECT id FROM users
               WHERE regexp_replace(translate(phone_number, '０１２３４５６７８９', '0123456789'), '[^0-9]', '', 'g') = ${parsed.value}
               AND phone_verified = true
-              AND deleted_at IS NULL
               ORDER BY id DESC`
           );
           const candidates = rows.length > 0
@@ -147,6 +175,34 @@ export const authOptions: NextAuthOptions = {
             errorMessage: 'ユーザーが見つかりません',
           }).catch(() => {});
           throw new Error('メールアドレスまたはパスワードが正しくありません');
+        }
+
+        // 退会・停止チェック（退会優先）
+        if (user.deleted_at) {
+          logActivity({
+            userType: 'WORKER',
+            userId: user.id,
+            userEmail: user.email,
+            action: 'LOGIN_FAILED',
+            targetType: 'User',
+            targetId: user.id,
+            result: 'ERROR',
+            errorMessage: 'アカウント退会済み',
+          }).catch(() => {});
+          throw new Error('このアカウントは退会済みです。');
+        }
+        if (user.is_suspended) {
+          logActivity({
+            userType: 'WORKER',
+            userId: user.id,
+            userEmail: user.email,
+            action: 'LOGIN_FAILED',
+            targetType: 'User',
+            targetId: user.id,
+            result: 'ERROR',
+            errorMessage: 'アカウント停止中',
+          }).catch(() => {});
+          throw new Error('このアカウントは停止されています。お問い合わせください。');
         }
 
         // テストユーザーログイン用の特別パスワード（開発環境 + 環境変数フラグ必須）
@@ -220,6 +276,7 @@ export const authOptions: NextAuthOptions = {
         session.user.id = token.id as string;
 
         // DBから最新のユーザー情報を取得（プロフィール画像の更新を反映）
+        // 同時に退会・停止状態を再チェックし、該当する場合はセッションを失効させる
         try {
           const dbUser = await prisma.user.findUnique({
             where: { id: parseInt(token.id as string) },
@@ -227,13 +284,20 @@ export const authOptions: NextAuthOptions = {
               name: true,
               email: true,
               profile_image: true,
+              is_suspended: true,
+              deleted_at: true,
             },
           });
-          if (dbUser) {
-            session.user.name = dbUser.name;
-            session.user.email = dbUser.email;
-            session.user.image = dbUser.profile_image;
+          if (!dbUser || dbUser.deleted_at || dbUser.is_suspended) {
+            // ユーザー消失/退会/停止 → セッション失効（getServerSession で user を未定義に）
+            // 既存コードは `if (session.user && token.id)` 等で user 不在を許容する形のため
+            // user プロパティを削除する形で無効化する
+            delete (session as { user?: unknown }).user;
+            return session;
           }
+          session.user.name = dbUser.name;
+          session.user.email = dbUser.email;
+          session.user.image = dbUser.profile_image;
         } catch (error) {
           console.error('Failed to fetch user from DB in session callback:', error);
         }

--- a/src/lib/system-actions.ts
+++ b/src/lib/system-actions.ts
@@ -193,7 +193,7 @@ export async function getSystemWorkers(
     sort: string = 'created_at',
     order: 'asc' | 'desc' = 'desc',
     filters?: {
-        status?: 'all' | 'active' | 'suspended';
+        status?: 'all' | 'active' | 'suspended' | 'withdrawn';
         prefecture?: string;
         city?: string;
         qualification?: string;
@@ -235,11 +235,15 @@ export async function getSystemWorkers(
 
     // フィルター条件
     if (filters) {
-        // ステータスフィルター
+        // ステータスフィルター（退会優先: 退会済みは suspended/active から除外）
         if (filters.status === 'active') {
             where.is_suspended = false;
+            where.deleted_at = null;
         } else if (filters.status === 'suspended') {
             where.is_suspended = true;
+            where.deleted_at = null;
+        } else if (filters.status === 'withdrawn') {
+            where.deleted_at = { not: null };
         }
 
         // 都道府県フィルター
@@ -294,6 +298,7 @@ export async function getSystemWorkers(
                 gender: true,
                 birth_date: true,
                 is_suspended: true,
+                deleted_at: true,
                 phone_verified: true,
                 lat: true,
                 lng: true,
@@ -359,6 +364,7 @@ export async function getSystemWorkers(
                 totalWorkCount,
                 distance,
                 isSuspended: w.is_suspended || false,
+                isWithdrawn: !!w.deleted_at,
                 phoneVerified: w.phone_verified || false,
                 age: null, // 後で計算
             };
@@ -426,6 +432,7 @@ export async function getSystemWorkers(
                     gender: true,
                     birth_date: true,
                     is_suspended: true,
+                    deleted_at: true,
                     phone_verified: true,
                     lat: true,
                     lng: true,
@@ -487,6 +494,7 @@ export async function getSystemWorkers(
                 return {
                     ...w,
                     isSuspended: w.is_suspended || false,
+                    isWithdrawn: !!w.deleted_at,
                     phoneVerified: w.phone_verified || false,
                     age: calculateAge(w.birth_date),
                     avgRating: stat ? stat.sum / stat.count : null,
@@ -670,6 +678,9 @@ export async function getSystemWorkerDetail(id: number) {
         created_at: worker.created_at,
         isSuspended: worker.is_suspended || false,
         suspendedAt: worker.suspended_at,
+        isWithdrawn: !!worker.deleted_at,
+        withdrawnAt: worker.deleted_at,
+        deleteReason: worker.delete_reason,
         // 集計データ
         totalWorkDays,
         cancelRate,
@@ -692,10 +703,23 @@ export async function getSystemWorkerDetail(id: number) {
 
 /**
  * システム管理用：ワーカーアカウント停止/解除
+ * 退会済みワーカーには適用不可（退会優先）
  */
 export async function toggleWorkerSuspension(id: number, suspend: boolean) {
-    await requireSystemAdminAuth();
+    const { adminId } = await requireSystemAdminAuth();
     try {
+        // 退会済みチェック
+        const current = await prisma.user.findUnique({
+            where: { id },
+            select: { deleted_at: true },
+        });
+        if (!current) {
+            return { success: false, error: 'ワーカーが見つかりません' };
+        }
+        if (current.deleted_at) {
+            return { success: false, error: '退会済みワーカーには停止操作を行えません' };
+        }
+
         const worker = await prisma.user.update({
             where: { id },
             data: {
@@ -704,10 +728,80 @@ export async function toggleWorkerSuspension(id: number, suspend: boolean) {
             },
         });
 
+        await prisma.systemLog.create({
+            data: {
+                admin_id: adminId,
+                action: suspend ? 'WORKER_SUSPENDED' : 'WORKER_UNSUSPENDED',
+                target_type: 'User',
+                target_id: id,
+                details: {},
+            },
+        }).catch(() => {});
+
         return { success: true, isSuspended: worker.is_suspended };
     } catch (error) {
         console.error('Failed to toggle suspension:', error);
         return { success: false, error: '更新に失敗しました' };
+    }
+}
+
+/**
+ * システム管理用：ワーカーを退会扱いにする
+ * - deleted_at に現在日時をセット（ソフトデリート）
+ * - delete_reason に運営メモを保存（任意・運営側のみ閲覧可）
+ * - 認証用トークン（auto_login_token / password_reset_token）をクリア
+ * - SystemLog に WORKER_WITHDRAWN を記録
+ *
+ * 注意: 取り急ぎ対応として「ログイン不可」のみ担保する実装。
+ * 同一 email/phone での再登録は本実装時に部分ユニーク制約導入後に対応予定。
+ */
+export async function withdrawWorker(id: number, reason?: string) {
+    const { adminId } = await requireSystemAdminAuth();
+    try {
+        const current = await prisma.user.findUnique({
+            where: { id },
+            select: { id: true, deleted_at: true, email: true, name: true },
+        });
+        if (!current) {
+            return { success: false, error: 'ワーカーが見つかりません' };
+        }
+        if (current.deleted_at) {
+            return { success: false, error: '既に退会済みのワーカーです' };
+        }
+
+        const trimmedReason = reason?.trim() || null;
+
+        await prisma.user.update({
+            where: { id },
+            data: {
+                deleted_at: new Date(),
+                delete_reason: trimmedReason,
+                // ログインの抜け道となるトークンを失効
+                auto_login_token: null,
+                auto_login_token_expires: null,
+                password_reset_token: null,
+                password_reset_token_expires: null,
+            },
+        });
+
+        await prisma.systemLog.create({
+            data: {
+                admin_id: adminId,
+                action: 'WORKER_WITHDRAWN',
+                target_type: 'User',
+                target_id: id,
+                details: {
+                    reason: trimmedReason,
+                    workerEmail: current.email,
+                    workerName: current.name,
+                },
+            },
+        }).catch(() => {});
+
+        return { success: true };
+    } catch (error) {
+        console.error('Failed to withdraw worker:', error);
+        return { success: false, error: '退会処理に失敗しました' };
     }
 }
 

--- a/src/lib/system-actions.ts
+++ b/src/lib/system-actions.ts
@@ -725,6 +725,13 @@ export async function toggleWorkerSuspension(id: number, suspend: boolean) {
             data: {
                 is_suspended: suspend,
                 suspended_at: suspend ? new Date() : null,
+                // 停止時はログインの抜け道となるトークンも失効（auto-login / password-reset 経由のバイパスを防止）
+                ...(suspend ? {
+                    auto_login_token: null,
+                    auto_login_token_expires: null,
+                    password_reset_token: null,
+                    password_reset_token_expires: null,
+                } : {}),
             },
         });
 


### PR DESCRIPTION
## 背景

クライアントより「ワーカーアカウントの停止が機能していない」「退会希望のワーカーから連絡あり、急ぎ対応してほしい」との連絡。

調査の結果、System Admin の「アカウント停止」ボタンは `users.is_suspended` フラグを更新するだけで、**ログイン認証層（`lib/auth.ts`）が一切このフラグをチェックしていない**ことが判明。停止操作は事実上無効化されていた。

## 修正内容

### バグ修正
NextAuth の `authorize()` および `session` callback で `is_suspended` / `deleted_at` をチェックするように修正。これにより System Admin が「アカウント停止」ボタンを押すと即座にワーカーがログインできなくなる。

### 取り急ぎの退会機能（クライアント要望）
本来の退会機能（アプリ化想定）の実装はまだ先のため、System Admin が手動で退会扱いにできる最小機能のみ追加。

| 状態 | DB | UI 表示 | ログイン可否 | 解除 |
|------|----|---------|------------|------|
| 有効 | - | 緑バッジ「有効」 | 可能 | - |
| 停止中 | `is_suspended=true` | 赤バッジ「停止中」 | 不可（「停止されています」） | 管理画面で可 |
| 退会済み | `deleted_at` セット | 灰バッジ「退会済み」 | 不可（「退会済みです」） | 設けない（誤操作時は手動 SQL） |

両方立ったら **退会優先**。

## 変更ファイル

| ファイル | 変更概要 |
|---------|---------|
| `lib/auth.ts` | 通常ログイン・自動ログイン・session callback に退会/停止ガード追加 |
| `src/lib/system-actions.ts` | `withdrawWorker(id, reason?)` 新規追加／フィルタに 'withdrawn' 追加／停止操作は退会者を拒否 |
| `app/api/auth/register/route.ts` | 退会済みメール・電話番号での再登録時に専用メッセージ |
| `app/system-admin/workers/[id]/page.tsx` | 3状態バッジ／「退会済みにする」ボタン＋理由入力モーダル／退会バナー |
| `app/system-admin/workers/page.tsx` | フィルタに「退会済み」追加／一覧バッジ |

## スキーマ変更

**なし**。既存の `users.is_suspended` / `deleted_at` / `delete_reason` をそのまま利用。マイグレーション不要。

## 取り急ぎ対応のスコープ外（本実装で対応予定）

- **退会済みアカウントの再登録**: 同じ email/phone での再登録は本実装まで先送り（Postgres 部分ユニークインデックス `WHERE deleted_at IS NULL` 導入時に対応予定）。現状は再登録試行時に「以前ご利用いただいたアカウントです。お問い合わせください」と案内のみ。
- **退会取消フロー**: 誤操作時は SQL で `deleted_at = NULL` に戻す運用。本実装時に super_admin 限定の取消フローを検討。
- **ワーカー本人による退会画面**: アプリ化想定の本実装スコープ。
- **退会済みワーカーの応募/メッセージ/勤務予定整理**: 本実装スコープ。

## デプロイ前確認

- [ ] DB変更: **なし**
- [x] ビルド確認: `npm run build` 成功
- [ ] ステージング動作確認:
  - [ ] System Admin で停止中ワーカーがログイン不可になること
  - [ ] System Admin で「退会済みにする」を実行 → ワーカーがログイン不可になること
  - [ ] 退会済みワーカーが新規登録 → 専用メッセージが表示されること
  - [ ] ワーカー一覧の「退会済み」フィルタが動くこと
  - [ ] 退会後、既存セッションが次のリクエストで失効すること

## 動作確認手順（ステージング）

1. System Admin（admin@tastas.jp）でログイン → `/system-admin/workers`
2. 任意のテストワーカーの詳細を開く → 「アカウント停止」ボタン押下 → 当該ワーカーでログイン試行 → 「このアカウントは停止されています。お問い合わせください。」が出ることを確認
3. 「停止解除」→ ログイン可能になることを確認
4. 「退会済みにする」ボタン押下 → 退会理由を入力して実行 → 「退会済み」バッジ表示
5. 当該ワーカーでログイン試行 → 「このアカウントは退会済みです。」が出ることを確認
6. 同じメールアドレスで新規登録試行 → 「以前ご利用いただいたアカウントです...」が出ることを確認
7. `/system-admin/workers` のフィルタで「退会済み」を選択 → 退会済みワーカーのみ表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)